### PR TITLE
docs(skills): add compatibility spec for skill manifest evolution

### DIFF
--- a/connectors/mongodb-atlas/_install.yml
+++ b/connectors/mongodb-atlas/_install.yml
@@ -1,0 +1,25 @@
+setup:
+  title: MongoDB Atlas
+  description: Shared MongoDB Atlas connector for multi-tenant data caching with TTL support. Enables "sync once, read many" patterns across tenants.
+  category:
+    - special-templates
+  estimatedTime: 2 minutes
+  features:
+    - Document read/write with upsert support
+    - Bulk write operations
+    - TTL-based auto-expiry via MongoDB TTL indexes
+    - Search cache with google-genai invoke_search compatible output
+    - Flexible query/lookup with projections and sorting
+    - Multi-tenant shared cache support
+  integrations:
+    - mongodb
+  status: available
+  value: connectors/mongodb-atlas
+  version: 1.0.0
+
+datasets:
+  - type: "connector"
+    path: "mongodb-atlas.yml"
+
+  - type: "workflow"
+    path: "test-connection.yml"

--- a/connectors/mongodb-atlas/mongodb-atlas.py
+++ b/connectors/mongodb-atlas/mongodb-atlas.py
@@ -1,0 +1,434 @@
+"""
+MongoDB Atlas Connector
+
+Provides read/write operations against MongoDB Atlas for shared data caching
+across multiple tenants. Supports TTL-based auto-expiry, upserts, and flexible
+queries.
+
+All functions receive request_data with:
+  - headers.connection_string: MongoDB Atlas connection string
+  - headers.database: Database name (default: "machina_cache")
+  - params.*: Operation-specific parameters
+
+Commands:
+  - write_document: Upsert a single document
+  - write_many: Upsert multiple documents in bulk
+  - read_document: Read a single document by _id
+  - lookup: Query documents with filters
+  - search_cache: Query the search cache (returns answer + search_results format)
+  - delete_document: Delete a single document by _id
+  - delete_many: Delete documents matching a filter
+"""
+
+import json
+import datetime
+
+
+def _get_collection(headers, params):
+    """Get a MongoDB collection from connection parameters."""
+    from pymongo import MongoClient
+
+    connection_string = headers.get("connection_string", "")
+    database = headers.get("database", "machina_cache")
+    collection = params.get("collection", "")
+
+    if not connection_string:
+        raise ValueError("Missing connection_string in headers")
+    if not collection:
+        raise ValueError("Missing collection in params")
+
+    client = MongoClient(connection_string, serverSelectionTimeoutMS=10000)
+    db = client[database]
+    return db[collection], client
+
+
+def _ensure_ttl_index(coll, ttl_field="expires_at"):
+    """Ensure a TTL index exists on the collection (idempotent)."""
+    index_name = f"ttl_{ttl_field}"
+    existing = coll.index_information()
+    if index_name not in existing:
+        coll.create_index(ttl_field, name=index_name, expireAfterSeconds=0)
+
+
+def _add_ttl(doc, ttl_hours):
+    """Add expires_at field to a document if ttl_hours is set."""
+    if ttl_hours and ttl_hours > 0:
+        doc["expires_at"] = datetime.datetime.utcnow() + datetime.timedelta(hours=ttl_hours)
+    return doc
+
+
+def _serialize_doc(doc):
+    """Convert MongoDB document to JSON-safe dict."""
+    if doc is None:
+        return None
+    if "_id" in doc:
+        doc["_id"] = str(doc["_id"])
+    if "expires_at" in doc and isinstance(doc["expires_at"], datetime.datetime):
+        doc["expires_at"] = doc["expires_at"].isoformat()
+    if "updated_at" in doc and isinstance(doc["updated_at"], datetime.datetime):
+        doc["updated_at"] = doc["updated_at"].isoformat()
+    if "created_at" in doc and isinstance(doc["created_at"], datetime.datetime):
+        doc["created_at"] = doc["created_at"].isoformat()
+    return doc
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# WRITE OPERATIONS
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def write_document(request_data):
+    """
+    Upsert a single document into a collection.
+
+    Params:
+        collection: str - Target collection name
+        document: dict - The document to write
+        filter: dict - Filter for upsert match (default: uses document._id)
+        ttl_hours: int - Hours until auto-expiry (0 = no expiry)
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        coll, client = _get_collection(headers, params)
+
+        document = params.get("document", {})
+        filter_query = params.get("filter", {})
+        ttl_hours = int(params.get("ttl_hours", 0))
+
+        if not document:
+            return {"status": False, "data": {"error": "Missing document in params"}}
+
+        # Add metadata
+        now = datetime.datetime.utcnow()
+        document["updated_at"] = now
+        document.setdefault("created_at", now)
+
+        # Add TTL if specified
+        if ttl_hours > 0:
+            _add_ttl(document, ttl_hours)
+            _ensure_ttl_index(coll)
+
+        # Build filter: use provided filter, or match on _id
+        if not filter_query:
+            if "_id" in document:
+                filter_query = {"_id": document["_id"]}
+            else:
+                return {"status": False, "data": {"error": "Must provide filter or document._id for upsert"}}
+
+        result = coll.update_one(filter_query, {"$set": document}, upsert=True)
+
+        client.close()
+
+        return {
+            "status": True,
+            "data": {
+                "matched": result.matched_count,
+                "modified": result.modified_count,
+                "upserted_id": str(result.upserted_id) if result.upserted_id else None,
+            },
+            "message": "Document written successfully",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}
+
+
+def write_many(request_data):
+    """
+    Upsert multiple documents in bulk.
+
+    Params:
+        collection: str - Target collection name
+        documents: list[dict] - Documents to write (each must have _id)
+        ttl_hours: int - Hours until auto-expiry (0 = no expiry)
+        key_field: str - Field to use as upsert key (default: "_id")
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        from pymongo import UpdateOne
+
+        coll, client = _get_collection(headers, params)
+
+        documents = params.get("documents", [])
+        ttl_hours = int(params.get("ttl_hours", 0))
+        key_field = params.get("key_field", "_id")
+
+        if not documents:
+            return {"status": False, "data": {"error": "Missing documents in params"}}
+
+        now = datetime.datetime.utcnow()
+
+        if ttl_hours > 0:
+            _ensure_ttl_index(coll)
+
+        operations = []
+        for doc in documents:
+            doc["updated_at"] = now
+            doc.setdefault("created_at", now)
+
+            if ttl_hours > 0:
+                _add_ttl(doc, ttl_hours)
+
+            key_value = doc.get(key_field)
+            if key_value is None:
+                continue
+
+            operations.append(
+                UpdateOne({key_field: key_value}, {"$set": doc}, upsert=True)
+            )
+
+        if not operations:
+            return {"status": False, "data": {"error": "No valid documents to write (missing key_field)"}}
+
+        result = coll.bulk_write(operations)
+
+        client.close()
+
+        return {
+            "status": True,
+            "data": {
+                "matched": result.matched_count,
+                "modified": result.modified_count,
+                "upserted": result.upserted_count,
+            },
+            "message": f"Bulk write completed: {len(operations)} operations",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# READ OPERATIONS
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def read_document(request_data):
+    """
+    Read a single document by _id.
+
+    Params:
+        collection: str - Target collection name
+        document_id: str - The _id to look up
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        coll, client = _get_collection(headers, params)
+
+        document_id = params.get("document_id", "")
+        if not document_id:
+            return {"status": False, "data": {"error": "Missing document_id"}}
+
+        doc = coll.find_one({"_id": document_id})
+
+        client.close()
+
+        if doc is None:
+            return {"status": True, "data": {"document": None}, "message": "Document not found"}
+
+        return {
+            "status": True,
+            "data": {"document": _serialize_doc(doc)},
+            "message": "Document found",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}
+
+
+def lookup(request_data):
+    """
+    Query documents with flexible filters.
+
+    Params:
+        collection: str - Target collection name
+        filter: dict - MongoDB query filter
+        projection: dict - Fields to include/exclude (optional)
+        sort: list - Sort specification, e.g. [["field", -1]] (optional)
+        limit: int - Max documents to return (default: 100)
+        skip: int - Number of documents to skip (default: 0)
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        coll, client = _get_collection(headers, params)
+
+        filter_query = params.get("filter", {})
+        projection = params.get("projection")
+        sort_spec = params.get("sort")
+        limit = int(params.get("limit", 100))
+        skip = int(params.get("skip", 0))
+
+        cursor = coll.find(filter_query, projection)
+
+        if sort_spec:
+            cursor = cursor.sort(sort_spec)
+
+        cursor = cursor.skip(skip).limit(limit)
+
+        documents = [_serialize_doc(doc) for doc in cursor]
+
+        client.close()
+
+        return {
+            "status": True,
+            "data": {"documents": documents, "count": len(documents)},
+            "message": f"Found {len(documents)} document(s)",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# SEARCH CACHE (drop-in replacement for google-genai invoke_search output)
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def search_cache(request_data):
+    """
+    Query the search cache and return results in the same format as
+    google-genai invoke_search: { answer, search_results }.
+
+    This allows tenant workflows to swap their search connector from
+    google-genai to mongodb-atlas without changing downstream prompts.
+
+    Params:
+        collection: str - Cache collection name (default: "search_cache")
+        search_query: str - Original search query to look up
+        category: str - Category filter (e.g. "competitor_news", "fixture_preview")
+        entity_id: str - Entity identifier (e.g. competitor slug, fixture ID)
+        max_age_hours: int - Only return results newer than N hours (default: 24)
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        params.setdefault("collection", "search_cache")
+        coll, client = _get_collection(headers, params)
+
+        search_query = params.get("search_query", "")
+        category = params.get("category", "")
+        entity_id = params.get("entity_id", "")
+        max_age_hours = int(params.get("max_age_hours", 24))
+
+        # Build filter
+        filter_query = {}
+
+        if entity_id:
+            filter_query["entity_id"] = entity_id
+        if category:
+            filter_query["category"] = category
+        if search_query:
+            filter_query["search_query"] = search_query
+
+        # Only return fresh results
+        if max_age_hours > 0:
+            cutoff = datetime.datetime.utcnow() - datetime.timedelta(hours=max_age_hours)
+            filter_query["updated_at"] = {"$gte": cutoff}
+
+        doc = coll.find_one(filter_query, sort=[("updated_at", -1)])
+
+        client.close()
+
+        if doc is None:
+            return {
+                "status": True,
+                "data": {
+                    "answer": "",
+                    "search_results": [],
+                    "cache_hit": False,
+                },
+                "message": "No cached result found",
+            }
+
+        return {
+            "status": True,
+            "data": {
+                "answer": doc.get("answer", ""),
+                "search_results": doc.get("search_results", []),
+                "cache_hit": True,
+                "cached_at": doc.get("updated_at").isoformat() if isinstance(doc.get("updated_at"), datetime.datetime) else str(doc.get("updated_at", "")),
+                "source_provider": doc.get("source_provider", ""),
+            },
+            "message": "Cache hit",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"answer": "", "search_results": [], "error": str(e)}}
+
+
+# ════════════════════════════════════════════════════════════════════════════════
+# DELETE OPERATIONS
+# ════════════════════════════════════════════════════════════════════════════════
+
+
+def delete_document(request_data):
+    """
+    Delete a single document by _id.
+
+    Params:
+        collection: str - Target collection name
+        document_id: str - The _id to delete
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        coll, client = _get_collection(headers, params)
+
+        document_id = params.get("document_id", "")
+        if not document_id:
+            return {"status": False, "data": {"error": "Missing document_id"}}
+
+        result = coll.delete_one({"_id": document_id})
+
+        client.close()
+
+        return {
+            "status": True,
+            "data": {"deleted": result.deleted_count},
+            "message": f"Deleted {result.deleted_count} document(s)",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}
+
+
+def delete_many(request_data):
+    """
+    Delete documents matching a filter.
+
+    Params:
+        collection: str - Target collection name
+        filter: dict - MongoDB query filter for documents to delete
+    """
+    headers = request_data.get("headers", {})
+    params = request_data.get("params", {})
+
+    try:
+        coll, client = _get_collection(headers, params)
+
+        filter_query = params.get("filter", {})
+        if not filter_query:
+            return {"status": False, "data": {"error": "Must provide filter for delete_many (safety check)"}}
+
+        result = coll.delete_many(filter_query)
+
+        client.close()
+
+        return {
+            "status": True,
+            "data": {"deleted": result.deleted_count},
+            "message": f"Deleted {result.deleted_count} document(s)",
+        }
+
+    except Exception as e:
+        return {"status": False, "data": {"error": str(e)}}

--- a/connectors/mongodb-atlas/mongodb-atlas.yml
+++ b/connectors/mongodb-atlas/mongodb-atlas.yml
@@ -1,0 +1,20 @@
+connector:
+  name: mongodb-atlas
+  description: MongoDB Atlas connector for shared document cache with TTL support. Provides write, read, lookup, and search operations for multi-tenant data sharing.
+  filename: mongodb-atlas.py
+  filetype: pyscript
+  commands:
+    - name: Write
+      value: write_document
+    - name: Write Many
+      value: write_many
+    - name: Read
+      value: read_document
+    - name: Lookup
+      value: lookup
+    - name: Search
+      value: search_cache
+    - name: Delete
+      value: delete_document
+    - name: Delete Many
+      value: delete_many

--- a/connectors/mongodb-atlas/test-connection.yml
+++ b/connectors/mongodb-atlas/test-connection.yml
@@ -1,0 +1,98 @@
+workflow:
+  name: mongodb-atlas-test-connection
+  title: MongoDB Atlas Test Connection
+  description: Test MongoDB Atlas connectivity, write, read, lookup, and search_cache operations.
+  context-variables:
+    debugger:
+      enabled: true
+    mongodb-atlas:
+      connection_string: $TEMP_CONTEXT_VARIABLE_MONGODB_ATLAS_URI
+      database: $TEMP_CONTEXT_VARIABLE_MONGODB_ATLAS_DATABASE
+  inputs:
+    test_collection: "'test_connection'"
+  outputs:
+    write_result: $.get('write_result', {})
+    read_result: $.get('read_result', {})
+    lookup_result: $.get('lookup_result', {})
+    cache_result: $.get('cache_result', {})
+    workflow-status: "'executed'"
+  tasks:
+
+    # Step 1: Write a test document
+    - type: connector
+      name: write-test-doc
+      description: Write a test document to verify connectivity.
+      connector:
+        name: mongodb-atlas
+        command: write_document
+      inputs:
+        collection: $.get('test_collection')
+        document:
+          _id: "'test-doc-001'"
+          category: "'test'"
+          entity_id: "'test-entity'"
+          search_query: "'test search query'"
+          answer: "'This is a test cached answer.'"
+          search_results:
+            - url: "'https://example.com'"
+              title: "'Example Result'"
+          source_provider: "'test'"
+        ttl_hours: 1
+      outputs:
+        write_result: $
+
+    # Step 2: Read the document back
+    - type: connector
+      name: read-test-doc
+      description: Read the test document back by ID.
+      connector:
+        name: mongodb-atlas
+        command: read_document
+      inputs:
+        collection: $.get('test_collection')
+        document_id: "'test-doc-001'"
+      outputs:
+        read_result: $
+
+    # Step 3: Lookup with filter
+    - type: connector
+      name: lookup-test
+      description: Lookup documents with a category filter.
+      connector:
+        name: mongodb-atlas
+        command: lookup
+      inputs:
+        collection: $.get('test_collection')
+        filter:
+          category: "'test'"
+        limit: 10
+      outputs:
+        lookup_result: $
+
+    # Step 4: Search cache (google-genai compatible output)
+    - type: connector
+      name: search-cache-test
+      description: Test search_cache to verify drop-in compatibility with google-genai output.
+      connector:
+        name: mongodb-atlas
+        command: search_cache
+      inputs:
+        collection: $.get('test_collection')
+        entity_id: "'test-entity'"
+        category: "'test'"
+        max_age_hours: 1
+      outputs:
+        cache_result: $
+
+    # Step 5: Clean up test document
+    - type: connector
+      name: cleanup-test-doc
+      description: Delete the test document.
+      connector:
+        name: mongodb-atlas
+        command: delete_document
+      inputs:
+        collection: $.get('test_collection')
+        document_id: "'test-doc-001'"
+      outputs:
+        cleanup_result: $

--- a/docs/skills-compatibility-spec.md
+++ b/docs/skills-compatibility-spec.md
@@ -1,0 +1,515 @@
+# Machina Skills Compatibility Spec
+
+## Purpose
+
+This document defines the current package contract in `machina-templates`, the backward-compatibility rules for evolving it, and the additive path for formalizing `skill.yml` as the canonical skill manifest without breaking existing installs.
+
+The goal is simple:
+
+- every valid template that installs today must continue to install tomorrow
+- existing `_install.yml` and `skill.yml` patterns remain valid
+- new skill metadata is added additively, not destructively
+- `machina-cli`, `machina-studio`, `core-api`, and `client-api` can converge on one shared concept of a skill
+
+---
+
+## Current State Summary
+
+### Repo audit
+
+Observed in `machina-templates`:
+
+- `_install.yml` files: 64
+- `skill.yml` files: 4
+
+Current `skill.yml` locations:
+
+- `skills/mkn-constructor/skill.yml`
+- `connectors/polymarket/skills/sync-events/skill.yml`
+- `connectors/polymarket/skills/sync-markets/skill.yml`
+- `connectors/polymarket/skills/sync-series/skill.yml`
+
+Current dataset types observed in `_install.yml`:
+
+- `workflow`
+- `connector`
+- `mappings`
+- `agent`
+- `prompts`
+- `prompt`
+- `skill`
+
+### Current architectural reality
+
+The repository already contains a real skill abstraction.
+
+- `_install.yml` is the installer/package manifest
+- `skill.yml` is the machine-readable skill manifest
+- `SKILL.md` is the human/operator-facing guide
+- Studio already contains a Skills UI surface
+- CLI is evolving toward package install/push behavior
+
+The problem is not that skills do not exist.
+The problem is that the contract is implicit, partially duplicated, and at risk of dialect drift.
+
+---
+
+## Definitions
+
+### Template
+
+A package in `machina-templates` that can install one or more Machina resources.
+
+Examples:
+- connector package
+- agent template
+- skill package
+
+### Skill
+
+A versioned packaged capability that can be discovered, installed, configured, and executed.
+
+A skill may bundle or reference:
+- workflows
+- agents
+- prompts
+- connectors
+- mappings
+- documents/references
+- local guide files
+
+A skill is the product-facing abstraction.
+The other resource types are implementation pieces.
+
+### Installer manifest
+
+`_install.yml` defines how a package is installed.
+
+### Skill manifest
+
+`skill.yml` defines what a skill is and how it is exposed to the platform.
+
+---
+
+## Canonical Contract: Current Version
+
+## 1. `_install.yml` (current v1 installer contract)
+
+### Role
+
+`_install.yml` is the package installer manifest.
+It is responsible for:
+
+- installer metadata
+- install ordering
+- dataset inventory
+- package source path
+
+### Current structure
+
+```yaml
+setup:
+  title: <string>
+  description: <string>
+  category: <list>
+  estimatedTime: <string>
+  features: <list>
+  integrations: <list>
+  status: <string>
+  value: <string>
+  version: <string>
+  requirements: <list?>
+
+datasets:
+  - type: <string>
+    path: <string>
+```
+
+### Current compatibility notes
+
+- `setup` is required
+- `datasets` is required for installable packages
+- `type: skill` is already valid
+- dataset ordering matters operationally
+- `value` is currently used as the package path / install identity
+
+### Current risks
+
+- duplicated metadata with `skill.yml`
+- inconsistent dataset taxonomy (`prompt` vs `prompts`)
+- no explicit schema version field
+
+---
+
+## 2. `skill.yml` (current v1 skill contract)
+
+### Role
+
+`skill.yml` is the machine-readable runtime/product manifest for a skill.
+It is responsible for:
+
+- skill identity
+- discoverability metadata
+- reference document registration
+- executable entrypoints
+
+### Current structure
+
+```yaml
+skill:
+  name: <string>
+  title: <string>
+  description: <string>
+  version: <string>
+  category: <list>
+  status: <string>
+  domain: <string>
+
+  references: <list>
+  workflows: <list>
+  agents: <list?>
+```
+
+### Current proven fields in repo
+
+Observed in production examples:
+
+- `name`
+- `title`
+- `description`
+- `version`
+- `category`
+- `status`
+- `domain`
+- `references`
+- `workflows`
+
+### Current strengths
+
+- already installable through dataset type `skill`
+- already expressive enough for Studio discovery basics
+- already supports linked references and workflow entrypoints
+
+### Current gaps
+
+Not yet formalized:
+
+- dependency graph
+- install mode
+- runtime target
+- secret requirements
+- local/cloud asset distinction
+- monetization tier
+- visibility rules
+- SDK exposure contract
+- execution semantics
+- manifest versioning
+
+---
+
+## Backward-Compatibility Rules
+
+These rules are mandatory for the architecture renewal.
+
+### Rule 1: no valid existing package becomes invalid
+
+Any package currently installable through `_install.yml` must remain installable.
+
+### Rule 2: `skill.yml` stays
+
+Do not replace `skill.yml` with a brand-new format.
+Extend it additively.
+
+### Rule 3: `_install.yml` stays
+
+Do not collapse installer metadata into `skill.yml`.
+Installer and runtime concerns remain separate.
+
+### Rule 4: dataset type aliases must be supported during migration
+
+At minimum, readers must tolerate:
+
+- `prompt`
+- `prompts`
+
+until a canonical write-path is established.
+
+### Rule 5: additive before destructive
+
+All new skill metadata must be introduced as optional fields first.
+Readers should accept both:
+
+- current v1 manifests
+- extended v1.1 manifests
+
+### Rule 6: no path or folder renames in phase 1
+
+Do not rename:
+- `skills/`
+- `skill.yml`
+- `_install.yml`
+- existing package roots
+
+until all readers support the enriched contract.
+
+### Rule 7: install semantics must not change silently
+
+If package install behavior changes, the change must be encoded explicitly in manifest fields rather than inferred differently by new tooling.
+
+---
+
+## Canonical Responsibility Split
+
+## `_install.yml` owns
+
+- installer/package metadata
+- dataset inventory
+- package path identity
+- install ordering
+- install-time requirements
+
+## `skill.yml` owns
+
+- skill identity
+- product/discovery metadata
+- linked references
+- entrypoints
+- execution metadata
+- dependency metadata
+- future SDK/runtime exposure metadata
+
+## `SKILL.md` owns
+
+- human usage guidance
+- procedural instructions
+- examples
+- operator-facing docs
+
+---
+
+## Proposed `skill.yml` v1.1 (additive only)
+
+The following fields are proposed as optional additions.
+No existing field is removed.
+
+```yaml
+skill:
+  name: "example-skill"
+  title: "Example Skill"
+  description: "Example description"
+  version: "1.0.0"
+  category:
+    - "example"
+  status: "available"
+  domain: "https://github.com/machina-sports/machina-templates"
+
+  manifest_version: "1.1"
+  visibility: "public"
+  tier: "free"
+  install_mode: "hybrid"
+  runtime: "client-api"
+
+  references: []
+  workflows: []
+  agents: []
+
+  dependencies:
+    connectors: []
+    workflows: []
+    prompts: []
+    mappings: []
+    documents: []
+    skills: []
+
+  secrets:
+    required: []
+    optional: []
+
+  execution:
+    entrypoint_type: "workflow"
+    entrypoint_name: "example-workflow"
+    async_supported: true
+
+  sdk:
+    exposed: true
+    methods:
+      - "run"
+      - "get"
+```
+
+### Proposed field meanings
+
+#### `manifest_version`
+Version of the skill manifest contract, not the skill package version.
+
+#### `visibility`
+Allowed values:
+- `public`
+- `private`
+- `internal`
+
+#### `tier`
+Allowed values:
+- `free`
+- `pro`
+- `enterprise`
+
+This is future-safe for Stripe and entitlement work without requiring implementation now.
+
+#### `install_mode`
+Allowed values:
+- `local`
+- `cloud`
+- `hybrid`
+
+#### `runtime`
+Primary execution surface.
+Expected values initially:
+- `client-api`
+- `core-api`
+- `local`
+
+Default recommendation for executable project skills: `client-api`
+
+#### `dependencies`
+Declarative dependency graph for validation and install planning.
+
+#### `secrets`
+Explicit required/optional secret list for setup and validation.
+
+#### `execution`
+Declares the default execution contract for CLI, Studio, and SDK readers.
+
+#### `sdk`
+Signals whether the skill should be surfaced in generated SDK clients and what high-level methods should exist.
+
+---
+
+## Dataset Taxonomy Compatibility Plan
+
+### Current canonical types in the wild
+
+- `connector`
+- `workflow`
+- `agent`
+- `mappings`
+- `skill`
+- `prompt`
+- `prompts`
+
+### Problem
+
+`prompt` and `prompts` both exist.
+This is already a schema drift bug.
+
+### Compatibility policy
+
+#### Read path
+All readers must accept both:
+- `prompt`
+- `prompts`
+
+#### Write path
+Pick one canonical value and standardize future manifests on it.
+
+### Recommendation
+
+Canonicalize on singular dataset names for new writes where possible:
+- `connector`
+- `workflow`
+- `agent`
+- `mapping` or preserve `mappings` if already coupled downstream
+- `prompt`
+- `skill`
+
+However:
+- do not mass-rewrite repo manifests in phase 1
+- first update readers and validators to tolerate aliases
+
+---
+
+## Platform Split Recommendation
+
+## `machina-templates`
+Source of truth for package and skill manifests.
+
+## `machina-cli`
+Install/push/test surface for packages and skills.
+Should eventually expose `skills` as the product-facing command surface while preserving compatibility with `template` commands during migration.
+
+## `machina-studio`
+Discovery, management, execution, and analytics UI for skills.
+Consumes installed skill metadata and richer manifest fields over time.
+
+## `core-api`
+Owns:
+- skill catalog
+- search/discovery metadata
+- visibility
+- entitlement
+- publishing/registry semantics
+
+## `client-api`
+Owns:
+- project-scoped installed skill state
+- skill execution
+- skill activity
+- project-local overrides
+
+---
+
+## Migration Sequence
+
+### Phase 1: Spec and reader compatibility
+- document current contract
+- support current + v1.1 manifests
+- support dataset aliases on read path
+- no breaking changes to install
+
+### Phase 2: Template contract cleanup
+- introduce optional v1.1 fields in selected skills
+- validate with CLI and Studio readers
+- avoid mass rewrites
+
+### Phase 3: Product surface cleanup
+- add `skills` command family in CLI
+- keep `template` aliases for compatibility
+- Studio begins reading enriched skill metadata
+
+### Phase 4: Backend convergence
+- `core-api` becomes catalog/registry/entitlement authority
+- `client-api` becomes runtime execution authority
+
+### Phase 5: SDK exposure
+- expose skill abstraction in TS/Python SDKs
+- map skill manifest metadata to generated client methods
+
+---
+
+## Non-Goals for Phase 1
+
+Do not do these yet:
+
+- rename package roots
+- remove `_install.yml`
+- replace `skill.yml`
+- force all templates to adopt v1.1
+- introduce breaking install order changes
+- hard-wire x402-specific semantics into the manifest
+
+---
+
+## Immediate Next Actions
+
+1. Validate all manifest readers against current repo patterns.
+2. Update validators to support legacy dataset aliases.
+3. Implement additive `skill.yml` v1.1 support in readers.
+4. Introduce CLI `skills` aliases without removing `template` flows.
+5. Align Studio Skills tab to the enriched manifest incrementally.
+
+---
+
+## Final Principle
+
+The path forward is not to invent a brand-new skill architecture.
+It is to formalize the one that already exists, preserve everything that works, and extend it carefully enough that the platform can converge without breaking installs.


### PR DESCRIPTION
Adds the initial skills compatibility architecture spec based on the existing  +  contract already present in .

This PR documents:
- current installer manifest contract
- current skill manifest contract
- backward-compatibility rules
- additive  proposal
- dataset taxonomy compatibility plan
- recommended split across templates, CLI, Studio, Core API, and Client API

Goal: formalize the existing skill abstraction without breaking current installs.