### PR TITLE
feat(ea-football-chat): package sports-skills pyscript connector + runbook

### DIFF
--- a/agent-templates/ea-football-chat/README.md
+++ b/agent-templates/ea-football-chat/README.md
@@ -1,0 +1,87 @@
+# ea-football-chat
+
+Chat agent that answers football questions using live ESPN / Understat / FPL /
+Transfermarkt data. Designed for the EA Sports Hub demo (`factory-kfhagq0m.machina.gg`)
+and portable to any project whose platform has `google-genai` configured.
+
+## Architecture
+
+- **`agent.yml`** — 3-step agent: `chat-reasoning` → `map(tool_calls)` → `chat-response`.
+- **`prompts/`** — `chat-reasoning` picks tools + params; `chat-response` writes the reply; `tool-catalog` is reference.
+- **`workflows/`** — `chat-reasoning` (router) + `chat-response` (LLM call).
+- **`tools/`** — 6 tool workflows each calling the `sports-skills` connector via the `football` dispatcher.
+- **`connectors/sports-skills.{yml,py}`** — pyscript connector with a single `football` command that dispatches on the `command` input to the corresponding `sports_skills.football._connector` function.
+
+The dispatcher interface matches what the 6 tools already call:
+
+```yaml
+connector:
+  name: sports-skills
+  command: football
+inputs:
+  command: "'get_season_standings'"
+  season_id: "$.get('season_id')"
+```
+
+Allowed inner `command` values: `get_current_season`, `get_competitions`,
+`get_competition_seasons`, `get_season_schedule`, `get_season_standings`,
+`get_season_leaders`, `get_season_teams`, `search_team`, `search_player`,
+`get_team_profile`, `get_team_schedule`, `get_daily_schedule`,
+`get_event_summary`, `get_event_lineups`, `get_event_statistics`,
+`get_event_timeline`, `get_event_xg`, `get_event_players_statistics`,
+`get_head_to_head`, `get_missing_players`, `get_season_transfers`,
+`get_player_profile`, `get_player_season_stats`.
+
+## Platform prerequisites
+
+1. **`sports-skills` Python library available in the pyscript runtime.** The
+   connector does `from sports_skills.football import _connector`. Confirm
+   the platform runtime has it installed (`pip install sports-skills` — see
+   <https://pypi.org/project/sports-skills/>). If the connector returns
+   `{"error": True, "message": "sports-skills not installed: ..."}`, the
+   runtime image is missing the dependency.
+2. **`google-genai` connector configured** on the target project — either
+   AI Studio (api_key) or Vertex AI (credential + project_id). The
+   `chat-response` workflow currently uses `invoke_chat` with
+   `gemini-2.5-flash`.
+
+No API keys are required for the sports data itself — ESPN / Understat /
+FPL / Transfermarkt are all public endpoints the library hits directly.
+
+## Installing into a project
+
+Studio-side, once per project:
+
+1. **Import `_install.yml`.** Datasets install in order — connector first,
+   then agent, then prompts, then workflows, then tools.
+2. **Verify the connector landed.** The project should show a `sports-skills`
+   connector with a single `Football` command. If an older `sports-skills`
+   reference exists from a prior attempt, remove it first so the tools
+   resolve to this one.
+3. **Smoke-test a tool** via Studio's run-workflow UI:
+   - `get-league-standings` with `competition_id: "premier-league"` — expect
+     `workflow-status: true` and a populated `result.standings`.
+   - `get-daily-fixtures` with no params — expect today's matches.
+   - `search-entity` with `query: "Arsenal"` — expect team + player matches.
+4. **Smoke-test the agent** with `{ messages: [{ role: "user", content:
+   "Who's top of the Premier League?" }] }` — expect `chat-reasoning` to
+   emit `tool_calls: [{tool: "get-league-standings", args: {competition_id:
+   "premier-league"}}]`, the map step to fetch the table, and
+   `chat-response` to return a prose summary.
+
+## Related fix: OpenAI 401 invalid_organization
+
+Unrelated to this template but shipped in the same PR: the `machina-ai`
+connector's `invoke_prompt` / `invoke_embedding` now accept optional
+`organization` and `project` params. Projects hitting `401 invalid_organization`
+with `sk-proj-*` keys can fix it via workflow `context-variables`:
+
+```yaml
+context-variables:
+  machina-ai:
+    api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    organization: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_ORG_ID
+    project: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_PROJECT_ID
+```
+
+No connector rebuild needed.

--- a/agent-templates/ea-football-chat/_install.yml
+++ b/agent-templates/ea-football-chat/_install.yml
@@ -16,6 +16,9 @@ setup:
   version: 1.0.0
 
 datasets:
+  - type: "connector"
+    path: "connectors/sports-skills.yml"
+
   - type: "agent"
     path: "agent.yml"
   

--- a/agent-templates/ea-football-chat/connectors/sports-skills.yml
+++ b/agent-templates/ea-football-chat/connectors/sports-skills.yml
@@ -1,0 +1,8 @@
+connector:
+  name: "sports-skills"
+  description: "Football data via the sports-skills Python library (ESPN, Understat, FPL, Transfermarkt). Single dispatcher command — tools pass the internal function name via the `command` input."
+  filename: "sports_skills.py"
+  filetype: "pyscript"
+  commands:
+    - name: "Football"
+      value: "football"

--- a/agent-templates/ea-football-chat/connectors/sports_skills.py
+++ b/agent-templates/ea-football-chat/connectors/sports_skills.py
@@ -1,0 +1,78 @@
+"""sports-skills pyscript connector — single dispatcher entry point.
+
+The ea-football-chat tools call this connector with `command: "football"` and
+pass the internal function name via the `command` input param, e.g.:
+
+    connector:
+      name: sports-skills
+      command: football
+    inputs:
+      command: "'get_season_standings'"
+      season_id: "$.get('season_id')"
+
+This `football()` function dispatches the request to the corresponding
+`sports_skills.football._connector` function, which returns an ESPN /
+Understat / FPL / Transfermarkt payload. Returned as `{"result": <data>}`
+so the tools can read it via `$.get('result')`.
+"""
+
+from __future__ import annotations
+
+
+_ALLOWED = {
+    "get_current_season",
+    "get_competitions",
+    "get_competition_seasons",
+    "get_season_schedule",
+    "get_season_standings",
+    "get_season_leaders",
+    "get_season_teams",
+    "search_team",
+    "search_player",
+    "get_team_profile",
+    "get_team_schedule",
+    "get_daily_schedule",
+    "get_event_summary",
+    "get_event_lineups",
+    "get_event_statistics",
+    "get_event_timeline",
+    "get_event_xg",
+    "get_event_players_statistics",
+    "get_head_to_head",
+    "get_missing_players",
+    "get_season_transfers",
+    "get_player_profile",
+    "get_player_season_stats",
+}
+
+
+def football(params):
+    """Dispatch to the named sports_skills.football function.
+
+    params: flat dict of all workflow inputs. Reads `command` to pick the
+    function; forwards the remaining keys as the function's params.
+    """
+    command = params.get("command")
+    if not command:
+        return {"error": True, "message": "'command' input is required"}
+
+    if command not in _ALLOWED:
+        return {"error": True, "message": f"Unknown command: {command}"}
+
+    try:
+        from sports_skills.football import _connector
+    except ImportError as exc:
+        return {"error": True, "message": f"sports-skills not installed: {exc}"}
+
+    fn = getattr(_connector, command, None)
+    if fn is None:
+        return {"error": True, "message": f"Command not found on module: {command}"}
+
+    forwarded = {k: v for k, v in params.items() if k != "command"}
+
+    try:
+        data = fn({"params": forwarded})
+    except Exception as exc:
+        return {"error": True, "message": f"{command} failed: {exc}"}
+
+    return {"result": data}

--- a/connectors/machina-ai/machina-ai.py
+++ b/connectors/machina-ai/machina-ai.py
@@ -9,15 +9,26 @@ def invoke_embedding(params):
 
     model_name = params.get("model_name")
 
+    organization = params.get("organization") or params.get("org_id")
+
+    project = params.get("project") or params.get("project_id")
+
     if not api_key:
         return {"status": "error", "message": "API key is required."}
 
     if not model_name:
         return {"status": "error", "message": "Model name is required."}
 
+    kwargs = {"api_key": api_key, "model": model_name}
+
+    if organization:
+        kwargs["organization"] = organization
+
+    if project:
+        kwargs["default_headers"] = {"OpenAI-Project": project}
+
     try:
-        llm = OpenAIEmbeddings(api_key=api_key, model=model_name)
-        # llm = OpenAI(api_key=api_key)
+        llm = OpenAIEmbeddings(**kwargs)
 
     except Exception as e:
         return {"status": "error", "message": f"Exception when creating model: {e}"}
@@ -31,14 +42,31 @@ def invoke_prompt(params):
 
     model_name = params.get("model_name")
 
+    organization = params.get("organization") or params.get("org_id")
+
+    project = params.get("project") or params.get("project_id")
+
+    base_url = params.get("base_url")
+
     if not api_key:
         return {"status": "error", "message": "API key is required."}
 
     if not model_name:
         return {"status": "error", "message": "Model name is required."}
 
+    kwargs = {"model": model_name, "api_key": api_key}
+
+    if organization:
+        kwargs["organization"] = organization
+
+    if project:
+        kwargs["default_headers"] = {"OpenAI-Project": project}
+
+    if base_url:
+        kwargs["base_url"] = base_url
+
     try:
-        llm = ChatOpenAI(model=model_name, api_key=api_key)
+        llm = ChatOpenAI(**kwargs)
 
     except Exception as e:
         return {"status": "error", "message": f"Exception when creating model: {e}"}


### PR DESCRIPTION
## Summary

Additive on top of the existing `ea-football-chat` template on `main`. No collisions with the ongoing iteration — only 3 new files + 1 surgical edit + 1 orthogonal connector fix.

- **`agent-templates/ea-football-chat/connectors/sports-skills.{yml,py}`** (new) — pyscript connector exposing a single `football` dispatcher command that matches the interface the 6 tool workflows in `tools/*.yml` already use:
  ```yaml
  connector: { name: sports-skills, command: football }
  inputs:
    command: "'get_season_standings'"
    season_id: "$.get('season_id')"
  ```
  Dispatches to `sports_skills.football._connector.<fn>` with an allowlist covering all 23 public library functions. Returns `{"result": <data>}`.
- **`agent-templates/ea-football-chat/_install.yml`** (edit, +3 lines) — adds the connector dataset at the top of `datasets:` so importing the template registers the connector before the agent + tools try to resolve it. Closes the "Connector id not found" error.
- **`agent-templates/ea-football-chat/README.md`** (new) — install runbook: pyscript runtime prerequisite (`pip install sports-skills`), smoke-test payloads for the tools and agent, note on the `machina-ai` fix.
- **`connectors/machina-ai/machina-ai.py`** (edit) — `invoke_prompt` + `invoke_embedding` accept optional `organization` / `project` / `base_url` params. Unblocks `401 invalid_organization` on OpenAI sk-proj-* keys via workflow `context-variables` — no connector rebuild. Orthogonal to the EA chat but shipped together.

## Context

The EA Sports Hub demo (`factory-kfhagq0m.machina.gg`) had a working chat UI but the backing agent tools failed in the Podcasts project with "Connector id not found" because `sports-skills` was never packaged anywhere in `machina-templates`. This PR packages it where it belongs — inside the template's own `connectors/` — so the `_install.yml` manifest bootstraps both the agent and its connector atomically.

Separately, the first-party `chat-completions` template surfaced `401 invalid_organization` on that project because `machina-ai`'s `invoke_prompt` silently dropped org/project metadata from sk-proj-* keys. The same PR adds that surface to the connector.

## Test plan

- [x] YAML parses (`yaml.safe_load` on `_install.yml` + `sports-skills.yml`).
- [x] Python compiles (`py_compile` on `sports_skills.py` + `machina-ai.py`).
- [ ] Import `_install.yml` into a test project on Studio — confirm a `sports-skills` connector with a single `Football` command appears.
- [ ] Ensure the pyscript runtime on the target project has `sports-skills` installed (`pip install sports-skills`).
- [ ] Smoke-test tools via Studio run-workflow:
  - [ ] `get-league-standings` with `competition_id: "premier-league"` → populated `result.standings`.
  - [ ] `get-daily-fixtures` with no params → today's matches.
  - [ ] `search-entity` with `query: "Arsenal"` → teams + players.
- [ ] Invoke the agent with `{ messages: [{ role: "user", content: "Who's top of the Premier League?" }] }` → `chat-reasoning` emits `tool_calls: [{tool: "get-league-standings", args: {competition_id: "premier-league"}}]`, map step fetches data, `chat-response` returns prose.
- [ ] In a separate project hitting the 401, set `machina-ai.organization` + `machina-ai.project` context-variables alongside the sk-proj-* key → first-party `chat-completions` template succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)