### PR TITLE
feat(truth-point): Phase A+B — ingest action + tenant template

### DIFF
--- a/.github/scripts/truth_point_ingest.py
+++ b/.github/scripts/truth_point_ingest.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Walk the templates repo, build one payload per component, POST to Truth Point.
+
+A "component" is any directory containing an `_install.yml`. The directory's
+parent (e.g. `agent-templates`, `connectors`, `skills`) becomes the `kind`.
+
+Triggered from .github/workflows/truth-point-ingest.yml — accepts an optional
+list of changed paths so PR runs only re-ingest the affected components.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+
+COMPONENT_ROOTS = ("agent-templates", "connectors", "skills")
+MAX_FILE_BYTES = 256 * 1024  # 256 KiB per file — anything larger is summarized
+RETRIES = 3
+BACKOFF_SEC = 2
+
+
+def find_components(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for top in COMPONENT_ROOTS:
+        base = root / top
+        if not base.is_dir():
+            continue
+        for install in base.glob("*/_install.yml"):
+            out.append(install.parent)
+    return sorted(out)
+
+
+def filter_by_changed(components: list[Path], changed: list[str], root: Path) -> list[Path]:
+    if not changed:
+        return components
+    rels = []
+    for comp in components:
+        rel = comp.relative_to(root).as_posix() + "/"
+        if any(c.startswith(rel) for c in changed):
+            rels.append(comp)
+    return rels
+
+
+def read_text_safe(path: Path) -> tuple[str, bool]:
+    """Return (content, truncated). Skip binaries; truncate huge files."""
+    try:
+        size = path.stat().st_size
+        if size > MAX_FILE_BYTES:
+            with path.open("rb") as f:
+                head = f.read(MAX_FILE_BYTES)
+            try:
+                return head.decode("utf-8"), True
+            except UnicodeDecodeError:
+                return "", True
+        return path.read_text(encoding="utf-8"), False
+    except (UnicodeDecodeError, OSError):
+        return "", False
+
+
+def collect_files(component: Path) -> list[dict]:
+    files: list[dict] = []
+    for f in sorted(component.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.name.startswith(".") or "__pycache__" in f.parts:
+            continue
+        if f.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif", ".zip", ".pdf", ".mp3", ".mp4", ".wav"}:
+            continue
+        content, truncated = read_text_safe(f)
+        files.append(
+            {
+                "path": f.relative_to(component).as_posix(),
+                "content": content,
+                "truncated": truncated,
+                "size": f.stat().st_size,
+            }
+        )
+    return files
+
+
+def build_payload(component: Path, kind: str, repo: str, ref: str) -> dict:
+    install_path = component / "_install.yml"
+    install_raw = install_path.read_text(encoding="utf-8")
+    install = yaml.safe_load(install_raw) or {}
+    setup = install.get("setup", {}) or {}
+
+    categories = setup.get("category") or []
+    if isinstance(categories, str):
+        categories = [categories]
+
+    return {
+        "kind": kind,                                # agent-template | connector | skill
+        "name": component.name,                      # dir name
+        "source_repo": repo,                         # machina-sports/machina-templates
+        "source_path": component.relative_to(component.parent.parent).as_posix(),
+        "source_ref": ref,                           # commit SHA
+        "version": setup.get("version", ""),
+        "title": setup.get("title", ""),
+        "description": setup.get("description", ""),
+        "categories": categories,
+        "integrations": setup.get("integrations", []) or [],
+        "status": setup.get("status", ""),
+        "value": setup.get("value", ""),
+        "manifest": install_raw,                     # raw _install.yml
+        "manifest_parsed": install,
+        "files": collect_files(component),
+    }
+
+
+def post(endpoint: str, token: str, payload: dict, timeout: int = 60) -> tuple[int, str]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Api-Token": token,
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read().decode("utf-8", errors="replace")
+
+
+def post_with_retry(endpoint: str, token: str, payload: dict) -> tuple[bool, str]:
+    last_err = ""
+    for attempt in range(1, RETRIES + 1):
+        try:
+            status, text = post(endpoint, token, payload)
+            if 200 <= status < 300:
+                return True, f"http {status}"
+            last_err = f"http {status}: {text[:200]}"
+            if 400 <= status < 500 and status not in (408, 429):
+                return False, last_err  # don't retry client errors except 408/429
+        except urllib.error.HTTPError as e:
+            body = ""
+            try:
+                body = e.read().decode("utf-8", errors="replace")[:200]
+            except Exception:
+                pass
+            last_err = f"HTTPError {e.code}: {body}"
+            if 400 <= e.code < 500 and e.code not in (408, 429):
+                return False, last_err
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_err = f"{type(e).__name__}: {e}"
+        if attempt < RETRIES:
+            time.sleep(BACKOFF_SEC * attempt)
+    return False, last_err
+
+
+def parse_changed(path: str | None) -> list[str]:
+    if not path:
+        return []
+    p = Path(path)
+    if not p.exists():
+        return []
+    return [line.strip() for line in p.read_text().splitlines() if line.strip()]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".", help="Repo root")
+    parser.add_argument("--endpoint", default=os.environ.get("TRUTH_POINT_INGEST_URL", ""))
+    parser.add_argument("--token", default=os.environ.get("TRUTH_POINT_API_TOKEN", ""))
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "machina-sports/machina-templates"))
+    parser.add_argument("--ref", default=os.environ.get("GITHUB_SHA", "HEAD"))
+    parser.add_argument("--changed-paths", default="", help="Optional file with changed paths (one per line)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--strict", action="store_true", help="Fail loud on any per-component error")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    components = find_components(root)
+    if not components:
+        print("no components found")
+        return 0
+
+    changed = parse_changed(args.changed_paths)
+    targeted = filter_by_changed(components, changed, root) if changed else components
+
+    print(f"components total={len(components)}  targeted={len(targeted)}  changed_paths={len(changed)}")
+    if not targeted:
+        print("nothing to ingest")
+        return 0
+
+    if not args.dry_run:
+        if not args.endpoint or not args.token:
+            print("WARN: TRUTH_POINT_INGEST_URL or TRUTH_POINT_API_TOKEN missing — skipping (dry-run mode)")
+            args.dry_run = True
+
+    successes = 0
+    failures: list[tuple[str, str]] = []
+    for comp in targeted:
+        kind = comp.parent.name.rstrip("s")  # agent-templates → agent-template
+        if comp.parent.name == "skills":
+            kind = "skill"
+        elif comp.parent.name == "connectors":
+            kind = "connector"
+        elif comp.parent.name == "agent-templates":
+            kind = "agent-template"
+
+        try:
+            payload = build_payload(comp, kind, args.repo, args.ref)
+        except Exception as e:
+            failures.append((comp.name, f"build_payload: {type(e).__name__}: {e}"))
+            print(f"  SKIP {comp.name} (build error: {e})")
+            continue
+
+        if args.dry_run:
+            print(f"  DRY {kind}/{comp.name}  files={len(payload['files'])}  size={sum(len(f.get('content', '')) for f in payload['files'])}B")
+            successes += 1
+            continue
+
+        ok, msg = post_with_retry(args.endpoint, args.token, payload)
+        if ok:
+            successes += 1
+            print(f"  OK  {kind}/{comp.name}  {msg}")
+        else:
+            failures.append((comp.name, msg))
+            print(f"  ERR {kind}/{comp.name}  {msg}")
+
+    print(f"summary: ok={successes}  failed={len(failures)}")
+    if failures:
+        for name, err in failures:
+            print(f"  - {name}: {err}")
+        if args.strict or successes == 0:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/truth-point-ingest.yml
+++ b/.github/workflows/truth-point-ingest.yml
@@ -1,0 +1,90 @@
+name: Truth Point — Ingest Components
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent-templates/**"
+      - "connectors/**"
+      - "skills/**"
+      - ".github/scripts/truth_point_ingest.py"
+      - ".github/workflows/truth-point-ingest.yml"
+  pull_request:
+    paths:
+      - "agent-templates/**"
+      - "connectors/**"
+      - "skills/**"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "full = re-ingest every component; diff = only changed since base"
+        type: choice
+        options: [full, diff]
+        default: full
+      strict:
+        description: "Fail the workflow on any per-component error"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install --quiet pyyaml
+
+      - name: Compute changed paths
+        id: changed
+        env:
+          MODE: ${{ inputs.mode }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          out=changed.txt
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$out"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "$MODE" == "full" ]]; then
+            : > "$out"   # empty → script ingests everything
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ -n "${BEFORE_SHA:-}" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+              git diff --name-only "$BEFORE_SHA" "${{ github.sha }}" > "$out"
+            else
+              : > "$out"
+            fi
+          else
+            : > "$out"
+          fi
+          echo "----- changed paths -----"
+          cat "$out" || true
+          echo "-------------------------"
+
+      - name: Ingest
+        env:
+          TRUTH_POINT_INGEST_URL: ${{ secrets.TRUTH_POINT_INGEST_URL }}
+          TRUTH_POINT_API_TOKEN: ${{ secrets.TRUTH_POINT_API_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          extra=""
+          if [[ "${{ inputs.strict || 'false' }}" == "true" || "${{ github.event_name }}" == "push" ]]; then
+            extra="--strict"
+          fi
+          python .github/scripts/truth_point_ingest.py \
+            --root . \
+            --changed-paths changed.txt \
+            $extra \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -1,0 +1,29 @@
+setup:
+  title: Truth Point
+  description: Single source of truth for the Machina platform — receives component manifests from machina-templates (ingest), serves semantic retrieval to consumers like the Factory (query), and absorbs verdicts from job runs to keep itself current (feedback).
+  category:
+    - special-templates
+    - platform
+  estimatedTime: 5 minutes
+  features:
+    - Ingest endpoint (POST /workflow/schedule/<id>) — accepts a component payload and upserts it into machina-knowledge with a Vertex text-embedding-004 vector
+    - Query endpoint — vector search over indexed components, returns top-K with scores
+    - Feedback endpoint — appends a structured verdict to a component's verdict_history without re-embedding
+    - Stable component identity via metadata.component_id (kind:name)
+  status: available
+  integrations:
+    - google-vertex
+  value: agent-templates/truth-point
+  version: 1.0.0
+
+datasets:
+
+  # Workflows
+  - type: workflow
+    path: workflows/truth-point-ingest.yml
+
+  - type: workflow
+    path: workflows/truth-point-query.yml
+
+  - type: workflow
+    path: workflows/truth-point-feedback.yml

--- a/agent-templates/truth-point/workflows/truth-point-feedback.yml
+++ b/agent-templates/truth-point/workflows/truth-point-feedback.yml
@@ -1,0 +1,73 @@
+workflow:
+
+  # truth-point-feedback
+  name: truth-point-feedback
+  title: Truth Point — Record Verdict
+  description: Append a structured verdict for a component (success/partial/fail + artifacts) to its verdict_history. Used by the Factory and CI hooks to keep Truth Point aligned with reality. Does not re-embed.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    component_id: $.get('component_id', '')
+    verdict: $.get('verdict', '')        # success | partial | fail
+    summary: $.get('summary', '')        # one-line human reason
+    artifacts: $.get('artifacts', {})    # arbitrary {logs_url, pr_url, run_id, ...}
+    actor: $.get('actor', '')            # who/what produced the verdict (factory, ci, human, ...)
+
+  outputs:
+    component_id: $.get('component_id', '')
+    document_id: $.get('document_id', None)
+    verdicts_total: $.get('verdicts_total', 0)
+    workflow-status: $.get('document_id') is not None and 'executed' or 'skipped'
+
+  tasks:
+
+    # Locate the component doc by stable id
+    - type: document
+      name: lookup-component
+      description: Resolve component doc by component_id
+      condition: $.get('component_id') is not None and $.get('component_id') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'machina-knowledge'"
+        metadata.component_id: $.get('component_id')
+      outputs:
+        document_id: $.get('documents')[0].get('_id') if len($.get('documents', [])) > 0 else None
+        document_value: $.get('documents')[0].get('value', {}) if len($.get('documents', [])) > 0 else {}
+        existing_history: $.get('documents')[0].get('value', {}).get('verdict_history', []) if len($.get('documents', [])) > 0 else []
+
+    # Append the verdict atomically (no re-embedding)
+    - type: document
+      name: append-verdict
+      description: Append the new verdict to verdict_history
+      condition: $.get('document_id') is not None and $.get('verdict') in ['success', 'partial', 'fail']
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        machina-knowledge: |
+          {
+            **$.get('document_value'),
+            'verdict_history': [
+              *$.get('existing_history', []),
+              {
+                'verdict': $.get('verdict', ''),
+                'summary': $.get('summary', ''),
+                'artifacts': $.get('artifacts', {}),
+                'actor': $.get('actor', ''),
+                'recorded_at': datetime.now().isoformat()
+              }
+            ],
+            'last_verdict': $.get('verdict', ''),
+            'last_verdict_at': datetime.now().isoformat()
+          }
+      filters:
+        document_id: $.get('document_id')
+      outputs:
+        verdicts_total: len($.get('existing_history', [])) + 1

--- a/agent-templates/truth-point/workflows/truth-point-ingest.yml
+++ b/agent-templates/truth-point/workflows/truth-point-ingest.yml
@@ -1,0 +1,116 @@
+workflow:
+
+  # truth-point-ingest
+  name: truth-point-ingest
+  title: Truth Point — Ingest Component
+  description: Receives a component payload from machina-templates and upserts it into machina-knowledge with a Vertex embedding. Idempotent — re-ingest of the same component_id replaces the doc value but preserves verdict_history.
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
+  inputs:
+    kind: $.get('kind', '')
+    name: $.get('name', '')
+    source_repo: $.get('source_repo', '')
+    source_path: $.get('source_path', '')
+    source_ref: $.get('source_ref', '')
+    version: $.get('version', '')
+    title: $.get('title', '')
+    description: $.get('description', '')
+    categories: $.get('categories', [])
+    integrations: $.get('integrations', [])
+    status: $.get('status', '')
+    manifest: $.get('manifest', '')
+    files: $.get('files', [])
+
+  outputs:
+    component_id: $.get('component_id', '')
+    document_id: $.get('document_id', None)
+    action_taken: $.get('action_taken', 'noop')
+    workflow-status: $.get('component_id') and 'executed' or 'skipped'
+
+  tasks:
+
+    # Build a stable identity + the text we'll embed
+    - type: expression
+      name: prepare-identity
+      description: Compute component_id and the embedding_text used as embed-selector input
+      condition: $.get('kind') is not None and $.get('name') is not None and $.get('kind') != '' and $.get('name') != ''
+      outputs:
+        component_id: f"{$.get('kind')}:{$.get('name')}"
+        embedding_text: |
+          "\n".join([
+            $.get('title', '') or $.get('name', ''),
+            $.get('description', '') or '',
+            "Kind: " + ($.get('kind') or ''),
+            "Categories: " + ", ".join($.get('categories', []) or []),
+            "Integrations: " + ", ".join($.get('integrations', []) or []),
+            "Source: " + ($.get('source_repo', '') or '') + "/" + ($.get('source_path', '') or ''),
+            "",
+            ($.get('manifest', '') or '')[:6000]
+          ]).strip()
+
+    # Look for an existing doc with the same component_id so we preserve verdict_history
+    - type: document
+      name: lookup-existing
+      description: Find existing component doc by component_id (preserve verdict_history)
+      condition: $.get('component_id') is not None and $.get('component_id') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'machina-knowledge'"
+        metadata.component_id: $.get('component_id')
+      outputs:
+        existing_id: $.get('documents')[0].get('_id') if len($.get('documents', [])) > 0 else None
+        existing_verdict_history: $.get('documents')[0].get('value', {}).get('verdict_history', []) if len($.get('documents', [])) > 0 else []
+
+    # Upsert with a fresh embedding sourced from the embedding_text field via embed-selector
+    - type: document
+      name: save-component
+      description: Save (or replace) the component doc; embed only the embedding_text field
+      condition: $.get('component_id') is not None and $.get('component_id') != ''
+      config:
+        action: save
+        embed-vector: true
+        embed-selector: embedding_text
+        force-update: true
+      connector:
+        name: "google-genai"
+        command: "invoke_embedding"
+        model: "text-embedding-004"
+      documents:
+        machina-knowledge: |
+          {
+            'title': $.get('title', '') or $.get('name', ''),
+            'kind': $.get('kind', ''),
+            'name': $.get('name', ''),
+            'component_id': $.get('component_id'),
+            'source_repo': $.get('source_repo', ''),
+            'source_path': $.get('source_path', ''),
+            'source_ref': $.get('source_ref', ''),
+            'version': $.get('version', ''),
+            'description': $.get('description', ''),
+            'categories': $.get('categories', []),
+            'integrations': $.get('integrations', []),
+            'status': $.get('status', ''),
+            'manifest': $.get('manifest', ''),
+            'files': $.get('files', []),
+            'embedding_text': $.get('embedding_text', ''),
+            'verdict_history': $.get('existing_verdict_history', []),
+            'ingested_at': datetime.now().isoformat()
+          }
+      metadata:
+        component_id: $.get('component_id')
+        kind: $.get('kind', '')
+        name: $.get('name', '')
+        source_repo: $.get('source_repo', '')
+        source_ref: $.get('source_ref', '')
+      outputs:
+        document_id: $.get('documents')[0].get('_id') if len($.get('documents', [])) > 0 else None
+        action_taken: $.get('existing_id') and 'updated' or 'created'

--- a/agent-templates/truth-point/workflows/truth-point-query.yml
+++ b/agent-templates/truth-point/workflows/truth-point-query.yml
@@ -1,0 +1,81 @@
+workflow:
+
+  # truth-point-query
+  name: truth-point-query
+  title: Truth Point — Query Components
+  description: Vector search over indexed components. Given a natural-language query, returns the top-K most relevant components (kind/name/title/description/source_path) and their similarity scores. Used by the Factory before kicking off a job.
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
+  inputs:
+    query: $.get('query', '')
+    limit: $.get('limit', 5)
+    threshold: $.get('threshold', 0.3)
+    kind: $.get('kind', None)            # optional pre-filter (agent-template | connector | skill)
+    integration: $.get('integration', None)  # optional pre-filter (e.g. "google-vertex")
+
+  outputs:
+    query: $.get('query', '')
+    components: $.get('components', [])
+    workflow-status: $.get('query') is not None and $.get('query') != '' and 'executed' or 'skipped'
+
+  tasks:
+
+    # Build the metadata pre-filter as a dict (kind / integration are optional)
+    - type: expression
+      name: build-prefilter
+      condition: $.get('query') is not None and $.get('query') != ''
+      outputs:
+        prefilter: |
+          {
+            **({'metadata.kind': $.get('kind')} if $.get('kind') else {}),
+            **({'integrations': {'$in': [$.get('integration')]}} if $.get('integration') else {})
+          }
+
+    # Vector search across machina-knowledge with optional pre-filter
+    - type: document
+      name: vector-search
+      description: Embed the query and run cosine similarity over the KB
+      condition: $.get('query') is not None and $.get('query') != ''
+      config:
+        action: search
+        search-vector: true
+        search-limit: 100
+        threshold-docs: $.get('limit', 5)
+        threshold-similarity: $.get('threshold', 0.3)
+      connector:
+        name: "google-genai"
+        command: "invoke_embedding"
+        model: "text-embedding-004"
+      inputs:
+        name: "'machina-knowledge'"
+        search-query: $.get('query')
+      filters:
+        name: "'machina-knowledge'"
+      outputs:
+        components: |
+          [
+            {
+              'component_id': d.get('value', {}).get('component_id', ''),
+              'kind': d.get('value', {}).get('kind', ''),
+              'name': d.get('value', {}).get('name', ''),
+              'title': d.get('value', {}).get('title', ''),
+              'description': d.get('value', {}).get('description', ''),
+              'source_path': d.get('value', {}).get('source_path', ''),
+              'source_ref': d.get('value', {}).get('source_ref', ''),
+              'version': d.get('value', {}).get('version', ''),
+              'integrations': d.get('value', {}).get('integrations', []),
+              'categories': d.get('value', {}).get('categories', []),
+              'similarity': d.get('similarity_score', 0),
+              'verdict_summary': {
+                'count': len(d.get('value', {}).get('verdict_history', []) or []),
+                'last': (d.get('value', {}).get('verdict_history', []) or [{}])[-1] if (d.get('value', {}).get('verdict_history', []) or []) else None
+              }
+            }
+            for d in $.get('documents', [])
+          ]


### PR DESCRIPTION
## Summary

Bundles **Phase A** (GitHub Action that POSTs every component to a Truth Point endpoint) and **Phase B** (the agent-template that exposes the three Truth Point workflows when installed in a tenant). Reference: [automation flow](https://magenta-scone-a2157a.netlify.app/#1).

### Phase A — `.github/scripts/truth_point_ingest.py` + `.github/workflows/truth-point-ingest.yml`
Walks every dir containing `_install.yml` under `agent-templates/`, `connectors/`, `skills/` and POSTs a structured payload to `${{ secrets.TRUTH_POINT_INGEST_URL }}` with `${{ secrets.TRUTH_POINT_API_TOKEN }}`.

- Diff-aware on PR + push (uses `before` SHA)
- Full sweep on `workflow_dispatch` mode=`full`
- No-ops cleanly when secrets are unset → safe to land before the receiver
- Local dry-run: 69 components, 0 failed (27 agent-templates incl. `truth-point` itself, 41 connectors, 1 skill)

### Phase B — `agent-templates/truth-point/`
Drop-in template for a dedicated tenant (proposed name `machina-truth`). Three workflows:

| Workflow | Purpose |
|---|---|
| `truth-point-ingest` | Receives the GH-Action payload → upserts `machina-knowledge` with a Vertex `text-embedding-004` vector. Preserves `verdict_history` across re-ingests. |
| `truth-point-query` | Vector search → top-K components with similarity, source_path, integrations, last verdict. Consumed by the Factory before kicking off a job. |
| `truth-point-feedback` | Appends `{verdict, summary, artifacts, actor, recorded_at}` to a component's `verdict_history`. No re-embedding. |

Stable identity: `metadata.component_id = "<kind>:<name>"`. Embedding text is isolated via `embed-selector: embedding_text` so the `files[]` blob stays out of the vector.

## Operator runbook (after merge)

1. **Provision tenant** `machina-truth` via existing `/machina:deploy-tenant` flow.
2. **Set tenant secrets** (vault):
   - `TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL` — service-account JSON (same shape as assistant-boilerplate)
   - `TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID` — GCP project id
3. **Install template** `agent-templates/truth-point` in the tenant via studio import.
4. **Set repo secrets** (machina-templates → Settings → Secrets):
   - `TRUTH_POINT_INGEST_URL` = `https://machina-truth.org.machina.gg/workflow/schedule/<truth-point-ingest workflow id>`
   - `TRUTH_POINT_API_TOKEN` = a tenant API token with workflow execute scope
5. **Seed**: run `Truth Point — Ingest Components` workflow with `mode=full` to backfill all 68 existing components.
6. **Smoke-test**: invoke `truth-point-query` with `query: "how do I build a custom connector"` and confirm top hits are `connector/google-genai`, `connector/openai`, etc. with similarity > 0.5.

## Test plan
- [ ] Action no-ops cleanly on this PR (secrets unset → dry-run, exit 0)
- [ ] After step 5, all 68 components present in `machina-knowledge` with `metadata.component_id` set
- [ ] Re-ingest of any one component shows `action_taken=updated` and preserves any prior `verdict_history`
- [ ] Query returns relevant components above threshold
- [ ] Feedback workflow appends to history without changing the embedding

🤖 Generated with [Claude Code](https://claude.com/claude-code)