### PR TITLE
chore(probe): one-off smoke for reusable-emit-verdict@v1

### DIFF
--- a/.github/workflows/probe-emit-verdict.yml
+++ b/.github/workflows/probe-emit-verdict.yml
@@ -1,0 +1,39 @@
+name: Probe — Emit Verdict (one-off smoke)
+
+# Throwaway workflow used to smoke-test
+# machina-sports/.github/.github/workflows/reusable-emit-verdict.yml@v1
+# end-to-end against the live machina-truth-truth-point tenant. Delete this
+# file (and the probe/emit-verdict branch) after the verdict_history is
+# confirmed to grow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      component_id:
+        description: "Stable id <kind>:<name>"
+        required: true
+        type: string
+        default: "connector:vertex-embedding"
+      verdict:
+        description: "success | partial | fail"
+        required: true
+        type: choice
+        options: [success, partial, fail]
+        default: success
+      summary:
+        description: "One-line reason"
+        required: false
+        type: string
+        default: "smoke probe of reusable-emit-verdict@v1"
+
+jobs:
+  probe:
+    uses: machina-sports/.github/.github/workflows/reusable-emit-verdict.yml@v1
+    with:
+      component-id: ${{ inputs.component_id }}
+      verdict: ${{ inputs.verdict }}
+      summary: ${{ inputs.summary }}
+      actor: probe-machina-templates
+    secrets:
+      TRUTH_POINT_FEEDBACK_URL: ${{ secrets.TRUTH_POINT_FEEDBACK_URL }}
+      TRUTH_POINT_API_TOKEN: ${{ secrets.TRUTH_POINT_API_TOKEN }}


### PR DESCRIPTION
## Summary

Throwaway workflow_dispatch used to validate Phase D end-to-end. Hits `machina-sports/.github/.github/workflows/reusable-emit-verdict.yml@v1` against the live truth-point tenant.

**Will be reverted in a follow-up PR immediately after the smoke passes.** No runtime impact (workflow is dispatch-only).

## Test plan
- [ ] Merge → run via `gh workflow run` → confirm `value.verdict_history` length grew on `connector:vertex-embedding` doc → cleanup PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)