### PR TITLE
fix(truth-point): read similarity field (was similarity_score)

### DIFF
--- a/agent-templates/truth-point/workflows/truth-point-query.yml
+++ b/agent-templates/truth-point/workflows/truth-point-query.yml
@@ -55,7 +55,7 @@ workflow:
               'version': d.get('value', {}).get('version', ''),
               'integrations': d.get('value', {}).get('integrations', []),
               'categories': d.get('value', {}).get('categories', []),
-              'similarity': d.get('similarity_score', 0)
+              'similarity': d.get('similarity', d.get('similarity_score', 0))
             }
             for d in $.get('documents', [])
           ]


### PR DESCRIPTION
Document search returns `similarity`, not `similarity_score`. Without this fix sim was 0 across all components — Factory's threshold filter (=0.4) would have rejected everything if it had been working.