### PR TITLE
fix(truth-point): preserve verdict_history on re-ingest

### DIFF
--- a/agent-templates/truth-point/workflows/truth-point-ingest.yml
+++ b/agent-templates/truth-point/workflows/truth-point-ingest.yml
@@ -3,7 +3,7 @@ workflow:
   # truth-point-ingest
   name: truth-point-ingest
   title: Truth Point — Ingest Component
-  description: Receives a component payload and upserts it into machina-knowledge with a Vertex embedding. Idempotent on metadata.component_id.
+  description: Receives a component payload and upserts it into machina-knowledge with a Vertex embedding. Idempotent on metadata.component_id. Preserves verdict_history across re-ingests so the Factory's feedback signal is not lost when a template is pushed.
 
   context-variables:
     debugger:
@@ -30,6 +30,27 @@ workflow:
 
   tasks:
 
+    # Step 1 — read the existing doc (if any) so we can preserve fields the
+    # ingest payload doesn't carry (notably verdict_history, which the
+    # Factory writes asynchronously and which would otherwise be wiped on
+    # every re-ingest by force-update).
+    - type: document
+      name: lookup-existing
+      description: Lookup existing doc to preserve verdict_history
+      condition: $.get('kind') is not None and $.get('kind') != '' and $.get('name') is not None and $.get('name') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'machina-knowledge'"
+        metadata.component_id: $.get('kind') + ':' + $.get('name')
+      outputs:
+        existing_verdict_history: $.get('documents')[0].get('value', {}).get('verdict_history', []) if len($.get('documents', [])) > 0 else []
+        existing_last_verdict: $.get('documents')[0].get('value', {}).get('last_verdict', None) if len($.get('documents', [])) > 0 else None
+        existing_last_verdict_at: $.get('documents')[0].get('value', {}).get('last_verdict_at', None) if len($.get('documents', [])) > 0 else None
+
+    # Step 2 — upsert with the new payload + carried-over verdict_history.
     - type: document
       name: upsert-component
       description: Upsert (create-or-replace) the component doc with a Vertex embedding
@@ -56,6 +77,9 @@ workflow:
             'source_repo': $.get('source_repo', ''),
             'source_path': $.get('source_path', ''),
             'source_ref': $.get('source_ref', ''),
+            'verdict_history': $.get('existing_verdict_history', []),
+            'last_verdict': $.get('existing_last_verdict'),
+            'last_verdict_at': $.get('existing_last_verdict_at'),
             'ingested_at': datetime.now().isoformat()
           }
       metadata:


### PR DESCRIPTION
## Summary

The simplified ingest workflow (PR #128) collapsed the upsert into a single `action: update` with `force-update`, which `$set`-replaces the whole `value` field. That wiped any `verdict_history` the Factory had appended between two ingests of the same component.

**Concrete trace** — investigating the 3/5 verdict gap on PR #134:

1. 15:52:51 — Factory emits 5 success verdicts in parallel
2. 15:52:51 — `event-podcast`'s feedback workflow runs OK, appends to `verdict_history` ✅
3. 15:53:01 (10s later) — GH Action's auto-ingest of PR #134 re-ingests `event-podcast` and **wipes verdict_history** because the simplified ingest doesn't read existing first

## Fix

Restore the `lookup-existing` step (present in the original PR #127 design, dropped in #128). Read the doc first, carry over `verdict_history`, `last_verdict`, and `last_verdict_at` into the upsert payload.

Net diff: ~25 lines added (the lookup task + 3 fields in the upsert dict).

## Test plan
- [ ] After merge + PUT live: re-fire the podcast smoke job, confirm all 5 components get verdicts AND that re-ingesting the new event-podcast (which the GH Action will do automatically) does NOT wipe the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)