### PR TITLE
feat(event-podcast): style_prompt input + language-aware script

### DIFF
--- a/agent-templates/event-podcast/event-podcast.yml
+++ b/agent-templates/event-podcast/event-podcast.yml
@@ -17,6 +17,12 @@ workflow:
     event_id: "$.get('event_id', '')"
     voice_name: "$.get('voice_name', 'Kore')"
     language_code: "$.get('language_code', 'en-us')"
+    # Optional style hint prepended to the script before TTS. Use this to
+    # nudge tone (calm/excited), pacing, and especially pronunciation —
+    # for non-English content set a hint in the target language so the
+    # model treats proper nouns and accents naturally. Defaults to a
+    # neutral "podcast host" cue.
+    style_prompt: "$.get('style_prompt', 'Read the following text as an engaging, natural sports podcast host. Maintain a conversational pace and pronounce all proper nouns clearly')"
   outputs:
     event_id: "$.get('event_id')"
     title: "$.get('title')"
@@ -73,6 +79,7 @@ workflow:
         voice_name: "$.get('voice_name', 'Kore')"
         model_id: "gemini-2.5-flash-tts"
         language_code: "$.get('language_code', 'en-us')"
+        prompt: "$.get('style_prompt', '')"
       outputs:
         final_filename: f"event-podcast-{$.get('file_name', $.get('event_id', 'episode'))}-{datetime.now().strftime('%Y%m%d-%H%M%S')}.mp3"
         full_filepath: "$.get('file_path')"

--- a/agent-templates/event-podcast/prompts.yml
+++ b/agent-templates/event-podcast/prompts.yml
@@ -5,6 +5,20 @@ prompts:
     title: "Event Podcast Script Prompt"
     name: "event-podcast-script-prompt"
     description: "Generates a ~5-minute (~750 words) podcast script for a sports event, given the event ID and any retrieved event details."
+    instruction: |
+      You are writing a single-host sports podcast script.
+
+      Length: roughly 750 words (≈5 minutes when read aloud).
+      Shape: hook → 2-3 key moments → quick analysis → memorable closer.
+      Style: conversational, energetic, pronounceable. NO stage directions,
+      bullet lists, or markdown — only spoken-word prose.
+
+      Language: match the language of the event_id and event_details inputs.
+      If the user describes the event in Brazilian Portuguese (Corinthians,
+      Brasileirão, etc.), reply in Brazilian Portuguese. Same rule for any
+      other language. Proper nouns stay in their native form.
+
+      Output a structured JSON object matching the schema below.
     schema:
       title: "EventPodcastScript"
       description: "Structured podcast episode for a sports event, designed to run roughly 5 minutes when read aloud."


### PR DESCRIPTION
Tighten voice/pronunciation quality on the event-podcast template. Adds a `style_prompt` workflow input (flows to the TTS connector's `prompt` field) so callers can tune tone + pronunciation. Plus a small `instruction:` on the script prompt so the model explicitly matches input language (PT-BR in, PT-BR out).