### PR TITLE
feat(truth-point): add fetch workflow + carry manifest/files in indexed doc

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -8,6 +8,7 @@ setup:
   features:
     - Ingest endpoint (POST /workflow/schedule/<id>) — accepts a component payload and upserts it into machina-knowledge with a Vertex text-embedding-004 vector
     - Query endpoint — vector search over indexed components, returns top-K with scores
+    - Fetch endpoint — precise lookup of a single component by component_id, returns full manifest + files + verdict_history
     - Feedback endpoint — appends a structured verdict to a component's verdict_history without re-embedding
     - Stable component identity via metadata.component_id (kind:name)
   status: available
@@ -24,6 +25,9 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-query.yml
+
+  - type: workflow
+    path: workflows/truth-point-fetch.yml
 
   - type: workflow
     path: workflows/truth-point-feedback.yml

--- a/agent-templates/truth-point/workflows/truth-point-fetch.yml
+++ b/agent-templates/truth-point/workflows/truth-point-fetch.yml
@@ -1,0 +1,59 @@
+workflow:
+
+  # truth-point-fetch
+  name: truth-point-fetch
+  title: Truth Point — Fetch Component (by id)
+  description: Precise lookup of a single indexed component by component_id. Returns the full machina-knowledge value (manifest + files + integrations + verdict_history) without running a vector search. Backs the Factory's `truth_point_lookup` agent tool — gives the agent rich content on demand instead of forcing the system prompt to carry it.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    component_id: $.get('component_id', '')
+
+  outputs:
+    component_id: $.get('component_id', '')
+    found: $.get('found', False)
+    component: $.get('component', {})
+    workflow-status: $.get('component_id') and 'executed' or 'skipped'
+
+  tasks:
+
+    - type: document
+      name: lookup-by-id
+      description: Search machina-knowledge by metadata.component_id
+      condition: $.get('component_id') is not None and $.get('component_id') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'machina-knowledge'"
+        metadata.component_id: $.get('component_id')
+      outputs:
+        found: len($.get('documents', [])) > 0
+        # Project a lean shape: full manifest + file PATHS (no content) + metadata.
+        # The runtime caps workflow output at ~50KB, and components like
+        # bundesliga-podcast carry 100KB+ of file content. Returning paths
+        # only keeps the response well under the cap; the agent reads
+        # specific files via the Read tool when needed.
+        component: |
+          {
+            'component_id': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('component_id', ''),
+            'kind': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('kind', ''),
+            'name': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('name', ''),
+            'title': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('title', ''),
+            'description': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('description', ''),
+            'categories': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('categories', []),
+            'integrations': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('integrations', []),
+            'version': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('version', ''),
+            'source_repo': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('source_repo', ''),
+            'source_path': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('source_path', ''),
+            'source_ref': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('source_ref', ''),
+            'manifest': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('manifest', ''),
+            'file_paths': [f.get('path', '') for f in (($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('files') or [])],
+            'verdict_history': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('verdict_history', []),
+            'last_verdict': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('last_verdict'),
+            'ingested_at': ($.get('documents', [])[0].get('value', {}) if len($.get('documents', [])) > 0 else {}).get('ingested_at')
+          }

--- a/agent-templates/truth-point/workflows/truth-point-ingest.yml
+++ b/agent-templates/truth-point/workflows/truth-point-ingest.yml
@@ -23,6 +23,8 @@ workflow:
     source_repo: $.get('source_repo', '')
     source_path: $.get('source_path', '')
     source_ref: $.get('source_ref', '')
+    manifest: $.get('manifest', '')
+    files: $.get('files', [])
 
   outputs:
     component_id: $.get('kind') + ':' + $.get('name')
@@ -77,6 +79,8 @@ workflow:
             'source_repo': $.get('source_repo', ''),
             'source_path': $.get('source_path', ''),
             'source_ref': $.get('source_ref', ''),
+            'manifest': $.get('manifest', ''),
+            'files': $.get('files', []),
             'verdict_history': $.get('existing_verdict_history', []),
             'last_verdict': $.get('existing_last_verdict'),
             'last_verdict_at': $.get('existing_last_verdict_at'),


### PR DESCRIPTION
Backs the new `truth_point_lookup` agent tool in machina-factory. Two changes: re-adds `manifest` + `files` to the indexed doc value (dropped in PR #128 for leanness — needed now for the tool to return content), and adds `truth-point-fetch` workflow for precise lookup-by-component_id.