### PR TITLE
feat(truth-point): incident system — open / resolve / list active

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -31,3 +31,14 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-feedback.yml
+
+  # Incident system: marks connectors / components as DOWN / DEGRADED so the
+  # Factory stops generating new workflows against them until resolved.
+  - type: workflow
+    path: workflows/truth-point-incident-open.yml
+
+  - type: workflow
+    path: workflows/truth-point-incident-resolve.yml
+
+  - type: workflow
+    path: workflows/truth-point-active-incidents.yml

--- a/agent-templates/truth-point/workflows/truth-point-active-incidents.yml
+++ b/agent-templates/truth-point/workflows/truth-point-active-incidents.yml
@@ -1,0 +1,39 @@
+workflow:
+
+  # truth-point-active-incidents
+  name: truth-point-active-incidents
+  title: Truth Point — Active Incidents
+  description: Returns the list of currently open (ended_at is null) platform incidents. Consumed by the Factory before every agent run so the system prompt can warn the agent off any DOWN / DEGRADED components.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs: {}
+
+  outputs:
+    incidents: $.get('incidents', [])
+    count: $.get('count', 0)
+    workflow-status: "'executed'"
+
+  tasks:
+
+    - type: document
+      name: lookup-incidents
+      description: Fetch platform-incidents and project to active-only incidents
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'platform-incidents'"
+      outputs:
+        # Output expressions run against the document-search response, where
+        # `documents` is set. We project to incidents-with-no-ended_at in a
+        # single comprehension to avoid an expression task (which lacks a
+        # runner handler — its outputs always evaluate against an empty
+        # response).
+        incidents: |
+          [i for i in ($.get('documents', [])[0].get('value', {}).get('incidents', []) if len($.get('documents', [])) > 0 else []) if i.get('ended_at') is None]
+        count: |
+          len([i for i in ($.get('documents', [])[0].get('value', {}).get('incidents', []) if len($.get('documents', [])) > 0 else []) if i.get('ended_at') is None])

--- a/agent-templates/truth-point/workflows/truth-point-incident-open.yml
+++ b/agent-templates/truth-point/workflows/truth-point-incident-open.yml
@@ -1,0 +1,69 @@
+workflow:
+
+  # truth-point-incident-open
+  name: truth-point-incident-open
+  title: Truth Point — Open Incident
+  description: Mark a component (typically a connector) as DOWN or DEGRADED. Appends an incident to the singleton platform-incidents doc. The Factory consumes this list before each agent run and warns the agent off any matching components — so a known outage upstream stops new workflows from being generated against the broken connector until incident-resolve runs.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    component_id: $.get('component_id', '')
+    level: $.get('level', 'down')
+    summary: $.get('summary', '')
+    external_url: $.get('external_url', '')
+    actor: $.get('actor', 'ops')
+
+  outputs:
+    component_id: $.get('component_id', '')
+    workflow-status: $.get('component_id') and 'executed' or 'skipped'
+
+  tasks:
+
+    # Read the singleton platform-incidents doc; we'll append to its incidents.
+    - type: document
+      name: lookup-incidents
+      description: Pull existing platform-incidents.incidents
+      condition: $.get('component_id') is not None and $.get('component_id') != '' and $.get('level') in ['down', 'degraded']
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'platform-incidents'"
+      outputs:
+        existing_incidents: $.get('documents', [])[0].get('value', {}).get('incidents', []) if len($.get('documents', [])) > 0 else []
+
+    # Upsert by name=platform-incidents. The new incident is computed inline
+    # in the documents block (which evaluates against the workflow state, so
+    # $.get('component_id') resolves correctly here — unlike expression
+    # task outputs, which evaluate against an empty response object).
+    - type: document
+      name: append-incident
+      description: Write an updated platform-incidents.incidents with the new entry appended
+      condition: $.get('component_id') is not None and $.get('component_id') != ''
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        platform-incidents: |
+          {
+            'incidents': [
+              *$.get('existing_incidents', []),
+              {
+                'id': ($.get('component_id') or '') + '-' + datetime.now().strftime('%Y%m%d-%H%M%S'),
+                'component_id': $.get('component_id', ''),
+                'level': $.get('level', 'down'),
+                'summary': $.get('summary', ''),
+                'external_url': $.get('external_url', ''),
+                'actor': $.get('actor', 'ops'),
+                'started_at': datetime.now().isoformat(),
+                'ended_at': None
+              }
+            ]
+          }
+      metadata:
+        kind: "'platform-status'"

--- a/agent-templates/truth-point/workflows/truth-point-incident-resolve.yml
+++ b/agent-templates/truth-point/workflows/truth-point-incident-resolve.yml
@@ -1,0 +1,52 @@
+workflow:
+
+  # truth-point-incident-resolve
+  name: truth-point-incident-resolve
+  title: Truth Point — Resolve Incident
+  description: Close an incident by id. Sets ended_at on the matching incident in platform-incidents.incidents. Once resolved, the Factory's next agent run no longer warns against the affected component.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    id: $.get('id', '')
+
+  outputs:
+    id: $.get('id', '')
+    workflow-status: $.get('document_id') is not None and 'executed' or 'skipped'
+
+  tasks:
+
+    - type: document
+      name: lookup-incidents
+      description: Read the platform-incidents doc
+      condition: $.get('id') is not None and $.get('id') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'platform-incidents'"
+      outputs:
+        document_id: $.get('documents')[0].get('_id') if len($.get('documents', [])) > 0 else None
+        existing_incidents: $.get('documents')[0].get('value', {}).get('incidents', []) if len($.get('documents', [])) > 0 else []
+
+    - type: document
+      name: close-incident
+      description: Map over incidents; set ended_at on the one with matching id
+      condition: $.get('document_id') is not None
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        platform-incidents: |
+          {
+            'incidents': [
+              {**i, 'ended_at': datetime.now().isoformat()} if i.get('id') == $.get('id') and i.get('ended_at') is None else i
+              for i in $.get('existing_incidents', [])
+            ]
+          }
+      filters:
+        document_id: $.get('document_id')


### PR DESCRIPTION
Adds 3 workflows backing a platform-incidents singleton in machina-knowledge so ops can mark a component DOWN/DEGRADED. Companion PR in machina-factory wires the active-incidents query into the system prompt as a warning section the agent must avoid.