### PR TITLE
feat(truth-point): lessons-learned system — store DO/DON'T patterns

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -42,3 +42,11 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-active-incidents.yml
+
+  # Lessons-learned system: stores DO / DON'T patterns surfaced from
+  # historical regressions so the Factory's agent stops repeating them.
+  - type: workflow
+    path: workflows/truth-point-lesson-add.yml
+
+  - type: workflow
+    path: workflows/truth-point-lessons-active.yml

--- a/agent-templates/truth-point/workflows/truth-point-lesson-add.yml
+++ b/agent-templates/truth-point/workflows/truth-point-lesson-add.yml
@@ -1,0 +1,69 @@
+workflow:
+
+  # truth-point-lesson-add
+  name: truth-point-lesson-add
+  title: Truth Point — Add Lesson Learned
+  description: Append a lesson-learned (anti-pattern + correct pattern + explanation) to the singleton lessons-learned doc. The Factory consumes this list before each agent run so the agent can avoid known regressions. Caller passes a stable id, title, applies_to scope, and the do/don't pair.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    id: $.get('id', '')
+    title: $.get('title', '')
+    applies_to: $.get('applies_to', [])
+    anti_pattern: $.get('anti_pattern', '')
+    correct_pattern: $.get('correct_pattern', '')
+    explanation: $.get('explanation', '')
+    severity: $.get('severity', 'medium')
+    source_run_id: $.get('source_run_id', '')
+
+  outputs:
+    id: $.get('id', '')
+    workflow-status: $.get('id') and 'executed' or 'skipped'
+
+  tasks:
+
+    - type: document
+      name: lookup-lessons
+      description: Read the singleton lessons-learned doc; we'll append to its lessons
+      condition: $.get('id') is not None and $.get('id') != '' and $.get('title') is not None and $.get('title') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'lessons-learned'"
+      outputs:
+        existing_lessons: $.get('documents', [])[0].get('value', {}).get('lessons', []) if len($.get('documents', [])) > 0 else []
+
+    # Idempotent on id: if a lesson with the same id exists, replace it; otherwise append.
+    - type: document
+      name: append-lesson
+      description: Write lessons-learned with the new entry merged in (replace by id if present)
+      condition: $.get('id') is not None and $.get('id') != ''
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        lessons-learned: |
+          {
+            'lessons': [
+              *[l for l in $.get('existing_lessons', []) if l.get('id') != $.get('id')],
+              {
+                'id': $.get('id'),
+                'title': $.get('title', ''),
+                'applies_to': $.get('applies_to', []),
+                'anti_pattern': $.get('anti_pattern', ''),
+                'correct_pattern': $.get('correct_pattern', ''),
+                'explanation': $.get('explanation', ''),
+                'severity': $.get('severity', 'medium'),
+                'source_run_id': $.get('source_run_id', ''),
+                'created_at': datetime.now().isoformat()
+              }
+            ]
+          }
+      metadata:
+        kind: "'lessons-learned'"

--- a/agent-templates/truth-point/workflows/truth-point-lessons-active.yml
+++ b/agent-templates/truth-point/workflows/truth-point-lessons-active.yml
@@ -1,0 +1,49 @@
+workflow:
+
+  # truth-point-lessons-active
+  name: truth-point-lessons-active
+  title: Truth Point — Active Lessons Learned
+  description: Returns the list of lessons-learned, optionally filtered by `applies_to` (e.g. only show lessons relevant to agent-template work). Consumed by the Factory before every agent run so the system prompt can warn off known regressions.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    applies_to: $.get('applies_to', '')
+
+  outputs:
+    lessons: $.get('lessons', [])
+    count: $.get('count', 0)
+    workflow-status: "'executed'"
+
+  tasks:
+
+    - type: document
+      name: lookup-lessons
+      description: Fetch lessons-learned, project to the (optionally filtered) list
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'lessons-learned'"
+      outputs:
+        # If applies_to is empty string, return all; otherwise keep only lessons whose
+        # applies_to array contains the requested category.
+        lessons: |
+          [
+            l for l in (
+              $.get('documents', [])[0].get('value', {}).get('lessons', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+            if not $.get('applies_to') or $.get('applies_to') in (l.get('applies_to') or [])
+          ]
+        count: |
+          len([
+            l for l in (
+              $.get('documents', [])[0].get('value', {}).get('lessons', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+            if not $.get('applies_to') or $.get('applies_to') in (l.get('applies_to') or [])
+          ])


### PR DESCRIPTION
Adds 2 workflows backing a singleton lessons-learned doc. Companion PR in machina-factory wires the active-lessons query into the system prompt as a 'do not repeat' block.