### PR TITLE
feat(truth-point): PR-review pipeline — diff in, structured review out

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -58,3 +58,13 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-lesson-from-failure.yml
+
+  # PR-review pipeline: takes a unified diff + title, pulls the relevant
+  # slice of lessons / incidents / similar components, and asks Gemini for
+  # a structured review keyed to specific files/lines. The reusable
+  # GitHub Action in machina-sports/.github wraps this workflow.
+  - type: prompts
+    path: prompts/review-pr.yml
+
+  - type: workflow
+    path: workflows/truth-point-review-pr.yml

--- a/agent-templates/truth-point/prompts/review-pr.yml
+++ b/agent-templates/truth-point/prompts/review-pr.yml
@@ -1,0 +1,127 @@
+prompts:
+
+  # truth-point-review-pr-prompt
+  - type: "prompt"
+    title: "Review PR against Truth Point"
+    name: "truth-point-review-pr-prompt"
+    description: "Reads a PR (title + unified diff) plus the active lessons-learned, platform incidents, and semantically-similar components from Truth Point, and emits a structured code review keyed to specific files/lines. Each finding can cite the lesson_id or incident_id that motivated it. Designed to be the analyzer behind the platform's automated PR-review pipeline."
+    instruction: |
+      You are the Truth Point PR reviewer. You are given a pull request and
+      three sources of platform truth: active lessons (DO/DON'T patterns
+      extracted from past regressions), active incidents (components that are
+      currently DOWN/DEGRADED), and the most semantically-similar components
+      already in the platform.
+
+      Your job is to produce a small, high-signal review of the PR — only
+      findings that a reasonable reviewer would actually leave as a comment.
+
+      You are given:
+        - pr_title: the PR title.
+        - pr_diff: the unified diff (git format-patch / `gh pr diff` style).
+        - active_lessons: a list of {id, title, applies_to, anti_pattern,
+          correct_pattern, severity} entries. Each one is a rule the
+          platform has learned the hard way; if the diff exhibits the
+          anti-pattern, the finding MUST cite the lesson_id.
+        - active_incidents: a list of {id, component_id, status, summary}
+          entries for components that are currently broken in production.
+          If the diff introduces or extends a dependency on a DOWN
+          component, the finding MUST cite the incident_id.
+        - similar_components: a list of {component_id, kind, title,
+          description} entries — components already in the platform that
+          look semantically related to this PR. Use them to spot
+          duplication or to suggest mirroring an established convention.
+
+      Rules:
+        1. Output a STRUCTURED REVIEW matching the schema below.
+        2. Each finding is keyed to a SPECIFIC file (and line range when
+           the diff lets you point at one). `scope: "whole-pr"` is allowed
+           for cross-cutting observations but should be rare.
+        3. Findings MUST be derived from one of:
+             a. an active lesson the diff violates → cite `lesson_id`.
+             b. an active incident the diff depends on → cite `incident_id`.
+             c. a concrete code-quality issue you can defend in one sentence
+                (logic bug, dead code, accessibility, security, perf cliff,
+                unused import). DO NOT invent findings to pad the list.
+        4. `severity` is "high" for things that should block merge,
+           "medium" for follow-up nits worth fixing before merge, "low"
+           for optional improvements.
+        5. `verdict` is one of:
+             - "approve": no high/medium findings.
+             - "approve-with-nits": only low-severity findings.
+             - "request-changes": at least one high-severity finding.
+             - "scope-mismatch": none of the active lessons/incidents/
+                components are relevant to this PR's domain. Still emit
+                whatever code-quality findings stand on their own, but
+                signal that Truth Point's rubric does not currently cover
+                this PR's scope.
+        6. `meta_observation` is OPTIONAL — one sentence about the rubric
+           itself (e.g. "no frontend-scoped lessons exist; consider
+           seeding some"). Set to empty string when not useful. This is
+           how Truth Point learns where its coverage is thin.
+        7. Be conservative. An empty `findings` array with verdict
+           "approve" is a perfectly valid output. Reviewers who flag
+           noise lose trust.
+
+      ## Inputs
+
+      pr_title:
+      {pr_title}
+
+      pr_diff:
+      {pr_diff}
+
+      active_lessons:
+      {active_lessons}
+
+      active_incidents:
+      {active_incidents}
+
+      similar_components:
+      {similar_components}
+    schema:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "approve | approve-with-nits | request-changes | scope-mismatch"
+        summary:
+          type: string
+          description: "One-sentence overall verdict shown at the top of the PR comment."
+        findings:
+          type: array
+          description: "Specific, actionable review findings keyed to files/lines."
+          items:
+            type: object
+            properties:
+              severity:
+                type: string
+                description: "high | medium | low"
+              scope:
+                type: string
+                description: "file | line-range | whole-pr"
+              file:
+                type: string
+                description: "Path of the file the finding refers to. Empty for whole-pr scope."
+              line_start:
+                type: integer
+                description: "Starting line in the new file. 0 when not applicable."
+              line_end:
+                type: integer
+                description: "Ending line in the new file. Same as line_start for single-line findings. 0 when not applicable."
+              message:
+                type: string
+                description: "The finding itself, written as a reviewer comment."
+              lesson_id:
+                type: string
+                description: "Stable id of the active lesson this finding is grounded in. Empty when not applicable."
+              incident_id:
+                type: string
+                description: "Stable id of the active incident this finding is grounded in. Empty when not applicable."
+              category:
+                type: string
+                description: "One of: lesson-violation, incident-dependency, logic, security, accessibility, performance, dead-code, style, suggestion."
+            required: ["severity", "scope", "file", "line_start", "line_end", "message", "lesson_id", "incident_id", "category"]
+        meta_observation:
+          type: string
+          description: "Optional observation about the rubric itself (gaps in coverage). Empty string when not useful."
+      required: ["verdict", "summary", "findings", "meta_observation"]

--- a/agent-templates/truth-point/workflows/truth-point-review-pr.yml
+++ b/agent-templates/truth-point/workflows/truth-point-review-pr.yml
@@ -1,0 +1,149 @@
+workflow:
+
+  # truth-point-review-pr
+  name: truth-point-review-pr
+  title: Truth Point — Review PR
+  description: |
+    Reads a pull request (title + unified diff), pulls the relevant slice
+    of platform truth (active lessons, active incidents, semantically-
+    similar components), and asks Gemini for a structured review with
+    findings keyed to specific files/lines. Each finding can cite the
+    lesson_id or incident_id that motivated it. Designed to be the analyzer
+    behind reusable-review-pr.yml in machina-sports/.github — the GH Action
+    fetches the diff, posts the review as PR comments, and emits verdicts
+    back to Truth Point so the rubric keeps improving.
+
+    Inputs:
+      - pr_title: short title of the PR (used to seed the semantic query).
+      - pr_diff: full unified diff (`gh pr diff <num>` style).
+      - applies_to: optional kind filter for lessons (e.g. "agent-template",
+        "workflow", "studio"). Empty string → all lessons.
+
+    Outputs:
+      - verdict: approve | approve-with-nits | request-changes | scope-mismatch
+      - summary: one-line overall verdict
+      - findings: structured array of review comments
+      - meta_observation: optional rubric-coverage note
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+    vertex-embedding:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
+  inputs:
+    pr_title: $.get('pr_title', '')
+    pr_diff: $.get('pr_diff', '')
+    applies_to: $.get('applies_to', '')
+
+  outputs:
+    verdict: $.get('verdict', 'approve')
+    summary: $.get('summary', '')
+    findings: $.get('findings', [])
+    meta_observation: $.get('meta_observation', '')
+    workflow-status: $.get('pr_diff') and 'executed' or 'skipped'
+
+  tasks:
+
+    # 1. Pull active lessons, optionally filtered by applies_to.
+    - type: document
+      name: lookup-lessons
+      description: Fetch lessons-learned, project to (optionally filtered) list
+      condition: $.get('pr_diff') is not None and $.get('pr_diff') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'lessons-learned'"
+      outputs:
+        active_lessons: |
+          [
+            l for l in (
+              $.get('documents', [])[0].get('value', {}).get('lessons', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+            if not $.get('applies_to') or $.get('applies_to') in (l.get('applies_to') or [])
+          ]
+
+    # 2. Pull active (un-resolved) incidents.
+    - type: document
+      name: lookup-incidents
+      description: Fetch platform-incidents and project to active-only
+      condition: $.get('pr_diff') is not None and $.get('pr_diff') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'platform-incidents'"
+      outputs:
+        active_incidents: |
+          [
+            i for i in (
+              $.get('documents', [])[0].get('value', {}).get('incidents', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+            if i.get('ended_at') is None
+          ]
+
+    # 3. Semantic search over indexed components, seeded by the PR title.
+    #    This surfaces components the PR is likely related to so the analyzer
+    #    can spot duplication or suggest mirroring an established convention.
+    - type: document
+      name: similar-components
+      description: Vector search machina-knowledge for components related to the PR title
+      condition: $.get('pr_title') is not None and $.get('pr_title') != ''
+      config:
+        action: search
+        search-vector: true
+        search-limit: 100
+        threshold-docs: 5
+        threshold-similarity: 0.3
+      connector:
+        name: "vertex-embedding"
+        command: "invoke_embedding"
+        model: "text-embedding-004"
+      inputs:
+        name: "'machina-knowledge'"
+        search-query: $.get('pr_title')
+      outputs:
+        similar_components: |
+          [
+            {
+              'component_id': d.get('value', {}).get('component_id', ''),
+              'kind': d.get('value', {}).get('kind', ''),
+              'title': d.get('value', {}).get('title', ''),
+              'description': d.get('value', {}).get('description', '')
+            }
+            for d in $.get('documents', [])
+          ]
+
+    # 4. Run the analyzer prompt. The runner resolves the prompt by
+    # `task.name`, so this MUST match the prompt declared in
+    # prompts/review-pr.yml.
+    - type: prompt
+      name: truth-point-review-pr-prompt
+      description: Run the PR-review prompt to produce a structured review
+      condition: $.get('pr_diff') is not None and $.get('pr_diff') != ''
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-2.5-pro
+        location: global
+        provider: vertex_ai
+      inputs:
+        pr_title: $.get('pr_title', '')
+        pr_diff: $.get('pr_diff', '')
+        active_lessons: $.get('active_lessons', [])
+        active_incidents: $.get('active_incidents', [])
+        similar_components: $.get('similar_components', [])
+      outputs:
+        verdict: $.get('verdict', 'approve')
+        summary: $.get('summary', '')
+        findings: $.get('findings', [])
+        meta_observation: $.get('meta_observation', '')


### PR DESCRIPTION
## Summary

- **New workflow** `truth-point-review-pr` + analyzer **prompt** `review-pr` that take a unified diff + PR title, pull the relevant slice of platform truth (lessons-learned filtered by \`applies_to\`, active incidents, semantically-similar components), and ask Gemini for a structured review keyed to specific files/lines.
- Each finding can cite the **lesson_id** or **incident_id** that motivated it, so every review comment is auditable back to a stored rule or known outage.
- The **verdict** is one of \`approve\` / \`approve-with-nits\` / \`request-changes\` / \`scope-mismatch\` — the last one explicitly signals when Truth Point's coverage doesn't apply to the PR's domain, so we know where to seed lessons next.

## Why now

We've built Tier 1 (lessons-in-prompt), Tier 2 (deterministic validator), Tier 3 (auto-extract from failure). PRs are the missing surface — every PR is a candidate for both \"did we apply our lessons?\" and \"did we discover a new lesson?\". This workflow is the analyzer half. The wrapping GitHub Action (fetch diff → call workflow → post review comments → emit verdict back to Truth Point) lives in \`machina-sports/.github\`.

## Shape

- \`workflows/truth-point-review-pr.yml\` — sequence: lookup lessons → lookup incidents → semantic search by PR title → run analyzer prompt.
- \`prompts/review-pr.yml\` — strict schema, conservative instructions (\"empty findings + verdict approve is a perfectly valid output\"), three input categories explicitly grounded in Truth Point's existing data.
- \`_install.yml\` — registers both.

## Test plan

- [ ] Merge → ingest fires automatically (no manual seed needed)
- [ ] Smoke-test: call \`truth-point-review-pr\` with the unified diff from machina-studio PR #231 and confirm it returns a structured review without runtime error
- [ ] Verify the prompt sees the input it needs by checking the workflow execution payload after a real run
- [ ] Follow-up PR in \`machina-sports/.github\` adds the reusable GH Action

## Notes

- The semantic-search seed uses the PR title, not the diff body. Diffs are too noisy for embedding; titles are usually scoped enough to surface the right neighbors.
- \`applies_to\` is the same filter machine-readable lessons already use — passing \`"studio"\` will filter to frontend lessons (none seeded yet, that's the gap PR #231's review surfaced).