### PR TITLE
feat(truth-point): deploy-convention workflows (add + get)

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -68,3 +68,13 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-review-pr.yml
+
+  # Deploy conventions: stores per-repo deploy knowledge (target branch,
+  # deploy workflow files, tag prefix, semantic-release flag) so Factory's
+  # deploy mode knows which post-merge GitHub Actions workflow to watch
+  # instead of guessing the first run on the merge SHA.
+  - type: workflow
+    path: workflows/truth-point-deploy-convention-add.yml
+
+  - type: workflow
+    path: workflows/truth-point-deploy-convention-get.yml

--- a/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
+++ b/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
@@ -1,0 +1,79 @@
+workflow:
+
+  # truth-point-deploy-convention-add
+  name: truth-point-deploy-convention-add
+  title: Truth Point — Add Deploy Convention
+  description: |
+    Upsert a deploy convention for a repo into the singleton
+    `deploy-conventions` doc. Factory's deploy mode reads this list before
+    merging a PR so it can:
+      - identify which post-merge GitHub Actions workflow is the deploy
+        (and not confuse it with PR-checks runs)
+      - know the tag prefix the repo's semantic-release uses
+      - know whether the PR should target `staging` (gets auto-tagged) vs
+        `main` (production gate)
+
+    Idempotent on `repo` (e.g. "machina-sports/machina-studio"). A
+    convention with the same `repo` is replaced; otherwise the new one is
+    appended.
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    repo: $.get('repo', '')
+    target_branch_for_pr: $.get('target_branch_for_pr', 'main')
+    deploy_workflow_files: $.get('deploy_workflow_files', [])
+    tag_prefix_staging: $.get('tag_prefix_staging', '')
+    tag_prefix_production: $.get('tag_prefix_production', '')
+    semantic_release: $.get('semantic_release', True)
+    notes: $.get('notes', '')
+
+  outputs:
+    repo: $.get('repo', '')
+    workflow-status: $.get('repo') and 'executed' or 'skipped'
+
+  tasks:
+
+    - type: document
+      name: lookup-conventions
+      description: Read the singleton deploy-conventions doc to preserve siblings
+      condition: $.get('repo') is not None and $.get('repo') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'deploy-conventions'"
+      outputs:
+        existing_conventions: $.get('documents', [])[0].get('value', {}).get('conventions', []) if len($.get('documents', [])) > 0 else []
+
+    # Idempotent on repo: replace if present, append otherwise.
+    - type: document
+      name: append-convention
+      description: Write deploy-conventions with the new entry merged in (replace by repo)
+      condition: $.get('repo') is not None and $.get('repo') != ''
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        deploy-conventions: |
+          {
+            'conventions': [
+              *[c for c in $.get('existing_conventions', []) if c.get('repo') != $.get('repo')],
+              {
+                'repo': $.get('repo'),
+                'target_branch_for_pr': $.get('target_branch_for_pr', 'main'),
+                'deploy_workflow_files': $.get('deploy_workflow_files', []),
+                'tag_prefix_staging': $.get('tag_prefix_staging', ''),
+                'tag_prefix_production': $.get('tag_prefix_production', ''),
+                'semantic_release': $.get('semantic_release', True),
+                'notes': $.get('notes', ''),
+                'updated_at': datetime.now().isoformat()
+              }
+            ]
+          }
+      metadata:
+        kind: "'deploy-conventions'"

--- a/agent-templates/truth-point/workflows/truth-point-deploy-convention-get.yml
+++ b/agent-templates/truth-point/workflows/truth-point-deploy-convention-get.yml
@@ -1,0 +1,64 @@
+workflow:
+
+  # truth-point-deploy-convention-get
+  name: truth-point-deploy-convention-get
+  title: Truth Point — Get Deploy Convention
+  description: |
+    Lookup the deploy convention for a given repo
+    (e.g. "machina-sports/machina-studio"). Returns the matching entry
+    from the singleton `deploy-conventions` doc, or an empty result when
+    no convention has been seeded yet — Factory falls back to "blind
+    merge" in that case.
+
+    Consumed by Factory's deploy mode immediately before merging a PR so
+    it can identify the right post-merge GitHub Actions workflow to watch
+    (vs. picking the first run on the merge SHA, which can be a PR-checks
+    run).
+
+  context-variables:
+    debugger:
+      enabled: false
+
+  inputs:
+    repo: $.get('repo', '')
+
+  outputs:
+    repo: $.get('repo', '')
+    found: $.get('found', False)
+    convention: $.get('convention', {})
+    workflow-status: $.get('repo') and 'executed' or 'skipped'
+
+  tasks:
+
+    - type: document
+      name: lookup-conventions
+      description: Pull the deploy-conventions doc and project to the matching repo
+      condition: $.get('repo') is not None and $.get('repo') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'deploy-conventions'"
+      outputs:
+        # Match by repo (owner/name); first match wins. Returns an empty
+        # dict when no convention exists for the repo.
+        convention: |
+          next(
+            (
+              c for c in (
+                $.get('documents', [])[0].get('value', {}).get('conventions', [])
+                if len($.get('documents', [])) > 0 else []
+              )
+              if c.get('repo') == $.get('repo')
+            ),
+            {}
+          )
+        found: |
+          any(
+            c.get('repo') == $.get('repo')
+            for c in (
+              $.get('documents', [])[0].get('value', {}).get('conventions', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+          )


### PR DESCRIPTION
## Summary

Two new Truth Point workflows that turn it into the **source of deploy knowledge for Factory**:

- \`truth-point-deploy-convention-add\` — upserts a convention into the singleton \`deploy-conventions\` doc, keyed by \`repo\` (\`owner/name\`). Idempotent.
- \`truth-point-deploy-convention-get\` — returns the convention for a given repo, or \`{ found: false }\` when none exists.

## Convention shape

| field | meaning | example |
|---|---|---|
| \`repo\` | \`owner/name\` | \`machina-sports/machina-studio\` |
| \`target_branch_for_pr\` | PR target that triggers semantic-release | \`staging\` |
| \`deploy_workflow_files\` | filenames of workflows that DO the deploy (vs PR-checks) | \`["build-staging.yml"]\` |
| \`tag_prefix_staging\` | prefix semantic-release uses on staging tags | \`v.staging-main\` |
| \`tag_prefix_production\` | same for production | \`v.production-main\` |
| \`semantic_release\` | true when push triggers auto-tagging | \`true\` |
| \`notes\` | free-form description | "PR→staging→tag→reusable-deploy-aks" |

## Why this matters

Factory's deploy mode today does **blind merge** — merges and watches the first non-completed Actions run on the merge SHA, which often turns out to be a PR-checks run rather than the deploy. Pulling the convention from Truth Point lets Factory pick the right run deterministically.

Architecture per [docs/deploy-flow.md](https://github.com/machina-sports/.github/blob/main/docs/deploy-flow.md): each repo has its own deploy convention (\`v.staging-main.N\` for studio, \`v.staging-feat-X.N\` for sportingbot, etc.). Centralising these in Truth Point removes the need for Factory to introspect each repo's \`.github/workflows/\` and tag history.

## Test plan

- [ ] Merge → Truth Point auto-ingests both workflows
- [ ] Seed conventions via curl POST to \`truth-point-deploy-convention-add\` for: machina-studio, machina-factory, machina-templates
- [ ] Validate \`truth-point-deploy-convention-get\` with \`repo: "machina-sports/machina-studio"\` returns the seeded entry

## Related

- Factory-side reader (\`apps/api/src/lib/truth-point/deploy-conventions.ts\` + \`watchDeployWorkflow\` filtering by workflow_id) ships in machina-factory next.
- Companion to the deploy mode in machina-factory#66 and the graceful 403 handling in #68/#69.