### PR TITLE
feat(truth-point): deploy_trigger_branch — promote target before depl…

### DIFF
--- a/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
+++ b/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
@@ -12,6 +12,11 @@ workflow:
       - know the tag prefix the repo's semantic-release uses
       - know whether the PR should target `staging` (gets auto-tagged) vs
         `main` (production gate)
+      - know whether a post-merge promote step is needed before the
+        deploy workflow fires (e.g. machina-core-api: PRs merge to
+        `master` but `release-staging.yml` only triggers on push to the
+        `release-staging` branch — Factory must fast-forward
+        release-staging to master before the deploy can run)
 
     Idempotent on `repo` (e.g. "machina-sports/machina-studio"). A
     convention with the same `repo` is replaced; otherwise the new one is
@@ -28,6 +33,12 @@ workflow:
     tag_prefix_staging: $.get('tag_prefix_staging', '')
     tag_prefix_production: $.get('tag_prefix_production', '')
     semantic_release: $.get('semantic_release', True)
+    # Optional post-merge promote target. When set and different from
+    # target_branch_for_pr, Factory fast-forwards this branch to the
+    # merge SHA after merging the PR, then watches the deploy workflow
+    # there. Empty string = no promote step (default — deploy runs
+    # directly on target_branch_for_pr).
+    deploy_trigger_branch: $.get('deploy_trigger_branch', '')
     notes: $.get('notes', '')
 
   outputs:
@@ -70,6 +81,7 @@ workflow:
                 'tag_prefix_staging': $.get('tag_prefix_staging', ''),
                 'tag_prefix_production': $.get('tag_prefix_production', ''),
                 'semantic_release': $.get('semantic_release', True),
+                'deploy_trigger_branch': $.get('deploy_trigger_branch', ''),
                 'notes': $.get('notes', ''),
                 'updated_at': datetime.now().isoformat()
               }


### PR DESCRIPTION
…oy fires

Some repos don't fire their deploy workflow on the same branch the PR merges into. machina-core-api is the canonical example: PRs merge to `master` (target_branch_for_pr), but `release-staging.yml` only triggers on push to the `release-staging` branch. Without telling Factory about the promote step, deploy mode ends up watching the master commit forever and times out.

`deploy_trigger_branch` is an optional convention field. When set and different from `target_branch_for_pr`:
  - Factory fast-forwards `deploy_trigger_branch` to the merge SHA after merging the PR (via GitHub Refs API — no local clone needed)
  - Factory watches the deploy workflow run on `deploy_trigger_branch` instead of on the merge SHA itself

Empty / absent = current behavior (deploy fires directly on target_branch_for_pr, no promote step).

Schema-only PR. Factory deploy.ts wiring + machina-core-api convention reseed land in follow-up PRs.

# Pull Request

## What

<!-- Short description of what this PR does. -->

## Why

<!-- The motivation: which problem does it solve? Link issues / tickets. -->

## How

<!-- Brief notes on the approach, key decisions, and trade-offs. -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `perf:`, `revert:`)
- [ ] No `.env` / secrets / credentials committed (gitleaks will block)
- [ ] Lint, typecheck, tests, and build pass locally
- [ ] Targeting `staging` (default) — direct PRs to `main` only for hotfixes
- [ ] Updated `CHANGELOG.md` / docs if user-facing behavior changed
- [ ] Added or updated tests for new behavior

## Deploy notes

<!-- Anything special the deploy needs to know (env vars, migrations, feature flags)? -->

## Screenshots / videos

<!-- Optional, for UI changes. -->
