### PR TITLE
feat(truth-point): convention env-aware — *_production overrides

### DIFF
--- a/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
+++ b/agent-templates/truth-point/workflows/truth-point-deploy-convention-add.yml
@@ -39,6 +39,15 @@ workflow:
     # there. Empty string = no promote step (default — deploy runs
     # directly on target_branch_for_pr).
     deploy_trigger_branch: $.get('deploy_trigger_branch', '')
+    # Production-environment overrides. When env=production at deploy
+    # time, Factory prefers these over the staging-defaulted fields
+    # above. Empty / absent = fall back to the staging fields (lets
+    # repos that share a single workflow / branch keep one entry).
+    # Example for machina-core-api: staging fires release-staging.yml
+    # via the release-staging branch; production fires
+    # release-production.yml via the release-production branch.
+    deploy_workflow_files_production: $.get('deploy_workflow_files_production', [])
+    deploy_trigger_branch_production: $.get('deploy_trigger_branch_production', '')
     notes: $.get('notes', '')
 
   outputs:
@@ -82,6 +91,8 @@ workflow:
                 'tag_prefix_production': $.get('tag_prefix_production', ''),
                 'semantic_release': $.get('semantic_release', True),
                 'deploy_trigger_branch': $.get('deploy_trigger_branch', ''),
+                'deploy_workflow_files_production': $.get('deploy_workflow_files_production', []),
+                'deploy_trigger_branch_production': $.get('deploy_trigger_branch_production', ''),
                 'notes': $.get('notes', ''),
                 'updated_at': datetime.now().isoformat()
               }


### PR DESCRIPTION
## Summary
Extends the deploy convention with two optional production-only fields so a single entry per repo can describe both staging and production deploy paths:
- \`deploy_workflow_files_production\` — overrides \`deploy_workflow_files\` when env=production
- \`deploy_trigger_branch_production\` — overrides \`deploy_trigger_branch\` when env=production

Empty / absent = fall back to staging fields (current behavior). Same pattern as the existing \`tag_prefix_staging\` / \`tag_prefix_production\`.

machina-core-api needs this: staging fires \`release-staging.yml\` via the \`release-staging\` branch; production fires \`release-production.yml\` via \`release-production\`.

## Lands together with
- machina-factory: \`deploy.ts\` selects the right set based on \`config.env\`
- reseed: machina-core-api convention with the production fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)