### PR TITLE
feat(truth-point): pre-flight workflow — infer Factory intent from a task description

### DIFF
--- a/agent-templates/truth-point/_install.yml
+++ b/agent-templates/truth-point/_install.yml
@@ -78,3 +78,15 @@ datasets:
 
   - type: workflow
     path: workflows/truth-point-deploy-convention-get.yml
+
+  # Pre-flight: read a free-form task description and emit a structured
+  # intent (mode, target/reference repos, required credentials,
+  # applicable lessons) the Factory dashboard uses to auto-fill its
+  # form. Same RAG shape as the review-pr pipeline — pulls deploy
+  # conventions / lessons / similar components and asks Gemini for a
+  # schema-guided plan.
+  - type: prompts
+    path: prompts/pre-flight-task.yml
+
+  - type: workflow
+    path: workflows/truth-point-pre-flight-task.yml

--- a/agent-templates/truth-point/prompts/pre-flight-task.yml
+++ b/agent-templates/truth-point/prompts/pre-flight-task.yml
@@ -1,0 +1,158 @@
+prompts:
+
+  # truth-point-pre-flight-task-prompt
+  - type: "prompt"
+    title: "Pre-flight a Factory task against Truth Point"
+    name: "truth-point-pre-flight-task-prompt"
+    description: "Reads a free-form Factory task description plus the platform's known repos (deploy conventions), active lessons, and semantically-similar components, and emits a structured intent the Factory dashboard can use to auto-fill mode, target/reference repos, required credentials, and warnings."
+    instruction: |
+      You are Truth Point's pre-flight planner for the Machina Factory.
+      A developer has typed a task description in the Factory dashboard
+      (in any language). Your job is to read the task and the platform's
+      current truth — known repos, active lessons (DO/DON'T patterns),
+      and semantically-similar components — and emit a STRUCTURED
+      INTENT that lets the dashboard pre-fill the form sensibly.
+
+      You are given:
+        - task: the developer's free-form description (could be Portuguese,
+          Spanish, English, etc.).
+        - known_repos: a list of {repo, target_branch_for_pr, semantic_release,
+          notes} entries from the deploy-conventions doc. Treat this as the
+          set of repos the Factory knows how to operate. If the task clearly
+          targets one, set `target_repo` to it. If the task clearly references
+          another (e.g. "use the studio types"), add it to `reference_repos`.
+          Use ONLY repos in this list — don't invent.
+        - active_lessons: list of {id, title, applies_to, severity}.
+          Surface up to 3 lesson_ids that are most likely to apply to this
+          task in `applicable_lessons` so the dashboard can warn the dev.
+        - similar_components: list of {component_id, kind, title, description}.
+          Use these to detect when the task overlaps with existing work
+          (so the dev can reuse instead of duplicate). Surface as
+          `reusable_components`.
+
+      Rules for the structured intent:
+        1. `mode` must be exactly one of:
+             - "build": edit code, commit, open PR, deploy.
+             - "plan": draft a plan for review without executing.
+             - "shell": run a single command and report.
+             - "review-pr": review a specific GitHub PR.
+             - "deploy": merge an open PR and watch the deploy workflow.
+             - "issue": file a GitHub issue without writing code.
+           Default to "build" when ambiguous. Use "issue" when the task
+           sounds like a request/bug-report/question rather than an edit.
+           Use "review-pr" or "deploy" only when the task explicitly
+           mentions a PR number or URL.
+        2. `target_repo` is the SINGLE repo the work lands on. Pick the
+           best match from known_repos. Empty `{owner: "", name: ""}` if
+           you genuinely can't tell.
+        3. `reference_repos` is up to 3 OTHER repos that should be
+           cloned read-only as context. Don't repeat the target.
+        4. `open_pr`: true when `mode` is "build" (always opens a PR).
+           false for "plan", "shell", "issue". For "review-pr" and
+           "deploy" the PR already exists, so false.
+        5. `required_credentials` is a list of vault keys the task
+           probably needs. Only include keys that the task description
+           directly implies (e.g. "use OpenAI" → ["OPENAI_API_KEY"]).
+           Empty list when nothing specific is needed. The dashboard
+           cross-references with the existing vault to surface gaps.
+           Each entry: {vault_key, hint}.
+        6. `summary` is ONE sentence (≤140 chars) describing what you
+           think the developer wants to do, in English regardless of the
+           task language. This is shown back to the dev for confirmation.
+        7. `warnings` is a list of strings. Emit one when:
+             - the task overlaps strongly with an existing component
+               (point at it, suggest reuse).
+             - an active lesson clearly applies (cite the lesson_id).
+             - a credential is needed but unlikely to exist.
+           Each warning ≤140 chars. Empty list when nothing's worth
+           flagging.
+
+      Be conservative. Empty `reference_repos`, empty `warnings`,
+      empty `required_credentials` are all valid outputs.
+
+      ## Inputs
+
+      task:
+      {task}
+
+      known_repos:
+      {known_repos}
+
+      active_lessons:
+      {active_lessons}
+
+      similar_components:
+      {similar_components}
+    schema:
+      type: object
+      properties:
+        mode:
+          type: string
+          description: "build | plan | shell | review-pr | deploy | issue"
+        target_repo:
+          type: object
+          description: "The repo the work lands on. Empty owner/name if unknown."
+          properties:
+            owner:
+              type: string
+            name:
+              type: string
+          required: ["owner", "name"]
+        reference_repos:
+          type: array
+          description: "Up to 3 other repos to clone read-only as context."
+          items:
+            type: object
+            properties:
+              owner:
+                type: string
+              name:
+                type: string
+              branch:
+                type: string
+                description: "Optional. Empty string for repo default."
+            required: ["owner", "name", "branch"]
+        open_pr:
+          type: boolean
+          description: "Whether the mode opens a PR (true for build, false otherwise)."
+        required_credentials:
+          type: array
+          description: "Vault keys the task probably needs. Empty when nothing specific."
+          items:
+            type: object
+            properties:
+              vault_key:
+                type: string
+                description: "Stable env-style key, e.g. OPENAI_API_KEY."
+              hint:
+                type: string
+                description: "One-line hint about what the key unlocks."
+            required: ["vault_key", "hint"]
+        applicable_lessons:
+          type: array
+          description: "Up to 3 lesson_ids likely to apply to this task."
+          items:
+            type: string
+        reusable_components:
+          type: array
+          description: "Up to 3 component_ids the task overlaps with."
+          items:
+            type: string
+        summary:
+          type: string
+          description: "One-sentence English summary of the inferred intent (≤140 chars)."
+        warnings:
+          type: array
+          description: "Each warning ≤140 chars. Empty when nothing's worth flagging."
+          items:
+            type: string
+      required:
+        - mode
+        - target_repo
+        - reference_repos
+        - open_pr
+        - required_credentials
+        - applicable_lessons
+        - reusable_components
+        - summary
+        - warnings

--- a/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
+++ b/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
@@ -1,0 +1,170 @@
+workflow:
+
+  # truth-point-pre-flight-task
+  name: truth-point-pre-flight-task
+  title: Truth Point — Pre-flight a Factory task
+  description: |
+    Reads a free-form Factory task description (any language) plus the
+    platform's current truth — known repos, active lessons, similar
+    components — and asks Gemini for a STRUCTURED INTENT the Factory
+    dashboard can use to auto-fill mode, target/reference repos,
+    required credentials, and warnings.
+
+    Designed to live behind a "✨ Analyze task" button on /factory/new.
+    The dashboard's role is to render the suggestion and let the
+    operator accept or override; this workflow's only job is to turn
+    a sentence into structured fields the form already understands.
+
+    Inputs:
+      - task: developer's free-form description (any language).
+
+    Outputs:
+      - mode: one of build|plan|shell|review-pr|deploy|issue.
+      - target_repo: { owner, name } — best match from known_repos.
+      - reference_repos: up to 3 read-only repos for context.
+      - open_pr: true for build, false otherwise.
+      - required_credentials: vault keys the task probably needs.
+      - applicable_lessons: up to 3 lesson_ids most relevant.
+      - reusable_components: up to 3 component_ids the task overlaps with.
+      - summary: one-sentence English description of the inferred intent.
+      - warnings: human-readable nudges (lesson hits, missing credentials).
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+    vertex-embedding:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
+  inputs:
+    task: $.get('task', '')
+
+  outputs:
+    mode: $.get('mode', 'build')
+    target_repo: $.get('target_repo', {'owner': '', 'name': ''})
+    reference_repos: $.get('reference_repos', [])
+    open_pr: $.get('open_pr', False)
+    required_credentials: $.get('required_credentials', [])
+    applicable_lessons: $.get('applicable_lessons', [])
+    reusable_components: $.get('reusable_components', [])
+    summary: $.get('summary', '')
+    warnings: $.get('warnings', [])
+    workflow-status: $.get('task') and 'executed' or 'skipped'
+
+  tasks:
+
+    # 1. Pull the deploy-conventions doc — the canonical list of repos
+    #    Factory knows how to operate. Project to the slim shape the
+    #    prompt actually needs (owner+name+target branch+notes).
+    - type: document
+      name: lookup-known-repos
+      description: Read deploy-conventions and project to a known-repos list
+      condition: $.get('task') is not None and $.get('task') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'deploy-conventions'"
+      outputs:
+        known_repos: |
+          [
+            {
+              'repo': c.get('repo', ''),
+              'target_branch_for_pr': c.get('target_branch_for_pr', 'main'),
+              'semantic_release': c.get('semantic_release', True),
+              'notes': c.get('notes', '')
+            }
+            for c in (
+              $.get('documents', [])[0].get('value', {}).get('conventions', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+          ]
+
+    # 2. Pull active lessons (no kind filter — pre-flight applies broadly).
+    - type: document
+      name: lookup-lessons
+      description: Read lessons-learned, project to {id, title, applies_to, severity}
+      condition: $.get('task') is not None and $.get('task') != ''
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'lessons-learned'"
+      outputs:
+        active_lessons: |
+          [
+            {
+              'id': l.get('id', ''),
+              'title': l.get('title', ''),
+              'applies_to': l.get('applies_to', []),
+              'severity': l.get('severity', 'medium')
+            }
+            for l in (
+              $.get('documents', [])[0].get('value', {}).get('lessons', [])
+              if len($.get('documents', [])) > 0 else []
+            )
+          ]
+
+    # 3. Vector-search machina-knowledge by the task description so the
+    #    prompt can spot duplication / suggest reusable components.
+    - type: document
+      name: similar-components
+      description: Vector search for components related to the task description
+      condition: $.get('task') is not None and $.get('task') != ''
+      config:
+        action: search
+        search-vector: true
+        search-limit: 100
+        threshold-docs: 5
+        threshold-similarity: 0.3
+      connector:
+        name: "vertex-embedding"
+        command: "invoke_embedding"
+        model: "text-embedding-004"
+      inputs:
+        name: "'machina-knowledge'"
+        search-query: $.get('task')
+      outputs:
+        similar_components: |
+          [
+            {
+              'component_id': d.get('value', {}).get('component_id', ''),
+              'kind': d.get('value', {}).get('kind', ''),
+              'title': d.get('value', {}).get('title', ''),
+              'description': d.get('value', {}).get('description', '')
+            }
+            for d in $.get('documents', [])
+          ]
+
+    # 4. Run the planner prompt. Schema-guided so the dashboard can
+    #    consume the fields directly without parsing free-form text.
+    - type: prompt
+      name: truth-point-pre-flight-task-prompt
+      description: Infer Factory intent from task + known repos + lessons + similar components
+      condition: $.get('task') is not None and $.get('task') != ''
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-2.5-pro
+        location: global
+        provider: vertex_ai
+      inputs:
+        task: $.get('task', '')
+        known_repos: $.get('known_repos', [])
+        active_lessons: $.get('active_lessons', [])
+        similar_components: $.get('similar_components', [])
+      outputs:
+        mode: $.get('mode', 'build')
+        target_repo: $.get('target_repo', {'owner': '', 'name': ''})
+        reference_repos: $.get('reference_repos', [])
+        open_pr: $.get('open_pr', False)
+        required_credentials: $.get('required_credentials', [])
+        applicable_lessons: $.get('applicable_lessons', [])
+        reusable_components: $.get('reusable_components', [])
+        summary: $.get('summary', '')
+        warnings: $.get('warnings', [])


### PR DESCRIPTION
## Summary

A free-form task in the Factory dashboard (\"create a chatbot agent that uses OpenAI\") should be enough for Truth Point to figure out target repo, useful reference repos, required credentials, and the right Factory mode — without the operator filling each field by hand.

This PR is the **analyzer**: a workflow + prompt pair that takes one input (\`task\`) and returns a STRUCTURED INTENT the dashboard can auto-fill.

## Pipeline (mirrors review-pr)

1. \`lookup-known-repos\` — slim projection of \`deploy-conventions\` so the prompt can pick a target from the canonical repo list (no inventing).
2. \`lookup-lessons\` — active lessons (no kind filter, since pre-flight applies broadly).
3. \`similar-components\` — vector search over \`machina-knowledge\` so the prompt can flag duplication / suggest reuse.
4. \`truth-point-pre-flight-task-prompt\` — Gemini, schema-guided.

## Output schema

\`\`\`json
{
  \"mode\": \"build|plan|shell|review-pr|deploy|issue\",
  \"target_repo\": { \"owner\": \"...\", \"name\": \"...\" },
  \"reference_repos\": [ { \"owner\": \"...\", \"name\": \"...\", \"branch\": \"...\" } ],
  \"open_pr\": true,
  \"required_credentials\": [ { \"vault_key\": \"OPENAI_API_KEY\", \"hint\": \"...\" } ],
  \"applicable_lessons\": [ \"lesson-id-1\", ... ],
  \"reusable_components\": [ \"component-id-1\", ... ],
  \"summary\": \"One-sentence English description (≤140 chars).\",
  \"warnings\": [ \"...\" ]
}
\`\`\`

## Lands together with

- Factory dashboard PR (next): \`POST /factory/api/pre-flight\` + \"✨ Analyze\" button + read-only banner. PR #1 of the dashboard side ships visualization only — no auto-fill yet, validate inference quality first.
- Vault-existence check + inline credential insertion: separate dashboard PR (PR #3 of this series).

## Test plan after deploy

- [ ] After install on \`tenant-machina-truth\`, dispatch \`POST /workflow/schedule/truth-point-pre-flight-task\` with \`{\"task\": \"crie um agente de chatbot que usa OpenAI com o tema dazn\"}\`. Expect: mode=build, target_repo points at machina-templates, required_credentials includes OPENAI_API_KEY.
- [ ] Try \`{\"task\": \"merge PR #160 in machina-core-api\"}\` — expect mode=deploy.
- [ ] Try \`{\"task\": \"the worker poll loop is consuming too much CPU\"}\` — expect mode=issue, target_repo=machina-factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)