### PR TITLE
fix(truth-point): quote inline-dict default in pre-flight outputs

### DIFF
--- a/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
+++ b/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
@@ -43,16 +43,16 @@ workflow:
     task: $.get('task', '')
 
   outputs:
-    mode: $.get('mode', 'build')
-    target_repo: $.get('target_repo', {'owner': '', 'name': ''})
-    reference_repos: $.get('reference_repos', [])
-    open_pr: $.get('open_pr', False)
-    required_credentials: $.get('required_credentials', [])
-    applicable_lessons: $.get('applicable_lessons', [])
-    reusable_components: $.get('reusable_components', [])
-    summary: $.get('summary', '')
-    warnings: $.get('warnings', [])
-    workflow-status: $.get('task') and 'executed' or 'skipped'
+    mode: "$.get('mode', 'build')"
+    target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
+    reference_repos: "$.get('reference_repos', [])"
+    open_pr: "$.get('open_pr', False)"
+    required_credentials: "$.get('required_credentials', [])"
+    applicable_lessons: "$.get('applicable_lessons', [])"
+    reusable_components: "$.get('reusable_components', [])"
+    summary: "$.get('summary', '')"
+    warnings: "$.get('warnings', [])"
+    workflow-status: "$.get('task') and 'executed' or 'skipped'"
 
   tasks:
 
@@ -159,12 +159,12 @@ workflow:
         active_lessons: $.get('active_lessons', [])
         similar_components: $.get('similar_components', [])
       outputs:
-        mode: $.get('mode', 'build')
-        target_repo: $.get('target_repo', {'owner': '', 'name': ''})
-        reference_repos: $.get('reference_repos', [])
-        open_pr: $.get('open_pr', False)
-        required_credentials: $.get('required_credentials', [])
-        applicable_lessons: $.get('applicable_lessons', [])
-        reusable_components: $.get('reusable_components', [])
-        summary: $.get('summary', '')
-        warnings: $.get('warnings', [])
+        mode: "$.get('mode', 'build')"
+        target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
+        reference_repos: "$.get('reference_repos', [])"
+        open_pr: "$.get('open_pr', False)"
+        required_credentials: "$.get('required_credentials', [])"
+        applicable_lessons: "$.get('applicable_lessons', [])"
+        reusable_components: "$.get('reusable_components', [])"
+        summary: "$.get('summary', '')"
+        warnings: "$.get('warnings', [])"


### PR DESCRIPTION
## Problem
\`truth-point\` install on \`tenant-machina-truth\` bombed with:

\`\`\`
Failed to load YAML file ... mapping values are not allowed here
in line 47, column 47
\`\`\`

YAML parser interpreted the colons inside the inline dict literal as nested mapping keys.

## Fix
Wrap the \`$.get(...)\` expressions in double quotes — same trick the existing workflows use for output expressions. Runtime behavior is unchanged (engine still evaluates the string as a Python expr).

Two spots: workflow-level outputs and the \`prompt\` task's outputs. Both had the same \`{'owner': '', 'name': ''}\` default.

## Test
- [x] \`python3 -c "yaml.safe_load(open(...))"\` succeeds locally
- [ ] Re-install on tenant-machina-truth via Studio finishes without the YAML error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)