### PR TITLE
fix(skills/match-headline-generator): canonical workflow + prompt YAML shape

### DIFF
--- a/skills/match-headline-generator/prompts/generate-headlines.yml
+++ b/skills/match-headline-generator/prompts/generate-headlines.yml
@@ -1,40 +1,54 @@
-prompt:
-  name: generate-headlines-prompt
-  description: "Generates 5 distinct headlines from match facts."
-  type: "structured"
-  inputs:
-    - name: "match_data"
-      type: "object"
-  instruction: |
-    You are a sports journalist expert at crafting headlines for different audiences.
-    Analyze the provided match data and generate exactly 5 distinct headlines, one for each of the following perspectives:
-    1.  **neutral_news**: Factual, balanced, news-wire style.
-    2.  **analytical**: Focus on statistics (xG, possession) or key tactical moments.
-    3.  **winning_team_fan**: Celebratory and partisan for the winning team.
-    4.  **losing_team_fan**: Sympathetic or looking forward for the losing team.
-    5.  **clickbait**: Create a dramatic or controversial hook (but keep it tasteful).
+prompts:
 
-    **Rules:**
-    -   Each headline must be 90 characters or less.
-    -   Do not add a trailing period.
-    -   Return the output in English.
-    -   Your output MUST be a single valid JSON object that strictly follows the provided schema.
+  - type: "prompt"
+    title: "Generate match headlines"
+    name: generate-headlines-prompt
+    description: "Generates exactly 5 perspective-tagged headlines from match facts (neutral_news, analytical, winning_team_fan, losing_team_fan, clickbait)."
+    instruction: |
+      You are a sports journalist expert at crafting headlines for different
+      audiences. Analyze the provided match data and generate EXACTLY 5
+      distinct headlines, one for each of the following perspectives:
 
-  schema:
-    type: object
-    properties:
-      headlines:
-        type: array
-        items:
-          type: object
-          properties:
-            perspective:
-              type: string
-              enum: ["neutral_news", "analytical", "winning_team_fan", "losing_team_fan", "clickbait"]
-            headline:
-              type: string
-          required:
-            - perspective
-            - headline
-    required:
-      - headlines
+      1. **neutral_news**:      factual, balanced, news-wire style.
+      2. **analytical**:        focus on statistics (xG, possession) or key tactical moments.
+      3. **winning_team_fan**:  celebratory and partisan for the winning team.
+      4. **losing_team_fan**:   sympathetic or looking forward for the losing team.
+      5. **clickbait**:         dramatic or controversial hook, kept tasteful (no slurs, no fake stats).
+
+      Rules:
+        - Each headline ≤ 90 characters.
+        - No trailing period.
+        - English only.
+        - Output MUST be a single valid JSON object that strictly follows the schema.
+        - Order the array by the perspective list above.
+
+      ## Inputs
+
+      match_data:
+      {match_data}
+    schema:
+      type: object
+      properties:
+        headlines:
+          type: array
+          description: "Exactly 5 entries, one per perspective in the order above."
+          items:
+            type: object
+            properties:
+              perspective:
+                type: string
+                description: "neutral_news | analytical | winning_team_fan | losing_team_fan | clickbait"
+                enum:
+                  - neutral_news
+                  - analytical
+                  - winning_team_fan
+                  - losing_team_fan
+                  - clickbait
+              headline:
+                type: string
+                description: "≤ 90 characters, no trailing period, English."
+            required:
+              - perspective
+              - headline
+      required:
+        - headlines

--- a/skills/match-headline-generator/workflows/generate-headlines.yml
+++ b/skills/match-headline-generator/workflows/generate-headlines.yml
@@ -1,19 +1,41 @@
 workflow:
+
   name: generate-headlines
-  description: Takes match facts and generates 5 headlines.
+  title: Generate Match Headlines
+  description: |
+    Takes a `match` object (home_team, away_team, score, scorers, key
+    moments, optional xG/possession) and asks Gemini for 5 perspective-
+    tagged headlines: neutral_news, analytical, winning_team_fan,
+    losing_team_fan, clickbait. Useful for content teams that need
+    multiple framings of the same match.
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
   inputs:
-    match: $.get('match', {})
+    match: "$.get('match', {})"
+
   outputs:
-    headlines: $.get('generate-headlines-prompt.headlines.headlines', [])
-    workflow-status: "($.get('generate-headlines-prompt.headlines.headlines', []) and 'executed' or 'skipped')"
+    headlines: "$.get('headlines', [])"
+    workflow-status: "$.get('headlines') and 'executed' or 'skipped'"
+
   tasks:
-    - name: generate-headlines-prompt
-      type: prompt
+
+    - type: prompt
+      name: generate-headlines-prompt
+      description: Run the headline-generator prompt and capture the structured array
+      condition: "$.get('match') is not None and $.get('match') != {}"
       connector:
         name: google-genai
         command: invoke_prompt
-        model: gemini-1.5-flash
+        model: gemini-2.5-pro
+        location: global
+        provider: vertex_ai
       inputs:
         match_data: "$.get('match', {})"
       outputs:
-        headlines: "$.get('result', {})"
+        headlines: "$.get('headlines', [])"


### PR DESCRIPTION
## Problem
Studio rejected the auto-generated workflow with **\"Failed to save — Missing required field: title\"** and the prompt YAML used the wrong root key + spurious \`inputs:\` list that wouldn't have validated either.

## Workflow fix
- Add \`title:\`
- Add \`context-variables.google-genai\` block (the agent's draft missed it; Vertex AI invoke_prompt needs it)
- \`gemini-1.5-flash\` → \`gemini-2.5-pro\` for parity with other Truth Point analyzers
- Guard prompt task with \`condition: \$.get('match') != {}\` so empty payload skips instead of empty-prompt
- Flatten workflow output (direct from \`headlines\`, not the over-nested path)

## Prompt fix
- Root key \`prompts:\` (list), not \`prompt:\` (single)
- \`type: \"prompt\"\` (agent's \`\"structured\"\` is not a valid slug)
- Add \`title:\`
- Drop the bogus \`inputs:\` list (placeholder names in \`instruction:\` ARE the contract)
- Move \`match_data\` into the standard \`## Inputs\` block in the instruction body

## Lessons planted
Two new severity-\`high\` lessons in Truth Point's lessons-learned (won't surface in retrieved set until next pre-flight call):
- \`workflow-yaml-requires-title\` — applies_to: agent-template, workflow
- \`prompt-yaml-canonical-shape\` — applies_to: agent-template, prompt

Pre-flight will surface these on the next skill-creation task and the Apply suggestions block prepended to the agent's task will pin them at the top.

## Test
- [x] Both YAMLs parse via \`yaml.safe_load\`
- [ ] After merge: re-install \`match-headline-generator\` on the target tenant. Studio's run modal should now save without complaining and the workflow should execute against a sample \`match\` payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)