### PR TITLE
fix(skills): add missing setup block to _install.yml so skills surface in Studio

### DIFF
--- a/skills/news-monitor-storylines/_install.yml
+++ b/skills/news-monitor-storylines/_install.yml
@@ -1,3 +1,20 @@
+setup:
+  title: "News Monitor: Storylines"
+  description: "Fetches recent news for a team or player and clusters articles into ongoing storylines (transfer rumor, injury, controversy, etc.) with timeline + recommended action for the editorial team."
+  category:
+    - skills
+  estimatedTime: 1 minute
+  features:
+    - "Polls a configurable news source for recent coverage"
+    - "Clusters articles into named storylines with status + timeline"
+    - "Surfaces a recommended_action per storyline for editorial triage"
+  integrations:
+    - news-api
+    - google-genai
+  status: available
+  value: "skills/news-monitor-storylines"
+  version: 1.0.0
+
 datasets:
   - type: "skill"
     path: "skill.yml"

--- a/skills/press-conference-extractor/_install.yml
+++ b/skills/press-conference-extractor/_install.yml
@@ -1,4 +1,18 @@
-# Installation manifest for the Press Conference Extractor skill
+setup:
+  title: "Press Conference Extractor"
+  description: "Analyzes a press conference transcript to extract key quotes, identify topics, score sentiment, and rank the most newsworthy statements."
+  category:
+    - skills
+  estimatedTime: 1 minute
+  features:
+    - "Extracts attributed quotes with sentiment scoring"
+    - "Clusters statements into topics with summaries"
+    - "Ranks the top 5 newsworthy quotes by novelty + controversy + clarity"
+  integrations:
+    - google-genai
+  status: available
+  value: "skills/press-conference-extractor"
+  version: 1.0.0
 
 datasets:
   - type: "skill"


### PR DESCRIPTION
## Problem
Two skills installed \"successfully\" but never appeared in Studio's marketplace, so the operator couldn't find them to run. Datasets DID reach the tenant's Mongo — workflow + prompts + connector were runnable via API — but the marketplace card was missing.

Both \`_install.yml\` files jumped straight to \`datasets:\` with no \`setup:\` block. Studio reads \`setup.title/description/category/value/status\` to populate the marketplace card; without it the skill stays invisible.

## Fix
Add canonical \`setup:\` block to both manifests, mirroring \`skills/match-stats-formatter/_install.yml\` (which works).

## Lesson planted
\`install-yml-requires-setup-block\` (severity: high) on Truth Point. Pre-flight will surface it on the next skill scaffold so this stops happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)