### PR TITLE
fix(skills/press-conference-extractor): add context-variables.google-…

### DIFF
--- a/skills/press-conference-extractor/workflows/press-conference-extractor.yml
+++ b/skills/press-conference-extractor/workflows/press-conference-extractor.yml
@@ -1,28 +1,44 @@
 workflow:
+
   name: press-conference-extractor
   title: Press Conference Extractor
-  description: "Receives a transcript and returns extracted quotes, topics, and rankings."
+  description: |
+    Receives a press-conference transcript (any language) and asks
+    Gemini for extracted quotes (with attribution + sentiment +
+    newsworthiness), topic clusters with summaries, and the top 5
+    most-newsworthy quotes ranked.
+
+  context-variables:
+    debugger:
+      enabled: false
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+
   inputs:
-    transcript:
-      type: string
-      description: "The full text transcript of the press conference."
+    transcript: "$.get('transcript', '')"
+
+  outputs:
+    topics: "$.get('topics', [])"
+    quotes: "$.get('quotes', [])"
+    top_5_quotes: "$.get('top_5_quotes', [])"
+    workflow-status: "$.get('quotes') and 'executed' or 'skipped'"
+
   tasks:
+
     - type: prompt
-      name: press-conference-extractor-prompt # Must match the prompt name in the prompt YAML
+      name: press-conference-extractor-prompt
+      description: Run the extractor prompt and capture the structured response
+      condition: "$.get('transcript') is not None and $.get('transcript') != ''"
       connector:
         name: google-genai
         command: invoke_prompt
-        model: gemini-1.5-flash # Using a powerful model for complex analysis
-        provider: vertex_ai
+        model: gemini-2.5-pro
         location: global
+        provider: vertex_ai
       inputs:
         transcript: "$.get('transcript', '')"
       outputs:
         topics: "$.get('topics', [])"
         quotes: "$.get('quotes', [])"
         top_5_quotes: "$.get('top_5_quotes', [])"
-  outputs:
-    topics: "$.get('topics', [])"
-    quotes: "$.get('quotes', [])"
-    top_5_quotes: "$.get('top_5_quotes', [])"
-    workflow-status: "$.get('quotes', []) and 'executed' or 'skipped'"


### PR DESCRIPTION
…genai

Workflow finished in 16ms with 0 LLM tokens consumed, returning empty arrays for every output — the LLM was never actually called. Root cause: the workflow YAML had a `type: prompt` task that pointed at google-genai, but lacked the workflow-level
`context-variables.google-genai` block. Truth Point's connector runtime resolves provider credentials from that block; without it the connector short-circuits with no audit-log error.

Fix: add the canonical context-variables block (matches the shape used by every truth-point/* workflow). Also bumped model from gemini-1.5-flash to gemini-2.5-pro for parity, added a guard condition so an empty/missing transcript skips cleanly, and migrated the workflow inputs to `$.get(…)` getter expressions (lesson inputs-values-must-be-getter-expressions).

Lesson `workflow-context-variables-required-for-llm-tasks` planted on Truth Point (severity: high) so the next prompt-task workflow the agent scaffolds gets this surfaced via pre-flight. Was implicit knowledge across the truth-point reference workflows but never written down — that's the gap that let the agent regress.

news-monitor-storylines has the same problem PLUS broken connector auth and inputs shape; ships in a separate PR after this one unblocks the press-conference test path.

# Pull Request

## What

<!-- Short description of what this PR does. -->

## Why

<!-- The motivation: which problem does it solve? Link issues / tickets. -->

## How

<!-- Brief notes on the approach, key decisions, and trade-offs. -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `perf:`, `revert:`)
- [ ] No `.env` / secrets / credentials committed (gitleaks will block)
- [ ] Lint, typecheck, tests, and build pass locally
- [ ] Targeting `staging` (default) — direct PRs to `main` only for hotfixes
- [ ] Updated `CHANGELOG.md` / docs if user-facing behavior changed
- [ ] Added or updated tests for new behavior

## Deploy notes

<!-- Anything special the deploy needs to know (env vars, migrations, feature flags)? -->

## Screenshots / videos

<!-- Optional, for UI changes. -->
