### PR TITLE
feat(truth-point): emit artifact_kind on pre-flight intent

### DIFF
--- a/agent-templates/truth-point/prompts/pre-flight-task.yml
+++ b/agent-templates/truth-point/prompts/pre-flight-task.yml
@@ -42,17 +42,15 @@ prompts:
            sounds like a request/bug-report/question rather than an edit.
            Use "review-pr" or "deploy" only when the task explicitly
            mentions a PR number or URL.
-        1a. `artifact_kind` is the CONCRETE artifact the prompt asks
+        2. `artifact_kind` is the CONCRETE artifact the prompt asks
            us to ship. Orthogonal to `mode` (which is execution shape).
            Must be exactly one of:
              - "skill": a single tool surface the agent can call (one
-               verb, narrow scope; lives in sports-skills/skills).
-               Examples: "summarize a match", "extract player stats
-               from an HTML page".
+               verb, narrow scope). Examples: "summarize a match",
+               "extract player stats from an HTML page".
              - "connector": integration with an external API / data
-               source (lives in machina-templates/connectors). Examples:
-               "polymarket odds feed", "kalshi market puller",
-               "webhook receiver for FotMob".
+               source. Examples: "polymarket odds feed", "kalshi
+               market puller", "webhook receiver for FotMob".
              - "workflow": multi-step pipeline orchestrating other
                components on a trigger (cron, webhook). Examples:
                "daily fixture digest", "ingest matches every hour".
@@ -61,31 +59,36 @@ prompts:
                "Brasileirão dashboard", "fan-engagement chatbot",
                "match-day live stats page". Pick this for any prompt
                mentioning "dashboard", "page", "site", "app", "UI",
-               "front-end" unless it's clearly pure-static (then "page").
+               or "front-end" UNLESS the prompt explicitly rules out
+               any backend / data-fetch (then "page" — see below).
              - "template": a reusable scaffold meant to seed future
-               builds (lives in machina-templates/agent-templates).
-             - "page": pure static HTML/JS page with no backend.
+               builds.
+             - "page": pure-static HTML/JS with NO dynamic data fetch
+               at all. If the task implies any backend call, runtime
+               data load, or personalization, pick "agent" instead.
+               Use "page" only for hand-written-content artifacts
+               (landing pages, wikis, single-file demos).
              - "data-pipeline": ETL / batch processing that isn't
                surfaced as a workflow.
            Default to "agent" when ambiguous — it's the broadest catch.
-        2. `target_repo` is the SINGLE repo the work lands on. Pick the
+        3. `target_repo` is the SINGLE repo the work lands on. Pick the
            best match from known_repos. Empty `{owner: "", name: ""}` if
            you genuinely can't tell.
-        3. `reference_repos` is up to 3 OTHER repos that should be
+        4. `reference_repos` is up to 3 OTHER repos that should be
            cloned read-only as context. Don't repeat the target.
-        4. `open_pr`: true when `mode` is "build" (always opens a PR).
+        5. `open_pr`: true when `mode` is "build" (always opens a PR).
            false for "plan", "shell", "issue". For "review-pr" and
            "deploy" the PR already exists, so false.
-        5. `required_credentials` is a list of vault keys the task
+        6. `required_credentials` is a list of vault keys the task
            probably needs. Only include keys that the task description
            directly implies (e.g. "use OpenAI" → ["OPENAI_API_KEY"]).
            Empty list when nothing specific is needed. The dashboard
            cross-references with the existing vault to surface gaps.
            Each entry: {vault_key, hint}.
-        6. `summary` is ONE sentence (≤140 chars) describing what you
+        7. `summary` is ONE sentence (≤140 chars) describing what you
            think the developer wants to do, in English regardless of the
            task language. This is shown back to the dev for confirmation.
-        7. `warnings` is a list of strings. Emit one when:
+        8. `warnings` is a list of strings. Emit one when:
              - the task overlaps strongly with an existing component
                (point at it, suggest reuse).
              - an active lesson clearly applies (cite the lesson_id).
@@ -114,10 +117,19 @@ prompts:
       properties:
         mode:
           type: string
-          description: "build | plan | shell | review-pr | deploy | issue"
+          enum: ["build", "plan", "shell", "review-pr", "deploy", "issue"]
+          description: "Execution shape — what the worker should DO with the task."
         artifact_kind:
           type: string
-          description: "skill | connector | workflow | agent | template | page | data-pipeline"
+          enum:
+            - "skill"
+            - "connector"
+            - "workflow"
+            - "agent"
+            - "template"
+            - "page"
+            - "data-pipeline"
+          description: "Concrete artifact the prompt asks us to ship — orthogonal to mode."
         target_repo:
           type: object
           description: "The repo the work lands on. Empty owner/name if unknown."

--- a/agent-templates/truth-point/prompts/pre-flight-task.yml
+++ b/agent-templates/truth-point/prompts/pre-flight-task.yml
@@ -42,6 +42,32 @@ prompts:
            sounds like a request/bug-report/question rather than an edit.
            Use "review-pr" or "deploy" only when the task explicitly
            mentions a PR number or URL.
+        1a. `artifact_kind` is the CONCRETE artifact the prompt asks
+           us to ship. Orthogonal to `mode` (which is execution shape).
+           Must be exactly one of:
+             - "skill": a single tool surface the agent can call (one
+               verb, narrow scope; lives in sports-skills/skills).
+               Examples: "summarize a match", "extract player stats
+               from an HTML page".
+             - "connector": integration with an external API / data
+               source (lives in machina-templates/connectors). Examples:
+               "polymarket odds feed", "kalshi market puller",
+               "webhook receiver for FotMob".
+             - "workflow": multi-step pipeline orchestrating other
+               components on a trigger (cron, webhook). Examples:
+               "daily fixture digest", "ingest matches every hour".
+             - "agent": a hosted application or chat surface — full
+               UI with pages, often with a backend. Examples:
+               "Brasileirão dashboard", "fan-engagement chatbot",
+               "match-day live stats page". Pick this for any prompt
+               mentioning "dashboard", "page", "site", "app", "UI",
+               "front-end" unless it's clearly pure-static (then "page").
+             - "template": a reusable scaffold meant to seed future
+               builds (lives in machina-templates/agent-templates).
+             - "page": pure static HTML/JS page with no backend.
+             - "data-pipeline": ETL / batch processing that isn't
+               surfaced as a workflow.
+           Default to "agent" when ambiguous — it's the broadest catch.
         2. `target_repo` is the SINGLE repo the work lands on. Pick the
            best match from known_repos. Empty `{owner: "", name: ""}` if
            you genuinely can't tell.
@@ -89,6 +115,9 @@ prompts:
         mode:
           type: string
           description: "build | plan | shell | review-pr | deploy | issue"
+        artifact_kind:
+          type: string
+          description: "skill | connector | workflow | agent | template | page | data-pipeline"
         target_repo:
           type: object
           description: "The repo the work lands on. Empty owner/name if unknown."
@@ -148,6 +177,7 @@ prompts:
             type: string
       required:
         - mode
+        - artifact_kind
         - target_repo
         - reference_repos
         - open_pr

--- a/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
+++ b/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
@@ -20,6 +20,10 @@ workflow:
 
     Outputs:
       - mode: one of build|plan|shell|review-pr|deploy|issue.
+      - artifact_kind: one of skill|connector|workflow|agent|template|page|data-pipeline.
+        Concrete artifact the prompt is asking us to ship — orthogonal
+        to mode (which is execution shape). Lets the customer-facing
+        Factory pick the right scaffold without keyword guessing.
       - target_repo: { owner, name } — best match from known_repos.
       - reference_repos: up to 3 read-only repos for context.
       - open_pr: true for build, false otherwise.
@@ -44,6 +48,7 @@ workflow:
 
   outputs:
     mode: "$.get('mode', 'build')"
+    artifact_kind: "$.get('artifact_kind', '')"
     target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
     reference_repos: "$.get('reference_repos', [])"
     open_pr: "$.get('open_pr', False)"
@@ -160,6 +165,7 @@ workflow:
         similar_components: $.get('similar_components', [])
       outputs:
         mode: "$.get('mode', 'build')"
+        artifact_kind: "$.get('artifact_kind', '')"
         target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
         reference_repos: "$.get('reference_repos', [])"
         open_pr: "$.get('open_pr', False)"

--- a/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
+++ b/agent-templates/truth-point/workflows/truth-point-pre-flight-task.yml
@@ -48,7 +48,7 @@ workflow:
 
   outputs:
     mode: "$.get('mode', 'build')"
-    artifact_kind: "$.get('artifact_kind', '')"
+    artifact_kind: "$.get('artifact_kind', 'agent')"
     target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
     reference_repos: "$.get('reference_repos', [])"
     open_pr: "$.get('open_pr', False)"
@@ -165,7 +165,7 @@ workflow:
         similar_components: $.get('similar_components', [])
       outputs:
         mode: "$.get('mode', 'build')"
-        artifact_kind: "$.get('artifact_kind', '')"
+        artifact_kind: "$.get('artifact_kind', 'agent')"
         target_repo: "$.get('target_repo', {'owner': '', 'name': ''})"
         reference_repos: "$.get('reference_repos', [])"
         open_pr: "$.get('open_pr', False)"


### PR DESCRIPTION
## Summary
- Adds `artifact_kind` to `truth-point-pre-flight-task` outputs (skill | connector | workflow | agent | template | page | data-pipeline)
- Updated prompt with classification rules + schema requires the new field
- Backwards compatible: consumers that don't read it still work; default fallback is "agent"

## Why
Customer-facing /c surface was inferring artifact kind from a regex on the prompt — breaks for typo'd repo names ("machina-skills" → falsely routed to machina-templates on Apr 30). Truth Point already has the catalog + lessons context, so it's the right place to classify. Consumer-side change in machina-factory-customers reads `intent.artifact_kind` first and falls through to the regex cascade only when missing.

## Test plan
- [ ] Trigger the workflow with a "Cria uma skill que…" prompt → expect `artifact_kind: skill`
- [ ] Trigger with "Build a Brasileirão dashboard" → expect `artifact_kind: agent`
- [ ] Trigger with "Connector for Polymarket odds" → expect `artifact_kind: connector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)