### PR TITLE
feat(connectors): honor per-call timeout in google-genai + machina-ai-fast

### DIFF
--- a/connectors/google-genai/google-genai.py
+++ b/connectors/google-genai/google-genai.py
@@ -64,6 +64,19 @@ def invoke_prompt(params):
     if not model_name:
         return {"status": False, "message": "Model name is required."}
 
+    # Optional per-call timeout (seconds). Values larger than 600 are
+    # interpreted as milliseconds for backwards compatibility with workflows
+    # that already set e.g. `timeout: 20000`.
+    timeout_param = params.get("timeout")
+    timeout_seconds = None
+    if timeout_param is not None:
+        try:
+            timeout_seconds = float(timeout_param)
+            if timeout_seconds > 600:
+                timeout_seconds = timeout_seconds / 1000.0
+        except (TypeError, ValueError):
+            timeout_seconds = None
+
     # AI Studio Implementation (default)
     if provider == "ai_studio":
         api_key = params.get("api_key")
@@ -72,7 +85,10 @@ def invoke_prompt(params):
             return {"status": False, "message": "API key is required for AI Studio."}
 
         try:
-            llm = ChatGoogleGenerativeAI(model=model_name, api_key=api_key)
+            llm_kwargs = {"model": model_name, "api_key": api_key}
+            if timeout_seconds is not None:
+                llm_kwargs["timeout"] = timeout_seconds
+            llm = ChatGoogleGenerativeAI(**llm_kwargs)
             return {
                 "status": True,
                 "data": llm,
@@ -122,13 +138,23 @@ def invoke_prompt(params):
             if priority_mode:
                 additional_headers["x-vertex-ai-llm-shared-request-type"] = "priority"
 
-            llm = ChatVertexAI(
-                model_name=model_name,
-                project=project_id,
-                location=location,
-                credentials=credentials,
-                additional_headers=additional_headers if additional_headers else None,
-            )
+            vertex_kwargs = {
+                "model_name": model_name,
+                "project": project_id,
+                "location": location,
+                "credentials": credentials,
+                "additional_headers": additional_headers if additional_headers else None,
+            }
+            if timeout_seconds is not None:
+                # ChatVertexAI accepts both `timeout` (modern langchain) and
+                # `request_timeout` (legacy). Pass `timeout`; fall back if the
+                # installed version rejects it.
+                try:
+                    llm = ChatVertexAI(timeout=timeout_seconds, **vertex_kwargs)
+                except TypeError:
+                    llm = ChatVertexAI(request_timeout=timeout_seconds, **vertex_kwargs)
+            else:
+                llm = ChatVertexAI(**vertex_kwargs)
 
             endpoint_info = (
                 "Global Endpoint"

--- a/connectors/machina-ai-fast/machina-ai-fast.py
+++ b/connectors/machina-ai-fast/machina-ai-fast.py
@@ -29,11 +29,24 @@ def invoke_prompt(params):
     if not api_key:
         return {"status": "error", "message": "API key is required."}
 
+    # Optional per-call timeout (seconds). Values larger than 600 are
+    # interpreted as milliseconds for backwards compatibility with workflows
+    # that already set e.g. `timeout: 20000`.
+    timeout_param = params.get("timeout")
+    timeout_seconds = None
+    if timeout_param is not None:
+        try:
+            timeout_seconds = float(timeout_param)
+            if timeout_seconds > 600:
+                timeout_seconds = timeout_seconds / 1000.0
+        except (TypeError, ValueError):
+            timeout_seconds = None
+
     try:
-        llm = ChatGroq(
-            api_key=api_key,
-            model_name=model_name
-        )
+        llm_kwargs = {"api_key": api_key, "model_name": model_name}
+        if timeout_seconds is not None:
+            llm_kwargs["timeout"] = timeout_seconds
+        llm = ChatGroq(**llm_kwargs)
     except Exception as e:
         return {"status": "error", "message": f"Exception when creating model: {e}"}
 


### PR DESCRIPTION
## Summary
Today, workflow YAMLs that set `timeout: <ms>` on a prompt task are silently ignored — neither `google-genai` nor `machina-ai-fast` reads the field. As a result, hung Vertex AI calls can freeze agents for minutes (we observed 187s and 402s hangs on prd today), and the gateway's existing Groq fallback never fires on a hang because hangs aren't errors.

This PR makes both connectors honor an optional \`timeout\` param on \`invoke_prompt\`.

## What changed

### \`connectors/google-genai/google-genai.py\` — \`invoke_prompt\`
- Reads \`timeout\` from params (seconds, float).
- Passes \`timeout=<seconds>\` to \`ChatGoogleGenerativeAI\` (AI Studio).
- Passes \`timeout=<seconds>\` to \`ChatVertexAI\` (Vertex), with a \`TypeError\` fallback to \`request_timeout=\` for legacy \`langchain-google-vertexai\` builds.

### \`connectors/machina-ai-fast/machina-ai-fast.py\` — \`invoke_prompt\`
- Reads \`timeout\` from params and passes \`timeout=<seconds>\` to \`ChatGroq\`.

### Backwards compatibility
Values > 600 are interpreted as **milliseconds** and converted to seconds. Existing workflows already use \`timeout: 20000\` (clearly intended as 20s) on Groq tasks in entain-templates — those keep working unchanged. New YAMLs are free to use either unit.

## Why this matters
The entain-sbot prd today hit a Vertex tail-latency burst:

| Run | Model | Duration | Outcome |
|---|---|---|---|
| 15:57 gateway | gemini-3.1-flash-lite-preview | **402s** | Eventually returned valid output. Frontend timed out long before. |
| 16:01 gateway | gemini-3.1-flash-lite-preview | **187s** | Same. |
| 16:08 sbot-response | same | hung 4+ min | Released manually. |

Same model on stg returned in ~2s for identical input. The fix isn't to swap models — it's to cap each call so a hung Vertex doesn't take the agent with it.

## Verification
- No behavior change when \`timeout\` is absent (existing call sites unaffected).
- Both connectors compile (no syntax errors).
- Edits are minimal: one new param read + kwargs construction.
- Safe rollout: only a tenant that explicitly sets \`timeout\` on a workflow task will see new behavior.

## Follow-ups (separate PRs)
1. \`entain-templates\`: add \`timeout: 8000\` to the 3 Gemini-primary tasks (\`gateway-category-detection\`, \`sbot-reasoning\`, \`sbot-response\`). Lands once this PR ships and the connector is re-imported into each tenant.
2. Optionally extend the Gemini fallback chain (Gemini-lite → Gemini-3-flash → Groq llama) so timeouts cascade through model alternatives.

## Test plan
- [ ] Re-import \`google-genai\` and \`machina-ai-fast\` connectors into a stg tenant.
- [ ] Add \`timeout: 8000\` to a test workflow's Gemini call, send a query, confirm normal latency unchanged.
- [ ] Force an artificial hang (e.g. a giant prompt that times out at the model layer) and confirm the connector returns \`status: false\` after ~8s instead of hanging.
- [ ] Confirm existing Groq tasks with \`timeout: 20000\` still work (backwards-compat ms→s conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)