### PR TITLE
docs(voice-tts-studio): require Cloud Text-to-Speech API on GCP project

### DIFF
--- a/agent-templates/voice-tts-studio/README.md
+++ b/agent-templates/voice-tts-studio/README.md
@@ -14,6 +14,22 @@ The same `synthesize-with-custom-voice` workflow handles both modes —
 just pass either `voice_clone_key` (instant) or `custom_voice_model`
 (pro), or a `speaker_label` we previously persisted.
 
+## Prerequisites
+
+Custom Voice runs on the **Cloud Text-to-Speech API**, which is a
+distinct API from Vertex AI on the same GCP project. Before installing
+this template, enable it on the project that owns
+`TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID`:
+
+```
+https://console.developers.google.com/apis/api/texttospeech.googleapis.com/overview?project=<your-project-id>
+```
+
+If TTS is disabled, every Custom Voice call fails with
+`403 PERMISSION_DENIED` and the workflow returns
+`workflow-status: failed` even though the HTTP envelope is `200`.
+Enabling Vertex AI alone is **not** sufficient — Custom Voice uses TTS.
+
 ## What's in this template
 
 | File | Purpose |

--- a/agent-templates/voice-tts-studio/_install.yml
+++ b/agent-templates/voice-tts-studio/_install.yml
@@ -1,6 +1,6 @@
 setup:
   title: "Voice TTS Studio"
-  description: "End-to-end studio for cloning a voice with Google Custom Voice (Instant + Professional) and synthesizing new lines from text."
+  description: "End-to-end studio for cloning a voice with Google Custom Voice (Instant + Professional) and synthesizing new lines from text. Requires the Cloud Text-to-Speech API to be enabled on the same GCP project as your Vertex AI credentials — Vertex AI alone is not enough for Custom Voice."
   category:
     - custom-templates
   estimatedTime: 10 minutes


### PR DESCRIPTION
## Summary

- Adds a **Prerequisites** section to `agent-templates/voice-tts-studio/README.md` that calls out the Cloud Text-to-Speech API requirement (with the direct GCP enable link) before any other setup step.
- Appends a one-line warning to the `description` in `_install.yml` so the marketplace tile shows the requirement before install.

## Why

Tracking issue: machina-sports/machina-client-api#215.

A real install hit `403 PERMISSION_DENIED` because Vertex AI was enabled on the GCP project but **Cloud Text-to-Speech API** (a distinct API on the same project) was not. The workflow surfaced as `HTTP 200` with `outputs.workflow-status: failed` and the upstream error nested in `outputs.workflow-error.message` — easy to miss. Documenting the API requirement up front prevents the same trap for the next installer.

## Out of scope

- Action 2 from the issue (frontend `assertWorkflowOk` helper across the 4 workflow handlers) — the `app.js` referenced in the issue does **not** live in either `machina-client-api` (Flask/Python only) or `machina-templates` (YAMLs only). It is most likely a Factory-generated build artifact for the customer project; that fix needs to land wherever that source lives. Flagged in a comment on #215.

## Test plan

- [ ] Render the README on GitHub and confirm the Prerequisites section appears above "What's in this template".
- [ ] Confirm the `_install.yml` description renders cleanly in the marketplace tile (length sanity check).
- [ ] No workflow / connector / agent files were touched — install pipeline unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)