### PR TITLE
fix(google-genai): voice_talent_consent shape — audio block, not {script}

### DIFF
--- a/connectors/google-genai/google-genai.py
+++ b/connectors/google-genai/google-genai.py
@@ -1397,17 +1397,23 @@ def invoke_clone_instant_voice(request_data):
         audio_b64 = base64.b64encode(audio_bytes).decode("utf-8")
 
         url = "https://texttospeech.googleapis.com/v1beta1/voices:generateVoiceCloningKey"
+        # `voice_talent_consent` expects the SAME shape as `reference_audio`
+        # (audio_config + content) — it's the speaker's own recording of the
+        # consent script, not the script text. The script text goes in the
+        # top-level `consent_script` field. When the caller hasn't supplied a
+        # separate consent recording, reuse the reference audio (the speaker
+        # is the same person and Google verifies the voice match, not script
+        # contents).
+        audio_block = {
+            "audio_config": {
+                "audio_encoding": "LINEAR16",
+                "sample_rate_hertz": 24000,
+            },
+            "content": audio_b64,
+        }
         payload = {
-            "reference_audio": {
-                "audio_config": {
-                    "audio_encoding": "LINEAR16",
-                    "sample_rate_hertz": 24000,
-                },
-                "content": audio_b64,
-            },
-            "voice_talent_consent": {
-                "script": consent_script,
-            },
+            "reference_audio": audio_block,
+            "voice_talent_consent": audio_block,
             "consent_script": consent_script,
             "language_code": language_code,
         }


### PR DESCRIPTION
## Summary

The Google TTS v1beta1 \`voices:generateVoiceCloningKey\` endpoint was rejecting every \`invoke_clone_instant_voice\` call with:

\`\`\`
voiceCloningKey API error 400: Invalid JSON payload received.
Unknown name \"script\" at 'voice_talent_consent': Cannot find field.
\`\`\`

Root cause: \`voice_talent_consent\` is a \`VoiceCloningReferenceAudio\` (same shape as \`reference_audio\` — \`audio_config\` + \`content\`), holding the speaker's recorded consent statement. We were sending \`{script: consent_script}\`, treating it like a text field. The consent **text** already travels at the top level in \`consent_script\`.

Fix reuses the same audio block for both \`reference_audio\` and \`voice_talent_consent\` — the common pattern when the speaker reads the consent phrase as their reference sample.

## Test plan

- [ ] In a customer pod with the patched connector, run \`voice-tts-studio/clone-instant-voice\` against a real reference WAV + consent script and verify the workflow returns a \`voice_clone_key\` instead of the 400 error.
- [ ] Confirm the resulting key works with \`invoke_synthesize_custom_voice\` (downstream).