### PR TITLE
fix(sports-skills): filter framework kwargs + correct smoke output path

### DIFF
--- a/connectors/sports-skills/sports-skills.py
+++ b/connectors/sports-skills/sports-skills.py
@@ -24,6 +24,7 @@ Runtime requirement:
 """
 
 import importlib
+import inspect
 import subprocess
 import sys
 
@@ -38,24 +39,58 @@ def _ensure_sports_skills():
     so a fresh pod can use this connector immediately after template
     install, without operator action. Long-term the package should be
     baked into the pod base image — this branch is a graceful degrade.
+
+    Uses `--user` so the install lands in the running container user's
+    `~/.local` (the pod runs as a non-root user that can't write to the
+    system site-packages). After install, the `~/.local/lib/...`
+    site-packages dir is added to `sys.path` so the in-process import
+    sees the newly installed package without a restart.
     """
     try:
         importlib.import_module("sports_skills")
         return True, None
     except ImportError:
         pass
-    try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--no-cache-dir", _PIP_PACKAGE],
-            timeout=120,
-        )
-    except Exception as e:  # noqa: BLE001 — surface any pip failure verbatim
-        return False, f"pip install {_PIP_PACKAGE} failed: {e}"
+
+    # First-call pip install. Capture stdout+stderr so failures surface a
+    # real error in the workflow output instead of a cryptic exit code.
+    proc = subprocess.run(  # noqa: S603 — args are constants, no shell
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--user",
+            "--no-cache-dir",
+            _PIP_PACKAGE,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if proc.returncode != 0:
+        # pip prints the actionable bit to stderr; include both for safety.
+        tail = (proc.stderr or proc.stdout or "")[-1500:]
+        return False, f"pip install {_PIP_PACKAGE} failed (rc={proc.returncode}): {tail}"
+
+    # `--user` writes to a path Python doesn't know about yet in this
+    # process. Re-resolve and inject into sys.path so the import below
+    # finds it.
+    import site
+
+    user_site = site.getusersitepackages()
+    if user_site and user_site not in sys.path:
+        sys.path.insert(0, user_site)
+    importlib.invalidate_caches()
+
     try:
         importlib.import_module("sports_skills")
         return True, None
     except ImportError as e:
-        return False, f"sports_skills still not importable after pip install: {e}"
+        return False, (
+            f"sports_skills installed but not importable from {user_site}: {e}. "
+            f"pip stdout tail: {(proc.stdout or '')[-500:]}"
+        )
 
 
 def _dispatch(module_name, request_data):
@@ -98,6 +133,24 @@ def _dispatch(module_name, request_data):
                 f"Available: {', '.join(available)}"
             ),
         }
+
+    # The workflow runtime injects framework-level keys (model_name,
+    # debugger, api_key, headers, etc.) into every connector params dict.
+    # sports_skills functions have narrow signatures and reject unknown
+    # kwargs with TypeError. Filter `params` down to what the function
+    # actually accepts so the agent never has to know which keys are
+    # framework noise vs. real call args.
+    try:
+        sig = inspect.signature(fn)
+        accepts_kwargs = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        if not accepts_kwargs:
+            allowed = set(sig.parameters.keys())
+            params = {k: v for k, v in params.items() if k in allowed}
+    except (TypeError, ValueError):
+        # Builtins / C-extensions don't expose signatures — pass through.
+        pass
 
     try:
         result = fn(**params)

--- a/connectors/sports-skills/test-credentials.yml
+++ b/connectors/sports-skills/test-credentials.yml
@@ -19,4 +19,7 @@ workflow:
       inputs:
         command: "'get_competitions'"
       outputs:
-        competitions: "$.get('data', {}).get('items', $.get('data', []))"
+        # The package wraps responses as `{"competitions": [...]}`, and the
+        # connector envelope wraps that as `{"data": {"competitions": [...]}}`.
+        # Reach for the inner list directly.
+        competitions: "$.get('data', {}).get('competitions', [])"


### PR DESCRIPTION
## Summary

Two follow-up fixes caught on the first end-to-end test of #189 against the live \`tenant-machina-factory-factory-customers\` pod.

## 1. Framework kwargs leaking into sports_skills functions

The pod's workflow runtime injects framework-level keys (\`model_name\`, \`debugger\`, \`api_key\`, etc.) into every connector \`params\` dict. \`sports_skills\` functions have narrow signatures and reject unknown kwargs:

\`\`\`
get_competitions() got an unexpected keyword argument 'model_name'
\`\`\`

\`_dispatch\` now uses \`inspect.signature(fn)\` to filter \`params\` down to what the function actually accepts before forwarding, with a pass-through fallback for builtins/C-extensions that don't expose a signature.

## 2. Smoke output extractor pointed at the wrong key

The smoke workflow walked \`data.items\` — but the package returns \`{"competitions": [...]}\`. Updated to \`data.competitions\`.

## 3. Bonus improvements to the pip-install fallback

The fallback is now mostly dead code thanks to machina-sports/machina-client-api#216 baking \`sports-skills\` into the pod image, but improvements landed while diagnosing the perms issue:
- Switched to \`subprocess.run(..., capture_output=True)\` so failures surface real \`stderr\` instead of a cryptic exit code.
- Use \`--user\` and inject \`site.getusersitepackages()\` into \`sys.path\` for the in-process import.

## Test plan

- [x] Hot-patched the live connector source on \`tenant-machina-factory-factory-customers\`, re-ran \`workflow/execute/sports-skills-test-credentials\`:
  \`\`\`
  workflow-status: executed
  competitions: [Premier League, La Liga, Bundesliga, Serie A, Ligue 1, ...]
  \`\`\`
- [ ] Re-install template after merge (instead of hot-patch) and confirm the same result.
- [ ] Smoke another module to be safe: \`invoke_polymarket\` with \`command=get_todays_events\`.