### PR TITLE
feat(agent-templates): replace OpenAI/machina-ai with Vertex AI

### DIFF
--- a/agent-templates/assistant-tools/_install.yml
+++ b/agent-templates/assistant-tools/_install.yml
@@ -8,7 +8,8 @@ setup:
     - AI Agent to assist moderators to create content for Chat Tools.
   status: available
   integrations:
-    - machina-ai
+    - google-genai
+    - vertex-embedding
   value: agent-templates/assistant-tools
   version: 1.0.0
 

--- a/agent-templates/assistant-tools/tools/event-matcher.yml
+++ b/agent-templates/assistant-tools/tools/event-matcher.yml
@@ -7,8 +7,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     competitionIds: $.get('competitionIds') or $.get('competitionItem', {}).get('competitionIds')
     competitionItem: $.get('competitionItem')

--- a/agent-templates/assistant-tools/tools/find-faq.yml
+++ b/agent-templates/assistant-tools/tools/find-faq.yml
@@ -8,9 +8,12 @@ workflow:
     debugger:
       enabled: false
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:
@@ -53,9 +56,9 @@ workflow:
         search-limit: 100
         search-vector: true
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       inputs:
         name: "'content-faq-snippets'"
         search-query: $.get('search_query')

--- a/agent-templates/assistant-tools/tools/find-historical.yml
+++ b/agent-templates/assistant-tools/tools/find-historical.yml
@@ -10,8 +10,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:
@@ -76,9 +77,9 @@ workflow:
         search-sorters: ["value.schema:startDate", -1]
         search-vector: context.get('vector_search')
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         "value.sport:status": "{'$in': ['Played', 'closed', 'ended']}"
         "value.schema:startDate": |
@@ -134,9 +135,9 @@ workflow:
         search-sorters: ["value.schema:startDate", -1]
         search-vector: context.get('vector_search')
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         "value.sport:status": "{'$in': ['Played', 'closed', 'ended']}"
         "value.schema:startDate": |

--- a/agent-templates/assistant-tools/tools/find-insights.yml
+++ b/agent-templates/assistant-tools/tools/find-insights.yml
@@ -10,8 +10,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:
@@ -55,9 +56,9 @@ workflow:
         search-limit: 10000
         search-vector: true
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         "metadata.event_code": |
           $.get('event_code') if $.get('event_code') is not None else None
@@ -85,9 +86,9 @@ workflow:
         search-limit: 10000
         search-vector: true
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         "metadata.event_code": |
           $.get('event_code') if $.get('event_code') is not None else None

--- a/agent-templates/assistant-tools/tools/find-markets.yml
+++ b/agent-templates/assistant-tools/tools/find-markets.yml
@@ -13,8 +13,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:
@@ -102,9 +103,9 @@ workflow:
         search-sorters: ["value.startDate", 1]
         search-vector: true
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         '$or': "[{'value.startDate':{'$gt': $.get('search_date_interval', {}).get('start_date') + 'T07:00:00+00:00'}}, {'value.startDateUtc': {'$gt': $.get('search_date_interval', {}).get('start_date') + 'T07:00:00+00:00'}}]"
         value.isOpenForBetting: "{'$eq': True}"

--- a/agent-templates/assistant-tools/tools/find-upcoming.yml
+++ b/agent-templates/assistant-tools/tools/find-upcoming.yml
@@ -10,8 +10,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:
@@ -76,9 +77,9 @@ workflow:
         search-sorters: ["value.schema:startDate", 1]
         search-vector: context.get('vector_search')
       connector:
-        name: machina-ai
+        name: vertex-embedding
         command: invoke_embedding
-        model: text-embedding-3-small
+        model: text-embedding-004
       filters:
         "value.schema:startDate": |
           {

--- a/agent-templates/assistant-tools/workflows/chat-reasoning.yml
+++ b/agent-templates/assistant-tools/workflows/chat-reasoning.yml
@@ -10,8 +10,6 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:

--- a/agent-templates/assistant-tools/workflows/chat-response.yml
+++ b/agent-templates/assistant-tools/workflows/chat-response.yml
@@ -10,8 +10,6 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:

--- a/agent-templates/assistant-tools/workflows/chat-update.yml
+++ b/agent-templates/assistant-tools/workflows/chat-update.yml
@@ -10,8 +10,6 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   inputs:

--- a/agent-templates/bundesliga-podcast/_install.yml
+++ b/agent-templates/bundesliga-podcast/_install.yml
@@ -8,8 +8,8 @@ setup:
     - AI Agent to generate Bundesliga podcast content based on user profile.
     - AI Reporter to generate Bundesliga podcast content based on user profile.
   integrations:
-    - machina-ai
     - google-genai
+    - vertex-embedding
     - storage
     - api-mailgun
   status: available

--- a/agent-templates/bundesliga-podcast/workflows/compose-template.yml
+++ b/agent-templates/bundesliga-podcast/workflows/compose-template.yml
@@ -12,8 +12,9 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     storage:
       api_key: "$TEMP_CONTEXT_VARIABLE_AZURE_BLOB_STRING"
   inputs:
@@ -33,9 +34,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: $.get('document_id')
       inputs:

--- a/agent-templates/bundesliga-podcast/workflows/generate-audio.yml
+++ b/agent-templates/bundesliga-podcast/workflows/generate-audio.yml
@@ -15,8 +15,9 @@ workflow:
     google-storage:
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY
       bucket_name: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     document_id: "$.get('document_id')"
     voice_name: "$.get('voice_name', 'Kore')"
@@ -34,9 +35,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: $.get('document_id')
       inputs:

--- a/agent-templates/bundesliga-podcast/workflows/generate-content.yml
+++ b/agent-templates/bundesliga-podcast/workflows/generate-content.yml
@@ -12,8 +12,9 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     storage:
       api_key: "$TEMP_CONTEXT_VARIABLE_AZURE_BLOB_STRING"
   inputs:
@@ -32,9 +33,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: $.get('document_id')
       inputs:

--- a/agent-templates/bundesliga-podcast/workflows/generate-image.yml
+++ b/agent-templates/bundesliga-podcast/workflows/generate-image.yml
@@ -12,8 +12,9 @@ workflow:
     google-storage:
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY
       bucket_name: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     oxylabs:
       username: $TEMP_CONTEXT_VARIABLE_OXYLABS_USERNAME
       password: $TEMP_CONTEXT_VARIABLE_OXYLABS_PASSWORD
@@ -39,9 +40,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: $.get('document_id')
       inputs:

--- a/agent-templates/bundesliga-podcast/workflows/store-user-profile.yml
+++ b/agent-templates/bundesliga-podcast/workflows/store-user-profile.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     name: "$.get('name')"
     favorite_sport: "$.get('favorite_sport')"

--- a/agent-templates/chat-completion/_install.yml
+++ b/agent-templates/chat-completion/_install.yml
@@ -7,7 +7,8 @@ setup:
   features:
     - AI Agent to generate chat completions.
   integrations:
-    - machina-ai
+    - google-genai
+    - vertex-embedding
   status: available
   value: agent-templates/chat-completion
   version: 1.0.0

--- a/agent-templates/chat-completion/workflows/chat-completions.yml
+++ b/agent-templates/chat-completion/workflows/chat-completions.yml
@@ -7,8 +7,9 @@ workflow:
       enabled: true
     google-genai:
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -29,9 +30,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -57,9 +58,6 @@ workflow:
         # model: "meta-llama/llama-4-maverick-17b-128e-instruct"
         # model: "deepseek-r1-distill-llama-70b"
         # model: "deepseek-r1-distill-llama-70b-specdec"
-        # name: "machina-ai"
-        # command: "invoke_prompt"
-        # model: "gpt-4.1-mini"
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"

--- a/agent-templates/chat-completion/workflows/chat-moderator.yml
+++ b/agent-templates/chat-completion/workflows/chat-moderator.yml
@@ -6,9 +6,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -29,6 +32,8 @@ workflow:
         command: "invoke_prompt"
         name: "google-genai"
         model: "gemini-2.5-flash-lite"
+        location: global
+        provider: vertex_ai
       inputs:
         _1-messages-parsed: "str($.get('messages'))"
       outputs:
@@ -52,9 +57,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'sport:Event'"
         search-query: "$.get('search_query')"
@@ -85,8 +90,8 @@ workflow:
         name: "google-genai"
         # model: "gemini-2.5-pro"
         model: "gemini-2.5-flash-lite"
-        # name: "machina-ai"
-        # model: "gpt-4.1"
+        location: global
+        provider: vertex_ai
       inputs:
         _0-date-time-now: "datetime.now().isoformat()"
         _1-events-parsed: "$.get('parsed_objects')"
@@ -129,6 +134,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         _event-title: "$.get('search_query')"
         _custom-instruction: "$.get('messages')"
@@ -160,9 +167,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "'sport:Event'"
       documents:
         items: "$.get('parsed_event', [])"
@@ -212,6 +219,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         events_data: "$.get('events', [])"
         events_count: "$.get('events_count', 0)"

--- a/agent-templates/chat-completion/workflows/event-search.yml
+++ b/agent-templates/chat-completion/workflows/event-search.yml
@@ -8,9 +8,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     search-query: "$.get('search-query') or None"
   outputs:
@@ -29,9 +32,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'sport:Event'"
         search-query: "$.get('search-query')"
@@ -52,10 +55,10 @@ workflow:
       condition: "$.get('parsed_objects') is not None"
       connector:
         command: "invoke_prompt"
-        # name: "google-genai"
-        # model: "gemini-2.5-pro"
-        name: "machina-ai"
-        model: "gpt-4.1"
+        name: "google-genai"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         _1-events-parsed: "$.get('parsed_objects')"
         _2-instruction: f"Select the event equivalent to {$.get('search-query')}"

--- a/agent-templates/corinthians-twitter/_install.yml
+++ b/agent-templates/corinthians-twitter/_install.yml
@@ -10,8 +10,8 @@ setup:
     - AI Agent to analyze pre-match and post-match stats.
   integrations:
     - api-football
-    - openai
     - google-genai
+    - vertex-embedding
   status: available
   value: agent-templates/corinthians-twitter
   version: 1.0.0

--- a/agent-templates/corinthians-twitter/workflows/chat-completions.yml
+++ b/agent-templates/corinthians-twitter/workflows/chat-completions.yml
@@ -5,12 +5,15 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     messages: "$.get('messages', [])"
   outputs:
@@ -29,9 +32,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -53,6 +56,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('parsed_documents')"
         messages: "$.get('messages')"

--- a/agent-templates/corinthians-twitter/workflows/soccer-embeddings.yml
+++ b/agent-templates/corinthians-twitter/workflows/soccer-embeddings.yml
@@ -7,10 +7,13 @@ workflow:
       enabled: true
     api-football:
       api_key: "$MACHINA_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
-    openai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -312,9 +315,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/corinthians-twitter/workflows/soccer-live-event.yml
+++ b/agent-templates/corinthians-twitter/workflows/soccer-live-event.yml
@@ -7,10 +7,13 @@ workflow:
       enabled: true
     api-football:
       api_key: "$MACHINA_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
-    openai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -243,9 +246,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/corinthians-twitter/workflows/soccer-news.yml
+++ b/agent-templates/corinthians-twitter/workflows/soccer-news.yml
@@ -5,10 +5,13 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    openai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   
   tasks:
     
@@ -109,9 +112,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/corinthians-twitter/workflows/soccer-pre-event.yml
+++ b/agent-templates/corinthians-twitter/workflows/soccer-pre-event.yml
@@ -7,10 +7,13 @@ workflow:
       enabled: true
     api-football:
       api_key: "$MACHINA_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
-    openai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -133,9 +136,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/coverage-tools/_install.yml
+++ b/agent-templates/coverage-tools/_install.yml
@@ -8,7 +8,7 @@ setup:
     - AI Agent to assist moderators to create content for Coverage Tools.
   status: available
   integrations:
-    - machina-ai
+    - google-genai
   value: agent-templates/coverage-tools
   version: 1.0.0
 

--- a/agent-templates/event-podcast/_install.yml
+++ b/agent-templates/event-podcast/_install.yml
@@ -10,7 +10,6 @@ setup:
     - "Uploads the resulting audio file to cloud storage and returns its path."
   integrations:
     - google-genai
-    - machina-ai
     - storage
   status: available
   value: "agent-templates/event-podcast"

--- a/agent-templates/event-podcast/event-podcast.yml
+++ b/agent-templates/event-podcast/event-podcast.yml
@@ -9,8 +9,6 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     storage:
       api_key: "$TEMP_CONTEXT_VARIABLE_AZURE_BLOB_STRING"
   inputs:

--- a/agent-templates/iptc-mappings/_install.yml
+++ b/agent-templates/iptc-mappings/_install.yml
@@ -10,6 +10,8 @@ setup:
     - iptc
     - api-football
     - sportradar
+    - google-genai
+    - vertex-embedding
   status: available
   value: "agent-templates/iptc-mappings"
   version: 1.0.0

--- a/agent-templates/iptc-mappings/any-source/custom-event-test.yml
+++ b/agent-templates/iptc-mappings/any-source/custom-event-test.yml
@@ -8,9 +8,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     custom-instruction: "$.get('custom_instruction') or None"
   outputs:
@@ -26,6 +29,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         _custom-instruction: "$.get('custom-instruction')"
       outputs:
@@ -56,9 +61,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "'sport:Event'"
       documents:
         items: "$.get('parsed_event', [])"

--- a/agent-templates/kalshi-market-agent/_install.yml
+++ b/agent-templates/kalshi-market-agent/_install.yml
@@ -11,7 +11,7 @@ setup:
     - Analyze market trends and identify high-volume opportunities
   integrations:
     - kalshi
-    - machina-ai
+    - google-genai
   status: available
   value: agent-templates/kalshi-market-agent
   version: 1.0.0

--- a/agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml
+++ b/agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml
@@ -9,8 +9,6 @@ workflow:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     seasonId: $.get('seasonId')
   outputs:

--- a/agent-templates/kalshi-market-agent/workflows/event-matcher.yml
+++ b/agent-templates/kalshi-market-agent/workflows/event-matcher.yml
@@ -7,8 +7,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     limit: $.get('limit', 50)
     market_id: $.get('market_id', None)

--- a/agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml
+++ b/agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml
@@ -5,8 +5,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     event_code: $.get('event_code')
   outputs:

--- a/agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml
+++ b/agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml
@@ -9,8 +9,6 @@ workflow:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     document_id: $.get('document_id')
   outputs:

--- a/agent-templates/kalshi-market-agent/workflows/market-analysis/update.yml
+++ b/agent-templates/kalshi-market-agent/workflows/market-analysis/update.yml
@@ -5,8 +5,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
   inputs:
     document_id: $.get('document_id')
     is_market_analysis_finished: $.get('is_market_analysis_finished', False)

--- a/agent-templates/machina-assistant/_install.yml
+++ b/agent-templates/machina-assistant/_install.yml
@@ -13,8 +13,8 @@ setup:
     - Context-aware conversation threads
   status: available
   integrations:
-    - machina-ai
-    - google-vertex
+    - google-genai
+    - vertex-embedding
   value: agent-templates/machina-assistant
   version: 1.0.0
 

--- a/agent-templates/machina-assistant/_populate-knowledge.yml
+++ b/agent-templates/machina-assistant/_populate-knowledge.yml
@@ -6,8 +6,9 @@ workflow:
   context-variables:
     debugger:
       enabled: false
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   
   outputs:
     workflow-status: "'executed'"
@@ -23,9 +24,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -47,9 +48,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -71,9 +72,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -95,9 +96,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -119,9 +120,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -143,15 +144,15 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
             'title': 'Document Database and Vector Search',
             'category': 'database',
-            'content': 'Document Database: Document Structure includes _id (unique identifier), name (document type like sport:Event, content-snippet, thread, etc.), value (content as JSON object), metadata (additional filterable fields), and embedding (vector for semantic search). Operations: save (create new documents), search (find with filters), update (modify existing), bulk-update (update multiple documents). Vector Search: Use embeddings for semantic search by setting search-vector to true, providing connector for embeddings (text-embedding-3-small), and configuring thresholds for similarity. Common Document Types: sport:Event (sports matches/events), sport:Team (team information), content-snippet (knowledge articles), thread (conversation threads), game-market (betting markets). Best Practices: Use meaningful document names, add comprehensive metadata, enable embeddings for semantic search, batch operations when possible.',
+            'content': 'Document Database: Document Structure includes _id (unique identifier), name (document type like sport:Event, content-snippet, thread, etc.), value (content as JSON object), metadata (additional filterable fields), and embedding (vector for semantic search). Operations: save (create new documents), search (find with filters), update (modify existing), bulk-update (update multiple documents). Vector Search: Use embeddings for semantic search by setting search-vector to true, providing connector for embeddings (text-embedding-004), and configuring thresholds for similarity. Common Document Types: sport:Event (sports matches/events), sport:Team (team information), content-snippet (knowledge articles), thread (conversation threads), game-market (betting markets). Best Practices: Use meaningful document names, add comprehensive metadata, enable embeddings for semantic search, batch operations when possible.',
             'tags': ['database', 'mongodb', 'vector-search', 'embeddings', 'documents']
           }
       metadata:
@@ -167,9 +168,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -191,9 +192,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -215,9 +216,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {
@@ -239,9 +240,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         machina-knowledge: |
           {

--- a/agent-templates/machina-assistant/workflows/assistant-reasoning.yml
+++ b/agent-templates/machina-assistant/workflows/assistant-reasoning.yml
@@ -11,8 +11,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   

--- a/agent-templates/machina-assistant/workflows/assistant-response.yml
+++ b/agent-templates/machina-assistant/workflows/assistant-response.yml
@@ -11,8 +11,9 @@ workflow:
     google-genai:
       credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
       project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
     machina-ai-fast:
       api_key: $TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY
   
@@ -64,9 +65,9 @@ workflow:
         search-limit: 100
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'machina-knowledge'"
         search-query: $.get('reasoning', {}).get('search_query')

--- a/agent-templates/nfl-2025-preseason/_install.yml
+++ b/agent-templates/nfl-2025-preseason/_install.yml
@@ -25,7 +25,7 @@ datasets:
     
   # connectors
   - type: "connector"
-    path: "../../connectors/machina-ai/machina-ai.yml"
+    path: "../../connectors/vertex-embedding/vertex-embedding.yml"
 
   - type: "connector"
     path: "../../connectors/machina-ai-fast/machina-ai-fast.yml"

--- a/agent-templates/nfl-2025-preseason/players-update.yml
+++ b/agent-templates/nfl-2025-preseason/players-update.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     player_id: "$.get('player_id')"
   outputs:

--- a/agent-templates/nfl-2025-preseason/search-players.yml
+++ b/agent-templates/nfl-2025-preseason/search-players.yml
@@ -6,9 +6,9 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     query: "$.get('query')"
   outputs:
@@ -22,7 +22,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
-        # model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         query: "$.get('query')"
       outputs:
@@ -60,7 +61,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-pro"
-        # model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         players: "$.get('players', [])"
       outputs:

--- a/agent-templates/nfl-2025-preseason/sync-games.yml
+++ b/agent-templates/nfl-2025-preseason/sync-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2025')"
     season_type: "$.get('season_type', 'PRE')"

--- a/agent-templates/nfl-2025-preseason/sync-players.yml
+++ b/agent-templates/nfl-2025-preseason/sync-players.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     team_id: "$.get('team_id')"
   outputs:

--- a/agent-templates/nfl-2025-preseason/sync-teams.yml
+++ b/agent-templates/nfl-2025-preseason/sync-teams.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   outputs:
     events: "$.get('events')"
     workflow-status: "$.get('events', []) is None and 'skipped' or 'executed'"

--- a/agent-templates/nfl-2025-preseason/teams-update.yml
+++ b/agent-templates/nfl-2025-preseason/teams-update.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     team_id: "$.get('team_id')"
   outputs:

--- a/agent-templates/nfl-2025-preseason/thread-executor.yml
+++ b/agent-templates/nfl-2025-preseason/thread-executor.yml
@@ -6,9 +6,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     storage:
@@ -35,9 +38,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         name: "'thread'"
         value.status: "$.get('input_status')"
@@ -57,9 +60,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {
@@ -75,13 +78,11 @@ workflow:
       description: "Draft NFL Search Players."
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4.1"
-        # name: "google-genai"
-        # command: "invoke_prompt"
-        # model: "gemini-2.5-pro"
-        # model: "gemini-2.5-flash"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         question: "$.get('question')"
       outputs:
@@ -153,13 +154,11 @@ workflow:
       description: "Draft NFL Select Players."
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4.1"
-        # name: "google-genai"
-        # command: "invoke_prompt"
-        # model: "gemini-2.5-pro"
-        # model: "gemini-2.5-flash"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         players: "$.get('players', [])"
       outputs:
@@ -205,9 +204,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         _id: "$.get('document_id')"
       inputs:
@@ -225,9 +224,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {

--- a/agent-templates/nfl-podcast-generator/_install.yml
+++ b/agent-templates/nfl-podcast-generator/_install.yml
@@ -17,7 +17,7 @@ datasets:
 
   # connectors
   - type: "connector"
-    path: "../../connectors/machina-ai/machina-ai.yml"
+    path: "../../connectors/vertex-embedding/vertex-embedding.yml"
 
   - type: "connector"
     path: "../../connectors/machina-ai-fast/machina-ai-fast.yml"

--- a/agent-templates/nfl-podcast-generator/generate-content.yml
+++ b/agent-templates/nfl-podcast-generator/generate-content.yml
@@ -6,9 +6,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -30,9 +33,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -48,6 +51,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"

--- a/agent-templates/nfl-podcast-generator/generate-speech.yml
+++ b/agent-templates/nfl-podcast-generator/generate-speech.yml
@@ -6,9 +6,9 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     storage:
@@ -35,9 +35,9 @@ workflow:
     #     search-limit: 1000
     #     search-vector: true
     #   connector:
-    #     name: "machina-ai"
+    #     name: "vertex-embedding"
     #     command: "invoke_embedding"
-    #     model: "text-embedding-3-small"
+    #     model: "text-embedding-004"
     #   inputs:
     #     name: "'content-snippet'"
     #     search-limit: "'1000'"
@@ -68,6 +68,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"

--- a/agent-templates/nfl-podcast-generator/sync-nfl-games.yml
+++ b/agent-templates/nfl-podcast-generator/sync-nfl-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2024')"
     season_type: "$.get('season_type', 'REG')"

--- a/agent-templates/nfl-podcast-generator/sync-nfl-team.yml
+++ b/agent-templates/nfl-podcast-generator/sync-nfl-team.yml
@@ -6,11 +6,14 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
     sportradar-nfl:
       sportradar_api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     team_id: "$.get('team_id') or None"
   outputs:
@@ -134,6 +137,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         team_home_name: "$.get('team_home_name')"
@@ -166,9 +171,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/nfl-podcast-generator/thread-executor.yml
+++ b/agent-templates/nfl-podcast-generator/thread-executor.yml
@@ -6,9 +6,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     storage:
@@ -35,9 +38,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         name: "'thread'"
         value.status: "$.get('input_status')"
@@ -57,9 +60,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {
@@ -81,9 +84,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -106,6 +109,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"
@@ -153,9 +158,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         _id: "$.get('document_id')"
       inputs:
@@ -173,9 +178,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {

--- a/agent-templates/onboarding/_install.yml
+++ b/agent-templates/onboarding/_install.yml
@@ -17,7 +17,9 @@ datasets:
 
   # connectors
   - type: "connector"
-    path: "../../connectors/machina-ai/machina-ai.yml"
+    path: "../../connectors/google-genai/google-genai.yml"
+  - type: "connector"
+    path: "../../connectors/vertex-embedding/vertex-embedding.yml"
   - type: "connector"
     path: "../../connectors/machina-ai-fast/machina-ai-fast.yml"
   - type: "connector"

--- a/agent-templates/onboarding/chat-completions.yml
+++ b/agent-templates/onboarding/chat-completions.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -27,9 +32,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -48,9 +53,11 @@ workflow:
         # model: "llama-3.1-8b-instant"
         # model: "deepseek-r1-distill-llama-70b"
         # model: "deepseek-r1-distill-llama-70b-specdec"
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"

--- a/agent-templates/onboarding/embed-nba.yml
+++ b/agent-templates/onboarding/embed-nba.yml
@@ -7,8 +7,13 @@ workflow:
       enabled: true
     sportradar-nba:
       sportradar_api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -118,9 +123,11 @@ workflow:
       description: "Embedding standings."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         standings: "$.get('result-standings')"
@@ -209,9 +216,11 @@ workflow:
       description: "Embedding h2h comparison."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         home-competitor: "$.get('result-home-competitor')"
@@ -271,9 +280,11 @@ workflow:
       description: "Embedding players to watch."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         home-competitor-profile: "$.get('result-home-competitor-profile')"
@@ -338,9 +349,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/onboarding/soccer-embeddings.yml
+++ b/agent-templates/onboarding/soccer-embeddings.yml
@@ -7,8 +7,13 @@ workflow:
       enabled: true
     sportradar-soccer:
       sportradar_api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -118,9 +123,11 @@ workflow:
       description: "Embedding standings."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         standings: "$.get('result-standings')"
@@ -209,9 +216,11 @@ workflow:
       description: "Embedding h2h comparison."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         home-competitor: "$.get('result-home-competitor')"
@@ -271,9 +280,11 @@ workflow:
       description: "Embedding players to watch."
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         home-competitor-profile: "$.get('result-home-competitor-profile')"
@@ -338,9 +349,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/onboarding/sync-mlb-games.yml
+++ b/agent-templates/onboarding/sync-mlb-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-mlb:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2024')"
     season_type: "$.get('season_type', 'REG')"

--- a/agent-templates/onboarding/sync-nba-embeds.yml
+++ b/agent-templates/onboarding/sync-nba-embeds.yml
@@ -7,8 +7,13 @@ workflow:
       enabled: true
     sportradar-nba:
       sportradar_api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -126,9 +131,11 @@ workflow:
       description: "Embed event details."
       condition: "$.get('event_exists') is True"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         team_home_name: "$.get('team_home_name')"
@@ -163,9 +170,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/onboarding/sync-nba-games.yml
+++ b/agent-templates/onboarding/sync-nba-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nba:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2024')"
     season_type: "$.get('season_type', 'REG')"

--- a/agent-templates/onboarding/sync-nba-team.yml
+++ b/agent-templates/onboarding/sync-nba-team.yml
@@ -7,8 +7,13 @@ workflow:
       enabled: true
     sportradar-nba:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     team_id: "$.get('team_id') or None"
   outputs:
@@ -109,9 +114,11 @@ workflow:
       description: "Generate comprehensive NBA team summary with championship history"
       condition: "$.get('team-profile') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         team_name: "$.get('team_name')"
         team_market: "$.get('team_market')"
@@ -144,9 +151,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('snippets_list')"

--- a/agent-templates/onboarding/sync-nfl-embeds.yml
+++ b/agent-templates/onboarding/sync-nfl-embeds.yml
@@ -7,8 +7,13 @@ workflow:
       enabled: true
     sportradar-nfl:
       sportradar_api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -127,9 +132,11 @@ workflow:
       description: "Embed event details."
       condition: "$.get('event_exists') is True"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         title: "$.get('title')"
         team_home_name: "$.get('team_home_name')"
@@ -161,9 +168,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/onboarding/sync-nfl-games.yml
+++ b/agent-templates/onboarding/sync-nfl-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2024')"
     season_type: "$.get('season_type', 'REG')"

--- a/agent-templates/onboarding/sync-nfl-team.yml
+++ b/agent-templates/onboarding/sync-nfl-team.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nfl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     team_id: "$.get('team_id') or None"
   outputs:

--- a/agent-templates/onboarding/sync-nhl-games.yml
+++ b/agent-templates/onboarding/sync-nhl-games.yml
@@ -7,8 +7,6 @@ workflow:
       enabled: true
     sportradar-nhl:
       api_key: "$TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     season_year: "$.get('season_year', '2024')"
     season_type: "$.get('season_type', 'REG')"

--- a/agent-templates/onboarding/thread-executor.yml
+++ b/agent-templates/onboarding/thread-executor.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -31,9 +32,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         name: "'thread'"
         value.status: "$.get('input_status')"
@@ -53,9 +54,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {
@@ -77,9 +78,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         metadata.event_code: "$.get('event_code')"
       inputs:
@@ -103,9 +104,6 @@ workflow:
         # model: "llama-3.3-70b-versatile"
         # model: "deepseek-r1-distill-llama-70b"
         # model: "deepseek-r1-distill-llama-70b-specdec"
-        #  name: "machina-ai"
-        #  command: "invoke_prompt"
-        #  model: "gpt-4o"
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"
@@ -123,9 +121,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         _id: "$.get('document_id')"
       inputs:
@@ -143,9 +141,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {

--- a/agent-templates/personalized-podcast/_install.yml
+++ b/agent-templates/personalized-podcast/_install.yml
@@ -8,8 +8,8 @@ setup:
     - AI Agent to generate personalized podcast content based on user profile.
     - AI Reporter to generate personalized podcast content based on user profile.
   integrations:
-    - machina-ai
     - google-genai
+    - vertex-embedding
     - google-storage
     - api-mailgun
     - oxylabs

--- a/agent-templates/personalized-podcast/workflows/compose-and-send-email.yml
+++ b/agent-templates/personalized-podcast/workflows/compose-and-send-email.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     api-mailgun:
       username: "api"
       password: "$TEMP_CONTEXT_VARIABLE_MAILGUN_API_KEY"
@@ -36,9 +37,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: "$.get('document_id')"
       inputs:

--- a/agent-templates/personalized-podcast/workflows/generate-audio.yml
+++ b/agent-templates/personalized-podcast/workflows/generate-audio.yml
@@ -12,8 +12,9 @@ workflow:
     google-storage:
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY
       bucket_name: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     document_id: "$.get('document_id')"
     language: "$.get('language', 'en')"
@@ -35,9 +36,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: "$.get('document_id')"
       inputs:

--- a/agent-templates/personalized-podcast/workflows/generate-content.yml
+++ b/agent-templates/personalized-podcast/workflows/generate-content.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     google-genai:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
@@ -30,9 +31,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: "$.get('document_id')"
       inputs:

--- a/agent-templates/personalized-podcast/workflows/generate-image.yml
+++ b/agent-templates/personalized-podcast/workflows/generate-image.yml
@@ -12,8 +12,9 @@ workflow:
     google-storage:
       api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY
       bucket_name: $TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME
-    machina-ai:
-      api_key: $TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     oxylabs:
       username: $TEMP_CONTEXT_VARIABLE_OXYLABS_USERNAME
       password: $TEMP_CONTEXT_VARIABLE_OXYLABS_PASSWORD
@@ -41,9 +42,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         document_id: "$.get('document_id')"
       inputs:

--- a/agent-templates/personalized-podcast/workflows/store-user-profile.yml
+++ b/agent-templates/personalized-podcast/workflows/store-user-profile.yml
@@ -5,8 +5,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     name: "$.get('name')"
     favorite_sport: "$.get('favorite_sport')"

--- a/agent-templates/psg-podcast-generator/_install.yml
+++ b/agent-templates/psg-podcast-generator/_install.yml
@@ -9,7 +9,7 @@ setup:
     - AI Reporter to generate PSG podcasts.
   integrations:
     - google-genai
-    - machina-ai
+    - vertex-embedding
     - machina-ai-fast
     - storage
   status: available

--- a/agent-templates/psg-podcast-generator/event-analyzer.yml
+++ b/agent-templates/psg-podcast-generator/event-analyzer.yml
@@ -9,8 +9,9 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code', [])"
   outputs:
@@ -75,9 +76,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/psg-podcast-generator/generate-content.yml
+++ b/agent-templates/psg-podcast-generator/generate-content.yml
@@ -9,8 +9,9 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -32,9 +33,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"

--- a/agent-templates/psg-podcast-generator/generate-speech.yml
+++ b/agent-templates/psg-podcast-generator/generate-speech.yml
@@ -9,8 +9,6 @@ workflow:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     storage:
@@ -37,9 +35,9 @@ workflow:
     #     search-limit: 1000
     #     search-vector: true
     #   connector:
-    #     name: "machina-ai"
+    #     name: "vertex-embedding"
     #     command: "invoke_embedding"
-    #     model: "text-embedding-3-small"
+    #     model: "text-embedding-004"
     #   inputs:
     #     name: "'content-snippet'"
     #     search-limit: "'1000'"

--- a/agent-templates/psg-podcast-generator/thread-executor.yml
+++ b/agent-templates/psg-podcast-generator/thread-executor.yml
@@ -6,9 +6,12 @@ workflow:
     debugger:
       enabled: true
     google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
     storage:
@@ -35,9 +38,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         name: "'thread'"
         value.status: "$.get('input_status')"
@@ -57,9 +60,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {
@@ -81,9 +84,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -106,6 +109,8 @@ workflow:
         name: "google-genai"
         command: "invoke_prompt"
         model: "gemini-2.5-flash"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"
@@ -153,9 +158,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         _id: "$.get('document_id')"
       inputs:
@@ -173,9 +178,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {

--- a/agent-templates/roast-agent/_install.yml
+++ b/agent-templates/roast-agent/_install.yml
@@ -9,7 +9,6 @@ setup:
     - Source citations with explanations accessible via "why?" feature
     - JSON API response optimized for mobile app consumption
   integrations:
-    - machina-ai
     - google-genai
     - oxylabs
     - grok

--- a/agent-templates/roast-agent/workflows/generate-roast.yml
+++ b/agent-templates/roast-agent/workflows/generate-roast.yml
@@ -5,8 +5,6 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
     google-genai:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"

--- a/agent-templates/social-media-generator/_install.yml
+++ b/agent-templates/social-media-generator/_install.yml
@@ -25,7 +25,6 @@ setup:
     - api-football
     - google-genai
     - google-storage
-    - machina-ai
   status: available
   value: agent-templates/social-media-generator
   version: 1.0.0

--- a/agent-templates/social-media-generator/workflows/generate-content.yml
+++ b/agent-templates/social-media-generator/workflows/generate-content.yml
@@ -14,8 +14,6 @@ workflow:
     google-storage:
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY"
       bucket_name: "$TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     event_id: "$.get('event_id')"
     content_types: "$.get('content_types', ['meme', 'stats', 'quiz'])"

--- a/agent-templates/social-media-generator/workflows/generate-image.yml
+++ b/agent-templates/social-media-generator/workflows/generate-image.yml
@@ -12,8 +12,6 @@ workflow:
     google-storage:
       api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_API_KEY"
       bucket_name: "$TEMP_CONTEXT_VARIABLE_GOOGLE_STORAGE_BUCKET_NAME"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
   inputs:
     suggestion_id: "$.get('suggestion_id')"
     custom_prompt: "$.get('custom_prompt', '')"

--- a/agent-templates/template-fastf1/_install.yml
+++ b/agent-templates/template-fastf1/_install.yml
@@ -21,7 +21,9 @@ datasets:
   - type: "connector"
     path: "../../connectors/fastf1/fastf1.yml"
   - type: "connector"
-    path: "../../connectors/machina-ai/machina-ai.yml"
+    path: "../../connectors/google-genai/google-genai.yml"
+  - type: "connector"
+    path: "../../connectors/vertex-embedding/vertex-embedding.yml"
 
   # workflows
   - type: "workflow"

--- a/agent-templates/template-fastf1/race-results.yml
+++ b/agent-templates/template-fastf1/race-results.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event: "$.get('event') or None"
     year: "$.get('year') or None"
@@ -31,9 +36,11 @@ workflow:
       name: "prompt-race-result-analysis"
       description: "Prompt to analyze race results."
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         race_results: "$.get('race_results')"
       outputs:
@@ -62,9 +69,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-newsletter/_install.yml
+++ b/agent-templates/template-newsletter/_install.yml
@@ -8,11 +8,9 @@ setup:
     - AI Agent to generate a personalized newsletter.
     - AI Reporter to generate a personalized newsletter.
   integrations:
-    - machina-ai
     - machina-ai-fast
     - groq
-    - openai
-    - google-vertex
+    - google-genai
   status: available
   value: "agent-templates/template-newsletter"
   version: 1.0.0

--- a/agent-templates/template-quizzes/_install.yml
+++ b/agent-templates/template-quizzes/_install.yml
@@ -7,7 +7,8 @@ setup:
   features:
     - Quizzes
   integrations:
-    - machina-ai
+    - google-genai
+    - vertex-embedding
   status: available
   value: agent-templates/template-quizzes
   version: 1.1.0
@@ -16,7 +17,9 @@ datasets:
 
   # connectors
   - type: "connector"
-    path: "../../connectors/machina-ai/machina-ai.yml"
+    path: "../../connectors/google-genai/google-genai.yml"
+  - type: "connector"
+    path: "../../connectors/vertex-embedding/vertex-embedding.yml"
   - type: "connector"
     path: "../../connectors/machina-ai-fast/machina-ai-fast.yml"
 

--- a/agent-templates/template-quizzes/chat-completions.yml
+++ b/agent-templates/template-quizzes/chat-completions.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     machina-ai-fast:
       api_key: "$TEMP_CONTEXT_VARIABLE_SDK_GROQ_API_KEY"
   inputs:
@@ -27,9 +32,9 @@ workflow:
         search-limit: 1000
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'content-snippet'"
         search-limit: "'1000'"
@@ -48,9 +53,11 @@ workflow:
         # model: "llama-3.1-8b-instant"
         # model: "deepseek-r1-distill-llama-70b"
         # model: "deepseek-r1-distill-llama-70b-specdec"
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         documents: "$.get('documents')"
         messages: "$.get('messages')"

--- a/agent-templates/template-quizzes/quizzes-by-topic.yml
+++ b/agent-templates/template-quizzes/quizzes-by-topic.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     debugger:
       enabled: true
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     topic: "$.get('topic') or None"
   outputs:
@@ -21,9 +26,11 @@ workflow:
       description: "Generate a briefing by topic."
       condition: "$.get('topic') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         topic: "$.get('topic')"
       outputs:
@@ -47,9 +54,9 @@ workflow:
         action: "bulk-save"
         embed-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed_items')"
@@ -65,9 +72,11 @@ workflow:
       description: "Generate a quiz by topic."
       condition: "$.get('topic') is not None"
       connector:
-        name: "machina-ai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         data-briefing: "$.get('content-briefing')"
         data-topic: "$.get('topic')"
@@ -83,9 +92,9 @@ workflow:
         action: "bulk-save"
         embed-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-quiz"
       documents:
         items: "$.get('parsed_items')"

--- a/agent-templates/template-sportsblog/_install.yml
+++ b/agent-templates/template-sportsblog/_install.yml
@@ -21,15 +21,13 @@ setup:
   integrations:
     - sportradar
     - machina-db
-    - machina-ai
+    - google-genai
     - hubspot
   status: available
   version: 1.0.0
   datasets:
 
   # connectors
-  - type: "connector"
-    path: "../connectors/openai/openai.yml"
   - type: "connector"
     path: "../connectors/perplexity/perplexity.yml"
   - type: "connector"

--- a/agent-templates/template-superbowl-lix/_install.yml
+++ b/agent-templates/template-superbowl-lix/_install.yml
@@ -14,7 +14,8 @@ setup:
     - AI Highlights
   integrations:
     - sportradar
-    - machina-ai
+    - google-genai
+    - vertex-embedding
   status: available
   value: agent-templates/template-superbowl-lix
   version: 1.0.0
@@ -25,7 +26,9 @@ datasets:
   - type: "connector"
     path: "../connectors/groq/groq.yml"
   - type: "connector"
-    path: "../connectors/openai/openai.yml"
+    path: "../connectors/google-genai/google-genai.yml"
+  - type: "connector"
+    path: "../connectors/vertex-embedding/vertex-embedding.yml"
   - type: "connector"
     path: "../connectors/sportradar-nfl/sportradar-nfl.yml"
 

--- a/agent-templates/template-superbowl-lix/completion.yml
+++ b/agent-templates/template-superbowl-lix/completion.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     groq:
       api_key: "$MACHINA_CONTEXT_VARIABLE_GROQ_API_KEY"
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "'ca9d8f84-8e7b-4ee7-a310-54c2e3ca4edc'"
     event_type: "$.get('event_type', 'content-snippet')"
@@ -31,9 +32,9 @@ workflow:
         search-limit: 1
         search-vector: false
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         name: "'thread'"
         value.status: "$.get('input_status')"
@@ -52,9 +53,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {
@@ -74,9 +75,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "$.get('event_type')"
         search-limit: "'5'"
@@ -96,9 +97,9 @@ workflow:
         search-vector: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "$.get('event_type')"
         search-limit: "'1000'"
@@ -140,7 +141,6 @@ workflow:
         model: "deepseek-r1-distill-llama-70b"
         #name: "openai"
         command: "invoke_prompt"
-        #model: "gpt-4o-mini"
       inputs:
         documents: |
           [
@@ -191,9 +191,9 @@ workflow:
         search-vector: false
       condition: "$.get('document_id') is not None"
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       filters:
         _id: "$.get('document_id')"
       inputs:
@@ -211,9 +211,9 @@ workflow:
         force-update: true
       condition: "$.get('document_id') is not None"
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       documents:
         thread: |
           {

--- a/agent-templates/template-superbowl-lix/exe-briefing.yml
+++ b/agent-templates/template-superbowl-lix/exe-briefing.yml
@@ -3,8 +3,13 @@ workflow:
   title: "Reporter Briefing"
   description: "Workflow to produce briefing in English."
   context-variables:
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -106,9 +111,11 @@ workflow:
       description: "Summarize the Briefing for the upcoming game"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         input_event: "$.get('event_selected')"
       outputs:
@@ -133,9 +140,11 @@ workflow:
       description: "Summarize the Briefing for the upcoming game"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         input_event: "$.get('content-briefing-match', {}).get('sections', [])"
         team-summary: "$.get('event-summary').get('home-team', {})"
@@ -161,9 +170,11 @@ workflow:
       description: "Summarize the Briefing for the upcoming game"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         input_event: "$.get('content-briefing-match', {}).get('sections', [])"
         team-summary: "$.get('event-summary').get('away-team', {})"
@@ -215,9 +226,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/exe-comparison.yml
+++ b/agent-templates/template-superbowl-lix/exe-comparison.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     sportradar-nfl:
       sportradar_api_key: "$MACHINA_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -189,9 +194,11 @@ workflow:
       description: "Analyze the key players from both teams, highlighting the strengths and weaknesses of each player."
       condition: "$.get('item_exists') is True and $.get('player1_id') is not None and $.get('player2_id') is not None"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-title: "$.get('title')"
         player1-name: "$.get('player1-name')"
@@ -243,9 +250,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/exe-gamerecap.yml
+++ b/agent-templates/template-superbowl-lix/exe-gamerecap.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     sportradar-nfl:
       sportradar_api_key: "$MACHINA_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
     debugger:
       enabled: true
   inputs:
@@ -156,9 +161,11 @@ workflow:
       description: "Generate a recap of the game, highlighting the key moments and insights."
       condition: "$.get('event_exists') is True and $.get('event-boxscore', {}).get('status', '') is not 'inprogress'"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         # data-event-boxscore: "$.get('event-boxscore', {})"
         data-summary-home: "$.get('event-statistics', {}).get('summary', {}).get('home', {})"
@@ -208,9 +215,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"
@@ -230,9 +237,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-insights"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/exe-insights.yml
+++ b/agent-templates/template-superbowl-lix/exe-insights.yml
@@ -3,8 +3,13 @@ workflow:
   title: "Reporter Insights"
   description: "Workflow to produce insights."
   context-variables:
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -125,9 +130,11 @@ workflow:
       description: "Generate a comprehensive game predictions, covering different aspects that could influence the game outcome."
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-briefing: "$.get('event-briefing')"
       outputs:
@@ -174,9 +181,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/exe-keyplayers.yml
+++ b/agent-templates/template-superbowl-lix/exe-keyplayers.yml
@@ -3,8 +3,13 @@ workflow:
   title: "Reporter Key Players"
   description: "Workflow to produce key players."
   context-variables:
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -126,9 +131,11 @@ workflow:
       description: "Select the key players from both teams, highlighting the strengths and weaknesses of each player."
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-briefing: "$.get('event-briefing')"
         home-players-data: "$.get('event-summary').get('home-team').get('players')"
@@ -162,9 +169,9 @@ workflow:
         embed-vector: false
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "player-comparison"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/exe-teamstats.yml
+++ b/agent-templates/template-superbowl-lix/exe-teamstats.yml
@@ -3,8 +3,13 @@ workflow:
   title: "Reporter Team Statistics"
   description: "Workflow to produce team statistics."
   context-variables:
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -126,9 +131,11 @@ workflow:
       description: "comprehensive team statistics across all phases of the game"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-briefing: "$.get('event-briefing')"
         home-team-stats: "$.get('event-summary').get('home-team-stats').get('record')"
@@ -154,9 +161,11 @@ workflow:
       description: "comprehensive team statistics across all phases of the game"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-briefing: "$.get('event-briefing')"
         away-team-stats: "$.get('event-summary').get('away-team-stats').get('record')"
@@ -182,9 +191,11 @@ workflow:
       description: "head-to-head performance between the two teams"
       condition: "$.get('event_exists') is True and $.get('event-summary_exists') is True"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         event-briefing: "$.get('event-briefing')"
         home-team-stats: "$.get('event-summary').get('home-team-stats').get('record')"
@@ -236,9 +247,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/live-updates.yml
+++ b/agent-templates/template-superbowl-lix/live-updates.yml
@@ -5,8 +5,13 @@ workflow:
   context-variables:
     sportradar-nfl:
       sportradar_api_key: "$MACHINA_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    google-genai:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
+      api_key: "$TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
   outputs:
@@ -155,9 +160,11 @@ workflow:
       description: "Generate a live narration of the game, highlighting the key moments and insights."
       condition: "$.get('event_exists') is True and $.get('event-boxscore', {}).get('status', '') == 'inprogress'"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         data-event-boxscore: "$.get('event-boxscore', {}).get('last_event', {})"
       outputs:
@@ -169,9 +176,11 @@ workflow:
       description: "Generate a live summary of the game, highlighting the key moments and insights."
       condition: "$.get('event_exists') is True and $.get('event-boxscore', {}).get('status', '') == 'inprogress'"
       connector:
-        name: "openai"
+        name: "google-genai"
         command: "invoke_prompt"
-        model: "gpt-4o"
+        model: "gemini-2.5-pro"
+        location: global
+        provider: vertex_ai
       inputs:
         data-event-boxscore: "$.get('event-boxscore', {}).get('last_event', {})"
       outputs:
@@ -218,9 +227,9 @@ workflow:
         embed-vector: true
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "content-snippet"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/template-superbowl-lix/sync-teams.yml
+++ b/agent-templates/template-superbowl-lix/sync-teams.yml
@@ -5,8 +5,9 @@ workflow:
   context-variables:
     sportradar-nfl:
       sportradar_api_key: "$MACHINA_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY"
-    openai:
-      api_key: "$MACHINA_CONTEXT_VARIABLE_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     event_code: "$.get('event_code') or None"
     season_year: "$.get('season_year') or None"
@@ -208,9 +209,9 @@ workflow:
         embed-vector: false
         force-update: true
       connector:
-        name: "openai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       document_name: "player-profile"
       documents:
         items: "$.get('parsed-items')"

--- a/agent-templates/voice-chat-completion/_install.yml
+++ b/agent-templates/voice-chat-completion/_install.yml
@@ -8,7 +8,8 @@ setup:
     - AI Agent to generate chat completions from voice input.
     - Server-side audio processing.
   integrations:
-    - machina-ai
+    - google-genai
+    - vertex-embedding
     - google-speech-to-text
     - google-storage
   status: available

--- a/agent-templates/voice-chat-completion/workflows/voice-chat.yml
+++ b/agent-templates/voice-chat-completion/workflows/voice-chat.yml
@@ -13,8 +13,9 @@ workflow:
     google-genai:
       credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
       project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
-    machina-ai:
-      api_key: "$TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY"
+    vertex-embedding:
+      credential: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL"
+      project_id: "$TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID"
   inputs:
     audio_base64: "$.get('audio_base64')"
     audio_path: "$.get('audio_path')"
@@ -77,9 +78,9 @@ workflow:
         search-limit: 100
         search-vector: true
       connector:
-        name: "machina-ai"
+        name: "vertex-embedding"
         command: "invoke_embedding"
-        model: "text-embedding-3-small"
+        model: "text-embedding-004"
       inputs:
         name: "'machina-knowledge'"
         search-limit: "'100'"


### PR DESCRIPTION
## Summary

- Replace all `machina-ai` LLM connectors (`gpt-4o`/`gpt-4.1`) with `google-genai` (`gemini-2.5-pro`/`gemini-2.5-flash`) + `location: global` / `provider: vertex_ai`
- Replace all `machina-ai` embedding connectors (`text-embedding-3-small`) with `vertex-embedding` (`text-embedding-004`)
- Remove unused `machina-ai:` context-variables from ~20 Category C workflows (declared but never used in tasks)
- Update all `_install.yml` files: remove `machina-ai`/`openai` from integrations, add `google-genai` and/or `vertex-embedding`
- `machina-ai-fast` (Groq) preserved in all files — not affected

## Scope

103 files across 21 templates: `assistant-tools`, `bundesliga-podcast`, `chat-completion`, `corinthians-twitter`, `event-podcast`, `iptc-mappings`, `kalshi-market-agent`, `machina-assistant`, `nfl-2025-preseason`, `nfl-podcast-generator`, `onboarding`, `personalized-podcast`, `psg-podcast-generator`, `roast-agent`, `social-media-generator`, `template-fastf1`, `template-newsletter`, `template-quizzes`, `template-sportsblog`, `template-superbowl-lix`, `voice-chat-completion`

## Verification

```bash
grep -r "machina-ai:\|name: machina-ai\|text-embedding-3\|gpt-4" agent-templates/**/*.yml
# → zero results
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)