### PR TITLE
feat(manifests): add project manifests for 3 canonical agent templates

### DIFF
--- a/agent-templates/chat-completion/project.manifest.yml
+++ b/agent-templates/chat-completion/project.manifest.yml
@@ -1,0 +1,35 @@
+# Chat Completion — Project Manifest
+#
+# Minimal chat-only project: one connector, one credential, a single chat
+# loop. Useful as the "hello world" baseline for Project Health adoption.
+#
+# Smallest possible manifest — bigger projects can copy this as the starting
+# point and add their own credentials + datasets.
+
+name: chat-completion
+version: 1
+description: "Minimal chat completion project — OpenAI-backed conversational loop"
+
+required_credentials:
+  - name: TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    source_label: "OpenAI API key (platform.openai.com)"
+    test_workflow: machina-ai-test-credentials
+    validation:
+      type: http
+      method: GET
+      url: "https://api.openai.com/v1/models"
+      headers:
+        Authorization: "Bearer {value}"
+      expect_status: 200
+
+required_config_documents: []
+
+required_templates:
+  - repo: https://github.com/machina-sports/machina-templates
+    path: agent-templates/chat-completion
+    reason: "This template — chat-executor agent + reasoning/response prompts"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/machina-ai
+    reason: "OpenAI connector"
+
+depends_on_datasets: []

--- a/agent-templates/daily-football-recap/project.manifest.yml
+++ b/agent-templates/daily-football-recap/project.manifest.yml
@@ -1,0 +1,62 @@
+# Daily Football Recap — Project Manifest
+#
+# Content-pipeline example: pulls fixtures from api-football, summarises with
+# Gemini, mails out daily recap via Mailgun. Demonstrates the manifest
+# pattern for a project with content datasets + multi-credential surface.
+
+name: daily-football-recap
+version: 1
+description: "Daily football recap pipeline — api-football → Gemini summary → Mailgun email"
+
+required_credentials:
+  - name: TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    source_label: "API-Football (dashboard.api-football.com)"
+    test_workflow: api-football-test-credentials
+    validation:
+      type: http
+      method: GET
+      url: "https://v3.football.api-sports.io/status"
+      headers:
+        x-rapidapi-key: "{value}"
+      expect_status: 200
+
+  - name: TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    source_label: "Gemini API key (aistudio.google.com)"
+    test_workflow: google-genai-test-credentials
+    validation:
+      type: non_empty_string
+
+  - name: TEMP_CONTEXT_VARIABLE_MAILGUN_API_KEY
+    source_label: "Mailgun API key (app.mailgun.com/settings/api_security)"
+    test_workflow: api-mailgun-test-credentials
+    validation:
+      type: non_empty_string
+
+required_config_documents:
+  - name: daily-football-recap-config
+    description: "Subscriber emails + competitions to cover"
+
+required_templates:
+  - repo: https://github.com/machina-sports/machina-templates
+    path: agent-templates/daily-football-recap
+    reason: "This template (recap pipeline + email rendering)"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/api-football
+    reason: "Fixtures + match data"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/google-genai
+    reason: "Gemini summary generation"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/api-mailgun
+    reason: "Email delivery"
+
+depends_on_datasets:
+  - name: api-football-fixtures
+    description: "Match fixtures pulled from api-football"
+    populated_by: api-football-get-fixtures
+    min_count: 1
+
+  - name: daily-recap-content
+    description: "Generated recap articles"
+    populated_by: daily-football-recap-generate-daily-recap
+    min_count: 1

--- a/agent-templates/machina-assistant/project.manifest.yml
+++ b/agent-templates/machina-assistant/project.manifest.yml
@@ -1,0 +1,74 @@
+# Machina Assistant — Project Manifest
+#
+# Declares the live-state requirements for any project that adopts the
+# `machina-assistant` template (the foundational AI assistant for the Machina
+# platform itself — used by Studio's in-app help and by reference projects
+# learning the platform).
+#
+# Consumed by:
+#   GET /project/health                  → snapshot vs vault + datasets
+#   POST /project/bootstrap-check        → blockers/warnings/oks preflight
+#   POST /vault/validate                 → probe a credential against its rule
+#   /workflow/<id>/dependencies          → DAG status overlay (Pipeline tab)
+#
+# How to install: when a project adopts this template, POST this YAML
+# (parsed) into the project's `project_manifest` Mongo collection:
+#
+#   POST /document
+#   {
+#     "collection_name": "project_manifest",
+#     "document": { "name": "<project>", "manifest": <parsed YAML> }
+#   }
+#
+# Or wait for the auto-import-on-install backend hook (Sprint 5 follow-up).
+
+name: machina-assistant
+version: 1
+description: "Foundational AI assistant for the Machina platform — chat, reasoning, knowledge base"
+
+required_credentials:
+  - name: TEMP_CONTEXT_VARIABLE_SDK_OPENAI_API_KEY
+    source_label: "OpenAI API key (platform.openai.com)"
+    test_workflow: machina-ai-test-credentials
+    validation:
+      type: http
+      method: GET
+      url: "https://api.openai.com/v1/models"
+      headers:
+        Authorization: "Bearer {value}"
+      expect_status: 200
+
+  - name: TEMP_CONTEXT_VARIABLE_GCW_CREDENTIAL
+    source_label: "GCP service account JSON for Google Vertex (Vertex AI User role)"
+    test_workflow: google-vertex-test-credentials
+    validation:
+      type: json_object
+      required_keys:
+        - project_id
+        - private_key
+        - client_email
+
+  - name: TEMP_CONTEXT_VARIABLE_GCW_PROJECT_ID
+    source_label: "GCP project ID where Vertex AI is enabled"
+    test_workflow: google-vertex-test-credentials
+    validation:
+      type: non_empty_string
+
+required_config_documents: []
+
+required_templates:
+  - repo: https://github.com/machina-sports/machina-templates
+    path: agent-templates/machina-assistant
+    reason: "This template (assistant executor + reasoning prompts + KB)"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/machina-ai
+    reason: "OpenAI connector"
+  - repo: https://github.com/machina-sports/machina-templates
+    path: connectors/google-vertex
+    reason: "Vertex AI / Gemini connector"
+
+depends_on_datasets:
+  - name: machina-assistant-thread
+    description: "Conversation threads with the assistant"
+    populated_by: machina-assistant-thread-create
+    min_count: 0  # Brand new projects start at zero; warns only after first use.

--- a/docs/project-manifest-guide.md
+++ b/docs/project-manifest-guide.md
@@ -1,0 +1,106 @@
+# Project Manifest — Adoption Guide
+
+Adding `project.manifest.yml` next to a template's `_install.yml` makes that
+template **observable** by the Project Health endpoints + Pipeline Visualizer
+in Studio. Operators get blockers/warnings/oks instead of grepping logs.
+
+## What a manifest declares
+
+```yaml
+name: <project-or-template-name>
+version: 1
+description: "One-liner so future operators know what this is for"
+
+required_credentials:
+  - name: TEMP_CONTEXT_VARIABLE_<NAME>          # vault key name
+    source_label: "Where the operator gets it"  # shown in /project/health
+    test_workflow: <slug>-test-credentials      # workflow that exercises the key
+    validation:                                  # optional — runs on vault save + the Studio "Validate" button
+      type: http | json_object | non_empty_string
+      # http:
+      url: "https://api.example.com/probe?key={value}"
+      method: GET
+      expect_status: 200
+      headers:
+        Authorization: "Bearer {value}"
+      # json_object:
+      required_keys: [project_id, private_key, ...]
+
+required_config_documents:
+  - name: <doc-name-in-mongo>
+    description: "What it holds"
+    example_path: "configs/<file>.example.json"   # optional, relative to template root
+
+required_templates:
+  - repo: https://github.com/<org>/<repo>
+    path: <relative/path>
+    reason: "Why this is a hard dep"
+
+depends_on_datasets:
+  - name: <document.name in Mongo>
+    description: "What this dataset is"
+    populated_by: <workflow-name>
+    min_count: 50                                  # /project/health flags red if below
+```
+
+## How it gets consumed
+
+1. **`/project/health`** — passive snapshot. Cross-references each
+   `required_credentials[]` against the project's vault, each
+   `required_config_documents[]` against the `document` collection, each
+   `depends_on_datasets[]` count vs the declared `min_count`.
+
+2. **`/project/bootstrap-check`** — preflight. Same primitives, classified as
+   blockers/warnings/oks. With `trigger_tests=true` it actively fires the
+   `test_workflow` for each credential.
+
+3. **`/vault/validate`** — Studio "Validate" button. Probes the credential
+   against its declared `validation` rule before persisting.
+
+4. **`/workflow/<id>/dependencies`** — Pipeline Visualizer DAG. Status of
+   every dataset/credential node in the graph comes from the manifest cross-check.
+
+## How to install a manifest into a project
+
+The loader checks two places (in order):
+
+1. **Mongo** — collection `project_manifest`, doc shape `{ name: <project>, manifest: <parsed YAML> }`. Editable at runtime, no rebuild.
+2. **Bundled file** — `core/system/manifests/bundled/<key>.yml` in the
+   client-api image. Falls back to filename matching project name (strips
+   env suffixes: `-production`, `-prod`, `-stg`, `-dev`).
+
+To install:
+
+```bash
+# Option A: upsert into Mongo via the document API
+curl -sS -X POST -H "x-api-token: $TOKEN" -H "Content-Type: application/json" \
+  https://<your-api-host>/document \
+  -d @- <<EOF
+{
+  "collection_name": "project_manifest",
+  "document": {
+    "name": "<your-project>",
+    "manifest": $(yq eval -o=json agent-templates/<template>/project.manifest.yml)
+  }
+}
+EOF
+
+# Option B: query the endpoint with ?project=<template-name> directly to use
+# the bundled fallback (only works for client-api versions ≥ v.staging-main.134)
+curl -sS -H "x-api-token: $TOKEN" \
+  "https://<your-api-host>/project/health?project=<template-name>"
+```
+
+## Examples in this repo
+
+- [`agent-templates/machina-assistant/project.manifest.yml`](../agent-templates/machina-assistant/project.manifest.yml) — the foundational assistant (OpenAI + Vertex)
+- [`agent-templates/chat-completion/project.manifest.yml`](../agent-templates/chat-completion/project.manifest.yml) — minimal chat (single credential)
+- [`agent-templates/daily-football-recap/project.manifest.yml`](../agent-templates/daily-football-recap/project.manifest.yml) — content pipeline (3 credentials + 2 datasets)
+
+## Roadmap
+
+- **V1 (now)**: manifest opt-in, manual install per project.
+- **V2**: auto-import manifest into Mongo on template install (backend hook in
+  `core/dataset/controller.py:process_install_file` — Sprint 5 follow-up).
+- **V3**: validation rules for connectors + `extends:` between manifests so a
+  project manifest can inherit from its template's manifest.


### PR DESCRIPTION
First wave of project.manifest.yml adoption in the public template repo. Generalises the manifest pattern beyond bwin (entain-templates #510). Adds manifests for machina-assistant, chat-completion, daily-football-recap + adoption guide. Consumed by /project/health, /bootstrap-check, /vault/validate, Pipeline Visualizer.