### PR TITLE
feat(skill): manifest-generator — auto-draft project.manifest.yml from workflows

### DIFF
--- a/skills/manifest-generator/SKILL.md
+++ b/skills/manifest-generator/SKILL.md
@@ -1,0 +1,84 @@
+# Project Manifest Generator
+
+Generates a draft `project.manifest.yml` for a Machina template by statically
+scanning a list of workflows and aggregating the credentials, connectors,
+datasets and agents they reference.
+
+Built to scale **Sprint 1A** of the Pipeline Platform Cleanup (the hand-written
+botandwin manifest at `entain-templates`) to every template in
+`machina-templates` without writing each one by hand.
+
+## What it does
+
+1. **Deterministic extraction (always)** — a pyscript connector walks each
+   workflow_object in your list and emits the union of:
+   - `TEMP_CONTEXT_VARIABLE_*` → credentials
+   - `task.connector.name` for `type=connector|prompt` tasks → connector deps
+   - `task.config.action == "search"` → dataset reads (external deps)
+   - `task.config.action == "update|insert|save"` → dataset writes (deps_on)
+   - `type=agent` references → agents
+   - `type=workflow` references → workflow calls (for `extends`-like inheritance)
+
+2. **Optional LLM enrichment** — pass `enrich_with_llm=true` and a
+   Gemini/Vertex AI call fills in:
+   - `source_label` ("OpenAI API key (platform.openai.com)" etc)
+   - `test_workflow` ("<connector>-test-credentials")
+   - `validation` rule (http for *_API_KEY, json_object for service-account JSON,
+     non_empty_string for generic strings)
+   - dataset `description` + `populated_by` guesses
+
+3. **Output** — writes a `<template_name>-manifest-draft` document into
+   the `document` collection. Operator opens it in Studio, eyeballs the
+   suggested values, edits, then copies the `manifest` field into the
+   real `project.manifest.yml` for commit.
+
+## How to run
+
+Install this skill into your project (via Studio template browser), then:
+
+```bash
+POST /workflow/executor/generate-project-manifest
+Content-Type: application/json
+
+{
+  "workflow_names": [
+    "machina-assistant-thread-create",
+    "machina-assistant-thread-respond",
+    "machina-assistant-kb-search"
+  ],
+  "template_name": "machina-assistant",
+  "description": "Foundational AI assistant for Machina platform",
+  "enrich_with_llm": true
+}
+```
+
+Response carries `manifest_draft_doc_name`. Fetch with:
+
+```bash
+POST /document/search
+{ "filters": { "name": "machina-assistant-manifest-draft" }, "page_size": 1 }
+```
+
+## Limitations (V1)
+
+- Doesn't fetch workflow YAMLs from a Git repo — works against the
+  workflows already imported into your project. To scan a template you
+  haven't installed yet: import it first.
+- Heuristic dataset detection (same caveats as
+  `core/workflow/dependency_graph.py` — `$.get('xxx')` is mostly inferred
+  from `type=document` tasks now, not just regex).
+- LLM enrichment is best-effort. Always review the draft before commit.
+
+## Roadmap
+
+- **V2**: clone-from-git input so you can manifest a template without
+  installing it.
+- **V3**: bulk mode — scan an entire repo and emit one PR per template.
+- **V4**: hook into `core/dataset/controller.py:process_install_file`
+  so installing a template auto-generates + offers a draft manifest.
+
+## Related
+
+- `agent-templates/machina-assistant/project.manifest.yml` (hand-written reference)
+- `docs/project-manifest-guide.md` (schema reference)
+- machina-client-api `/project/health`, `/bootstrap-check`, `/workflow/<id>/dependencies`

--- a/skills/manifest-generator/_install.yml
+++ b/skills/manifest-generator/_install.yml
@@ -1,0 +1,33 @@
+setup:
+  title: "Project Manifest Generator"
+  description: "Scans a template's workflows and emits a draft project.manifest.yml — credentials, datasets, connectors, agents — ready for review + commit."
+  category:
+    - special-templates
+  estimatedTime: 5 minutes
+  features:
+    - Static extraction (no LLM required for the deterministic skeleton)
+    - Optional LLM enrichment of `source_label` / `validation` / `description`
+    - Emits a `project_manifest_draft` document for operator review
+    - Designed to scale Sprint 1A (botandwin manifest) to every template in machina-templates
+  status: available
+  integrations: []
+  value: "skills/manifest-generator"
+  version: 1.0.0
+
+datasets:
+
+  # Pyscript connector — the deterministic extractor
+  - type: connector
+    path: connectors/manifest-extractor.yml
+
+  # LLM enrichment prompt — fills source_label + validation rules
+  - type: prompts
+    path: prompts/manifest-enrichment.yml
+
+  # Main orchestration workflow
+  - type: workflow
+    path: workflows/generate-project-manifest.yml
+
+  # Skill itself
+  - type: skill
+    path: skill.yml

--- a/skills/manifest-generator/connectors/manifest-extractor.py
+++ b/skills/manifest-generator/connectors/manifest-extractor.py
@@ -1,0 +1,248 @@
+"""Manifest Extractor — pyscript connector for the manifest-generator skill.
+
+Walks a list of workflow names, fetches each workflow_object from the
+`workflow` Mongo collection, runs static extraction, and returns an
+aggregated draft manifest ready to be rendered as YAML.
+
+This duplicates the core extraction primitives from machina-client-api's
+`core/workflow/dependency_graph.py` so the skill stays self-contained
+within a template repo (no client-api code import). When the patterns
+diverge, sync this file against the client-api one.
+
+Commands exposed (see manifest-extractor.yml):
+  - aggregate_manifest : the main entry point
+"""
+
+import re
+from collections import OrderedDict
+
+# Regex primitives — mirror dependency_graph.py
+_CRED_PATTERN = re.compile(r"TEMP_CONTEXT_VARIABLE_[A-Z0-9_]+")
+_GET_PATTERN = re.compile(r"\$\.get\(['\"]([a-z0-9_\-]+)['\"]")
+
+
+def _walk_strings(obj):
+    """Yield every string anywhere in a nested dict/list."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+def _strip_yaml_quotes(s):
+    """Workflow YAML quotes literals as `\"'name'\"`. Strip + reject expr noise."""
+    if not isinstance(s, str):
+        return None
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        s = s[1:-1]
+    if not s or any(c in s for c in ("{", "}", "$", " ", "\n", "(", ")", "[", "]")):
+        return None
+    return s
+
+
+def _extract_credentials(workflow_doc):
+    found = set()
+    for s in _walk_strings(workflow_doc):
+        found.update(_CRED_PATTERN.findall(s))
+    return found
+
+
+def _extract_connectors(workflow_doc):
+    out = set()
+    for task in workflow_doc.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("type") in ("connector", "prompt"):
+            conn = task.get("connector") or {}
+            if isinstance(conn, dict):
+                name = conn.get("name")
+                if isinstance(name, str) and name:
+                    out.add(name)
+    return out
+
+
+def _extract_agents(workflow_doc):
+    out = set()
+    for task in workflow_doc.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("type") == "agent":
+            ag = task.get("agent") or task.get("agent_id") or task.get("agent_name")
+            if isinstance(ag, str) and ag:
+                out.add(ag)
+    return out
+
+
+def _extract_dataset_reads(workflow_doc):
+    out = set()
+    for task in workflow_doc.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("type") != "document":
+            continue
+        cfg = task.get("config") or {}
+        action = (cfg.get("action") or "").lower()
+        if action not in ("search", "retrieve", "get", "find"):
+            continue
+        filters = task.get("filters") or {}
+        if isinstance(filters, dict):
+            name = _strip_yaml_quotes(filters.get("name"))
+            if name:
+                out.add(name)
+    return out
+
+
+def _extract_dataset_writes(workflow_doc):
+    out = set()
+    for task in workflow_doc.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("type") != "document":
+            continue
+        cfg = task.get("config") or {}
+        action = (cfg.get("action") or "").lower()
+        if action not in ("update", "insert", "save", "upsert", "create"):
+            continue
+        docs = task.get("documents") or {}
+        if isinstance(docs, dict):
+            for ds_name in docs.keys():
+                if isinstance(ds_name, str) and ds_name:
+                    out.add(ds_name)
+    return out
+
+
+def _extract_workflow_calls(workflow_doc):
+    out = set()
+    for task in workflow_doc.get("tasks") or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("type") in ("workflow", "execute-workflow"):
+            ref = task.get("workflow") or task.get("workflow_id") or task.get("workflow_name")
+            if isinstance(ref, str) and ref:
+                out.add(ref)
+    return out
+
+
+# -------------------------------------------------------------------------
+# Public connector commands
+# -------------------------------------------------------------------------
+
+def aggregate_manifest(inputs):
+    """Run the extraction across a list of workflow names + emit a draft.
+
+    Inputs (from the calling workflow task):
+        - workflow_names: list[str]   — workflows belonging to this template
+        - template_name:  str         — what to call this manifest
+        - description:    str         — one-liner for the manifest header
+
+    Returns a dict shaped like `project.manifest.yml` (no YAML serialisation
+    here — the workflow's next task renders it).
+    """
+    from core.system.database import MongoDBConnection  # available inside pyscript runtime
+
+    workflow_names = inputs.get("workflow_names") or []
+    template_name = inputs.get("template_name") or "unnamed-template"
+    description   = inputs.get("description")   or ""
+
+    if not isinstance(workflow_names, list) or not workflow_names:
+        return {
+            "ok": False,
+            "error": "workflow_names is required and must be a non-empty list",
+        }
+
+    col = MongoDBConnection().get_collection("workflow")
+    creds = set()
+    connectors = set()
+    ds_reads = set()
+    ds_writes = set()
+    agents = set()
+    wf_calls = set()
+    workflows_seen = []
+    missing = []
+
+    for name in workflow_names:
+        doc = col.find_one({"name": name})
+        if not doc:
+            missing.append(name)
+            continue
+        workflows_seen.append(name)
+        creds.update(_extract_credentials(doc))
+        connectors.update(_extract_connectors(doc))
+        ds_reads.update(_extract_dataset_reads(doc))
+        ds_writes.update(_extract_dataset_writes(doc))
+        agents.update(_extract_agents(doc))
+        wf_calls.update(_extract_workflow_calls(doc))
+
+    # Build the manifest skeleton. Source labels / validation rules / min_counts
+    # are left empty — the operator (or the optional LLM enrichment task)
+    # fills them in. Comments inline explain each block.
+    manifest = OrderedDict()
+    manifest["name"] = template_name
+    manifest["version"] = 1
+    if description:
+        manifest["description"] = description
+
+    manifest["required_credentials"] = [
+        {
+            "name": cred,
+            "source_label": "",          # operator fills: "<service> API key (<console-url>)"
+            "test_workflow": "",         # operator fills: "<connector>-test-credentials"
+            "validation": None,           # operator fills via LLM enrichment task or by hand
+        }
+        for cred in sorted(creds)
+    ]
+
+    manifest["required_config_documents"] = []  # not extractable from workflows alone
+
+    manifest["required_templates"] = [
+        # The template itself — placeholder, operator fills in the repo URL.
+        {
+            "repo": "https://github.com/<org>/<repo>",
+            "path": f"<path-to>/{template_name}",
+            "reason": "This template",
+        },
+    ] + [
+        # Each connector the workflows use likely points at a connector template.
+        {
+            "repo": "https://github.com/machina-sports/machina-templates",
+            "path": f"connectors/{c}",
+            "reason": f"Connector: {c}",
+        }
+        for c in sorted(connectors)
+    ]
+
+    manifest["depends_on_datasets"] = [
+        # Datasets the workflows WRITE to — these are the data this template
+        # produces and therefore the health signal for "is this project alive?".
+        {
+            "name": ds,
+            "description": "",                  # operator fills
+            "populated_by": "",                 # operator fills
+            "min_count": 1,                     # conservative default
+        }
+        for ds in sorted(ds_writes)
+    ]
+
+    return {
+        "ok": True,
+        "manifest": manifest,
+        "stats": {
+            "workflows_seen": len(workflows_seen),
+            "workflows_missing": len(missing),
+            "credentials": len(creds),
+            "connectors": len(connectors),
+            "datasets_read": len(ds_reads),
+            "datasets_written": len(ds_writes),
+            "agents": len(agents),
+            "workflow_calls": len(wf_calls),
+        },
+        "missing": missing,
+        "datasets_read_only": sorted(ds_reads - ds_writes),  # external deps to track elsewhere
+        "agents": sorted(agents),
+        "workflow_calls": sorted(wf_calls),
+    }

--- a/skills/manifest-generator/connectors/manifest-extractor.yml
+++ b/skills/manifest-generator/connectors/manifest-extractor.yml
@@ -1,0 +1,39 @@
+connector:
+
+  name: manifest-extractor
+  title: Project Manifest Extractor
+  description: |
+    Deterministic extractor that scans a list of Machina workflows and
+    aggregates the credentials, connectors, datasets and agents they
+    depend on — outputting a draft project.manifest.yml ready for review.
+  filename: manifest-extractor.py
+  filetype: pyscript
+  commands:
+    - name: Aggregate Manifest
+      value: aggregate_manifest
+      description: |
+        Walks each workflow_object in `workflow_names`, extracts deps,
+        and returns a manifest skeleton.
+      inputs:
+        - name: workflow_names
+          type: array
+          description: "List of workflow names to scan"
+        - name: template_name
+          type: string
+          description: "Manifest top-level `name` field"
+        - name: description
+          type: string
+          description: "One-line description for the manifest header"
+      outputs:
+        - name: manifest
+          type: object
+        - name: stats
+          type: object
+        - name: missing
+          type: array
+        - name: datasets_read_only
+          type: array
+        - name: agents
+          type: array
+        - name: workflow_calls
+          type: array

--- a/skills/manifest-generator/prompts/manifest-enrichment.yml
+++ b/skills/manifest-generator/prompts/manifest-enrichment.yml
@@ -1,0 +1,70 @@
+prompt:
+
+  name: manifest-enrichment
+  title: Manifest Enrichment Prompt
+  description: |
+    Takes a draft project.manifest.yml (produced by the manifest-extractor
+    pyscript) and fills in the human-facing fields: source_label,
+    test_workflow, validation rule, dataset descriptions, populated_by.
+
+    Stays conservative: only fills what can be inferred from the
+    credential / dataset name + the connector list. Leaves uncertain
+    fields empty so the operator notices what needs manual attention.
+
+  config:
+    response_format: json
+    temperature: 0.1
+    max_tokens: 3000
+
+  inputs:
+    - name: _1-template_name
+      description: "Top-level manifest name."
+    - name: _2-draft_manifest
+      description: "Manifest skeleton from the extractor."
+    - name: _3-external_datasets
+      description: "Dataset names the workflows READ from (likely populated by other templates)."
+
+  system: |
+    You're filling in a Machina project manifest. The skeleton already
+    has the credential names, connector references, and dataset writes.
+    Your job: enrich the human-readable bits using these rules.
+
+    Credential `source_label`:
+    - Naming convention: TEMP_CONTEXT_VARIABLE_<UPPERCASE>
+    - Pattern matches:
+      - ends in _API_KEY      → "<service> API key (<console URL>)"
+      - ends in _SECRET       → "<service> secret"
+      - matches _CREDENTIAL   → "Service account JSON for <service>"
+      - matches _ACCESS_ID    → "<service> partner access ID"
+
+    Credential `test_workflow`:
+    - Convention: `<connector-name>-test-credentials`. Pick the most
+      likely connector from the connectors list.
+
+    Credential `validation`:
+    - API keys for known services (OpenAI, SportRadar, Groq, API-Football,
+      Mailgun) → http rule with the conventional probe URL.
+    - JSON service accounts → json_object with required_keys
+      [project_id, private_key, client_email].
+    - Free-text strings → non_empty_string.
+    - If unsure → leave validation: null.
+
+    Dataset `description` + `populated_by`:
+    - description: short one-liner about what the dataset holds.
+    - populated_by: usually `<template>-<area>-<action>` — guess based
+      on the dataset name pattern.
+
+    Return the SAME manifest structure with these fields filled.
+
+  user: |
+    Template: {_1-template_name}
+
+    Draft manifest:
+    {_2-draft_manifest}
+
+    External datasets this template reads (populated by other templates):
+    {_3-external_datasets}
+
+  outputs:
+    - name: enriched_manifest
+      description: "The manifest dict with source_label, test_workflow, validation, descriptions filled in."

--- a/skills/manifest-generator/skill.yml
+++ b/skills/manifest-generator/skill.yml
@@ -1,0 +1,12 @@
+skill:
+  name: manifest-generator
+  title: Project Manifest Generator
+  description: |
+    Generate a draft `project.manifest.yml` from a list of workflows.
+    Powers fast adoption of the manifest pattern across machina-templates.
+  workflows:
+    - name: generate-project-manifest
+  connectors:
+    - name: manifest-extractor
+  prompts:
+    - name: manifest-enrichment

--- a/skills/manifest-generator/workflows/generate-project-manifest.yml
+++ b/skills/manifest-generator/workflows/generate-project-manifest.yml
@@ -1,0 +1,86 @@
+workflow:
+
+  name: generate-project-manifest
+  title: Generate Project Manifest
+  description: |
+    Scans a list of workflows (workflow_names) belonging to a template,
+    extracts deps (credentials / connectors / datasets / agents) via the
+    manifest-extractor pyscript connector, optionally enriches with an
+    LLM pass for source_label + validation rules, and writes the result
+    as a `project_manifest_draft` document for operator review.
+
+  context-variables:
+    debugger:
+      enabled: true
+
+  tasks:
+
+    - type: connector
+      name: extract-deps
+      description: "Run the deterministic pyscript extractor across all workflows."
+      connector:
+        name: manifest-extractor
+        command: aggregate_manifest
+      inputs:
+        workflow_names: "$.get('workflow_names', [])"
+        template_name:  "$.get('template_name', 'unnamed-template')"
+        description:    "$.get('description', '')"
+      outputs:
+        extraction_ok:    "$.get('ok', False)"
+        draft_manifest:   "$.get('manifest', {})"
+        extraction_stats: "$.get('stats', {})"
+        missing_workflows: "$.get('missing', [])"
+        external_datasets: "$.get('datasets_read_only', [])"
+
+    # Optional LLM enrichment — only runs if `enrich_with_llm=true` was
+    # passed in the input context. The prompt receives the draft manifest
+    # plus the list of external datasets it reads, and returns the same
+    # manifest with source_label, test_workflow + validation rules filled
+    # in. Output keys are merged onto draft_manifest by the next task.
+    - type: prompt
+      name: enrich-manifest
+      description: "Fill source_label, test_workflow, validation per credential."
+      condition: "$.get('enrich_with_llm', False) is True and $.get('extraction_ok', False) is True"
+      continue_on_error: true
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-3-flash-preview
+        provider: vertex_ai
+      inputs:
+        _1-template_name: "$.get('template_name', '')"
+        _2-draft_manifest: "$.get('draft_manifest', {})"
+        _3-external_datasets: "$.get('external_datasets', [])"
+      outputs:
+        enriched_manifest: "$.get('enriched_manifest', $.get('draft_manifest', {}))"
+
+    # Persist the result as a project_manifest_draft document. The
+    # operator can then edit it in Studio, tweak labels/validation, then
+    # promote to the real `project_manifest` collection.
+    - type: document
+      name: save-draft
+      description: "Write the draft manifest as a project_manifest_draft document."
+      condition: "$.get('extraction_ok', False) is True"
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        "{$.get('template_name', 'unnamed-template')}-manifest-draft": |
+          {
+            'manifest':            $.get('enriched_manifest', $.get('draft_manifest', {})),
+            'extraction_stats':    $.get('extraction_stats', {}),
+            'missing_workflows':   $.get('missing_workflows', []),
+            'external_datasets':   $.get('external_datasets', []),
+            'enriched':            $.get('enrich_with_llm', False),
+            'generated_at':        datetime.utcnow().isoformat(),
+            'template_name':       $.get('template_name', ''),
+          }
+
+  outputs:
+    ok: "$.get('extraction_ok', False)"
+    manifest_draft_doc_name: "'{$.get(\"template_name\", \"unnamed-template\")}-manifest-draft'"
+    stats: "$.get('extraction_stats', {})"
+    missing: "$.get('missing_workflows', [])"
+    workflow-status: |
+      'executed' if $.get('extraction_ok', False) else 'skipped'


### PR DESCRIPTION
Scales the manifest adoption story across 30+ templates. Pyscript extractor + optional LLM enrichment, outputs draft document for operator review. Full design + usage in SKILL.md. V1 — operator-driven, not yet integrated into auto-install hook (V4 roadmap).