### PR TITLE
fix(copilot): make reasoning workflow read-only on the thread doc

### DIFF
--- a/agent-templates/machina-copilot/workflows/copilot-reasoning.yml
+++ b/agent-templates/machina-copilot/workflows/copilot-reasoning.yml
@@ -2,9 +2,14 @@ workflow:
 
   # copilot-reasoning
   #
-  # Decides whether to dispatch tools or reply directly. Loads / creates the
-  # thread document, appends the user message, then runs the reasoning prompt
-  # to emit a structured {needs_tool_call, tool_calls[], short_message}.
+  # Decides whether to dispatch tools or reply directly. Loads the thread
+  # document (Python creates it before calling us), then runs the reasoning
+  # prompt to emit a structured {needs_tool_call, tool_calls[], short_message}.
+  #
+  # Thread state is OWNED by the Python orchestrator at
+  # machina-client-api:core/agent/copilot/orchestrator.py — this workflow does
+  # NOT write to the thread doc (used to, but caused duplicate user messages
+  # + cross-collection mismatches). Read-only here.
   name: copilot-reasoning
   title: Machina Copilot | Reasoning
   description: Decide which tools (if any) to dispatch for the user's message.
@@ -24,10 +29,10 @@ workflow:
     workflow-status: $.get('document_exists') is True and 'executed' or 'skipped'
   tasks:
 
-    # Load existing thread or create a fresh one
+    # Load the thread document (Python created it before calling us)
     - type: document
       name: load-thread-document
-      description: Load thread document if thread_id is provided
+      description: Load thread document — must exist by now (Python creates it)
       condition: $.get('thread_id') is not None and $.get('thread_id') != ''
       config:
         action: search
@@ -42,61 +47,11 @@ workflow:
         document_value: $.get('documents')[0].get('value', {}) if len($.get('documents', [])) > 0 else {}
         messages: $.get('documents')[0].get('value', {}).get('messages', []) if len($.get('documents', [])) > 0 else []
 
-    - type: document
-      name: create-thread-document
-      description: Create a new thread document if none exists
-      condition: ($.get('thread_id') is None or $.get('thread_id') == '') and ($.get('document_exists') is False or $.get('document_exists') is None)
-      config:
-        action: save
-        embed-vector: false
-        force-update: true
-      documents:
-        copilot-thread: |
-          {
-            'messages': [],
-            'status': 'created',
-            'status_message': 'Thread created'
-          }
-      metadata:
-        agent_id: "'copilot-executor'"
-        created_at: datetime.now().isoformat()
-        created_from: "'machina-copilot'"
-        source: "'machina-copilot'"
-        user_id: "'anonymous'"
-      outputs:
-        document_id: $.get('documents')[0].get('_id') if len($.get('documents', [])) > 0 else None
-        document_exists: len($.get('documents', [])) > 0 if $.get('documents') else False
-        document_value: $.get('documents')[0].get('value', {}) if len($.get('documents', [])) > 0 else {}
-
-    # Append the new user message to the thread before reasoning
-    - type: document
-      name: append-user-message
-      condition: $.get('document_id') is not None and $.get('input_message') is not None
-      config:
-        action: update
-        embed-vector: false
-        force-update: true
-      documents:
-        copilot-thread: |
-          {
-            **$.get('document_value', {}),
-            'messages': [
-              *$.get('document_value', {}).get('messages', []),
-              {
-                'role': 'user',
-                'content': $.get('input_message'),
-                'timestamp': datetime.now().isoformat()
-              }
-            ],
-            'status': 'processing'
-          }
-      filters:
-        document_id: $.get('document_id')
-
     # Load the live tool catalog so the reasoning prompt knows what's callable
     - type: workflow
       name: load-tool-catalog
       description: Build the current CLI + MCP tool catalog for this project
+      condition: $.get('document_id') is not None
       workflow:
         name: copilot-tools-list
       inputs: {}
@@ -128,30 +83,3 @@ workflow:
         _3-available-tools: $.get('available_tools', [])
       outputs:
         reasoning: $
-
-    # Persist reasoning + short status onto the thread
-    - type: document
-      name: update-thread-status
-      condition: $.get('document_id') is not None
-      config:
-        action: update
-        embed-vector: false
-        force-update: true
-      documents:
-        copilot-thread: |
-          {
-            **$.get('document_value', {}),
-            'messages': [
-              *$.get('document_value', {}).get('messages', []),
-              {
-                'role': 'user',
-                'content': $.get('input_message'),
-                'timestamp': datetime.now().isoformat()
-              }
-            ],
-            'status': 'reasoning',
-            'status_message': $.get('reasoning', {}).get('short_message', ''),
-            'last_reasoning': $.get('reasoning', {})
-          }
-      filters:
-        document_id: $.get('document_id')


### PR DESCRIPTION
## Bug

The chat returned an empty stream (\`start\` → \`done\` with no \`content\`) because:

1. The Python orchestrator wrote thread docs to a dedicated \`copilot_thread\` Mongo collection (fixed in machina-client-api companion PR).
2. The workflow loaded threads via Machina's \`document\` task → \`document\` collection with \`name: 'copilot-thread'\` filter — different collection. The load returned 0 docs, \`document_exists: False\`, and every downstream task short-circuited.

After fixing client-api to write to the right collection, the workflow's own write tasks (\`create-thread-document\`, \`append-user-message\`, \`update-thread-status\`) would create DUPLICATE user messages on top of Python's writes — Python and YAML both appending.

## Fix

Make this workflow read-only on the thread doc. Just:

1. Load the thread (Python creates it before invoking)
2. Load the tool catalog
3. Prepare message history
4. Run the reasoning prompt

Python orchestrator (\`machina-client-api: core/agent/copilot/orchestrator.py\`) is now the single source of truth for thread state. Companion PR there.

## Test plan

- [ ] Install template into a project. Send a chat message via \`POST /agent/copilot/run\`. NDJSON stream now emits \`content\` (not just \`start\` + \`done\`).
- [ ] Thread doc in \`document\` collection has exactly ONE user message per turn (no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)