### PR TITLE
fix(copilot): drop mcp- prefix instruction from reasoning prompt

### DIFF
--- a/agent-templates/machina-copilot/prompts/copilot-reasoning.yml
+++ b/agent-templates/machina-copilot/prompts/copilot-reasoning.yml
@@ -23,8 +23,12 @@ prompts:
 
       RULES for tool_calls:
       - `name` must be EXACTLY one of the tool names listed in
-        `_3-available-tools` (CLI names start with `cli-`, MCP names start
-        with `mcp-` plus the resolved tool name).
+        `_3-available-tools`. The catalog mixes two families:
+          * `cli-*` names — Machina CLI shortcuts (workflow, agent, execution).
+          * Other names like `search_documents`, `execute_workflow`,
+            `create_document` — MCP tools served by the project pod, exposed
+            verbatim (~58 of them).
+        Use the exact string from the catalog.
       - `arguments` is an object whose keys match the tool's input schema.
       - Prefer ONE tool call per turn unless the user explicitly asked for
         multiple independent actions. The orchestrator will run them


### PR DESCRIPTION
Companion to machina-sports/machina-client-api PR (MCP SSE bridge). The bridge now exposes MCP tool names verbatim (\`search_documents\`, \`execute_workflow\`, etc.) — not prefixed. Update the reasoning prompt rule so the LLM picks the exact name from the catalog instead of expecting a \`mcp-\` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)