### PR TITLE
fix(copilot-reasoning): force LLM to extract args from the user message

### DIFF
--- a/agent-templates/machina-copilot/prompts/copilot-reasoning.yml
+++ b/agent-templates/machina-copilot/prompts/copilot-reasoning.yml
@@ -29,16 +29,31 @@ prompts:
             `create_document` — MCP tools served by the project pod, exposed
             verbatim (~58 of them).
         Use the exact string from the catalog.
-      - `arguments` is an object whose keys match the tool's input schema.
+      - `arguments` MUST be a real object — never `{}` when the tool has
+        required params. Each entry in `_3-available-tools` carries a
+        `params_hint` like `repo_url*(str), branch(str=main)`. The `*`
+        marks REQUIRED params; the type in parens is the expected JSON type.
+        Read the user message, extract the values, and populate every
+        required key. URLs, project names, IDs, and key names mentioned
+        verbatim by the user almost always map to a required param.
       - Prefer ONE tool call per turn unless the user explicitly asked for
         multiple independent actions. The orchestrator will run them
         sequentially and feed the outputs back to you for synthesis.
       - For mutating tools (the catalog marks `mutating: true`), the Studio
         will render a confirm card. You don't need to ask the user "are you
         sure?" — the UI handles that.
-      - If a tool requires args you don't have, ask the user a follow-up
-        question (set `needs_tool_call=false` and put the question in
-        `assistant_message`).
+      - If a tool requires args you genuinely cannot infer from the message
+        or recent history, ask a follow-up question instead of guessing
+        (set `needs_tool_call=false`, put the question in `assistant_message`).
+
+      EXAMPLES of arg extraction:
+      - User: "get templates from https://github.com/foo/bar"
+        Tool `get_git_template_directories` has params_hint
+        `repo_url*(str), repo_branch(str=main), private_repository(bool=false)`.
+        → arguments = `{"repo_url": "https://github.com/foo/bar"}`
+      - User: "run workflow daily-digest with topic F1"
+        Tool `cli-workflow-run` has params_hint `workflow_name*(str), inputs(obj)`.
+        → arguments = `{"workflow_name": "daily-digest", "inputs": {"topic": "F1"}}`
 
       `short_message` is ALWAYS populated:
       - When dispatching tools: a 1-line status like "Looking up your projects…"


### PR DESCRIPTION
## Summary
- User typed \"get templates from https://github.com/foo/bar\" and the reasoning LLM still dispatched the tool with `arguments: {}` — the URL never made it into the call
- Strengthen the prompt to explicitly require populated args + introduce a \`params_hint\` convention (provided by the orchestrator) so the model sees a compact signature instead of nested JSON Schema
- Two worked examples cover MCP and CLI tool argument extraction

Paired with machina-client-api PR \`fix/copilot-args-extraction-hint\` which emits the `params_hint` field on each catalog entry.

## Test plan
- [ ] Merge after client-api PR ships `:beta`
- [ ] Re-install or re-sync prompt on a test project
- [ ] Repro the screenshot scenario; arguments should now contain `repo_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)