### PR TITLE
feat(api-football): add /fixtures/lineups + /predictions + /odds

### DIFF
--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -1536,6 +1536,336 @@
         }
       }
     },
+    "/fixtures/lineups": {
+      "get": {
+        "summary": "Get fixture lineups",
+        "description": "Get both teams' starting XI, formation string, coach, and substitutes for a fixture. Players come with a `grid` field like \"1:1\" / \"2:3\" (X = row from goal outward, Y = column left-to-right) — the canonical input for rendering a tactical pitch viz. Available 20-40 minutes before kick-off when the competition's coverage supports it; otherwise populated after the match.",
+        "operationId": "get-fixtures/lineups",
+        "security": [
+          {
+            "x-apisports-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fixture",
+            "in": "query",
+            "description": "Fixture ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "example": 592872
+            }
+          },
+          {
+            "name": "team",
+            "in": "query",
+            "description": "Team ID to filter lineups to one side",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 50
+            }
+          },
+          {
+            "name": "player",
+            "in": "query",
+            "description": "Player ID to filter lineups to a single player",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 35845
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Lineup subset (currently only startXI is documented)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["startXI"],
+              "example": "startXI"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "get": { "type": "string" },
+                    "parameters": { "type": "object" },
+                    "errors": { "type": "array", "items": { "type": "string" } },
+                    "results": { "type": "integer" },
+                    "response": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "team": { "type": "object" },
+                          "coach": { "type": "object" },
+                          "formation": { "type": "string", "example": "4-3-3" },
+                          "startXI": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "player": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": { "type": "integer" },
+                                    "name": { "type": "string" },
+                                    "number": { "type": "integer" },
+                                    "pos": { "type": "string" },
+                                    "grid": { "type": "string", "example": "2:1" }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "substitutes": { "type": "array", "items": { "type": "object" } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions": {
+      "get": {
+        "summary": "Get fixture predictions",
+        "description": "Pre-match probability for home/draw/away outcomes, advice text, expected winner, and side-by-side comparisons (form, attack, defence, h2h, goals, total) plus team season context. Available once both teams' last 10 fixtures of the season are processed.",
+        "operationId": "get-predictions",
+        "security": [
+          {
+            "x-apisports-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fixture",
+            "in": "query",
+            "description": "Fixture ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "example": 198772
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "get": { "type": "string" },
+                    "parameters": { "type": "object" },
+                    "errors": { "type": "array", "items": { "type": "string" } },
+                    "results": { "type": "integer" },
+                    "response": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "predictions": {
+                            "type": "object",
+                            "properties": {
+                              "winner": { "type": "object" },
+                              "win_or_draw": { "type": "boolean" },
+                              "under_over": { "type": "string" },
+                              "goals": { "type": "object" },
+                              "advice": { "type": "string" },
+                              "percent": {
+                                "type": "object",
+                                "properties": {
+                                  "home": { "type": "string", "example": "47%" },
+                                  "draw": { "type": "string", "example": "24%" },
+                                  "away": { "type": "string", "example": "29%" }
+                                }
+                              }
+                            }
+                          },
+                          "league": { "type": "object" },
+                          "teams": { "type": "object" },
+                          "comparison": { "type": "object" },
+                          "h2h": { "type": "array", "items": { "type": "object" } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/odds": {
+      "get": {
+        "summary": "Get pre-match odds",
+        "description": "Pre-match odds from multiple bookmakers for a fixture or league/season. NOTE this is pre-match only — for live odds use /odds/live (not yet wired here). Odds disappear from this endpoint a few hours after the fixture starts; archived odds live under /odds/mapping. At least one of (fixture, league, season, date) is required.",
+        "operationId": "get-odds",
+        "security": [
+          {
+            "x-apisports-key": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fixture",
+            "in": "query",
+            "description": "Fixture ID — narrowest filter",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 164327
+            }
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "description": "League ID (pair with `season`)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 39
+            }
+          },
+          {
+            "name": "season",
+            "in": "query",
+            "description": "Season year (YYYY)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 2024
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date YYYY-MM-DD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "example": "2024-08-17"
+            }
+          },
+          {
+            "name": "bookmaker",
+            "in": "query",
+            "description": "Bookmaker ID — narrow to a single sportsbook's lines",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 6
+            }
+          },
+          {
+            "name": "bet",
+            "in": "query",
+            "description": "Bet type ID — narrow to one market (e.g. 1 = Match Winner)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "description": "IANA timezone for date/time fields in the response",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "Europe/London"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Pagination cursor (default 1)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "get": { "type": "string" },
+                    "parameters": { "type": "object" },
+                    "errors": { "type": "array", "items": { "type": "string" } },
+                    "results": { "type": "integer" },
+                    "paging": { "type": "object" },
+                    "response": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "league": { "type": "object" },
+                          "fixture": { "type": "object" },
+                          "update": { "type": "string", "format": "date-time" },
+                          "bookmakers": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "integer" },
+                                "name": { "type": "string" },
+                                "bets": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": { "type": "integer" },
+                                      "name": { "type": "string" },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "value": { "type": "string" },
+                                            "odd": { "type": "string" }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/fixtures/players": {
       "get": {
         "summary": "Get fixture players statistics",


### PR DESCRIPTION
## Summary

Adds 3 endpoints to the `api-football` connector's OpenAPI spec. None of them need new auth — existing `x-apisports-key` covers them.

| endpoint | why |
|---|---|
| `/fixtures/lineups` | Players come with a `grid` field (`"1:1"` / `"2:3"`) + formation string (`"4-3-3"`) + coach + bench. **The killer feature** for tactical pitch viz — nothing in our existing @football-data (ESPN-based) exposes this. |
| `/predictions` | Pre-match probability (home/draw/away as %), expected winner, advice, and form/attack/defence comparisons. Pre-game card material. |
| `/odds` | Pre-match odds across multiple bookmakers — widens the market source for the Conversational Betting Builder gallery card (currently kalshi/polymarket-only). |

## Why now

Unblocks a "Tactical Match Center" gallery card in `machina-factory-customer` (PR to follow) that renders both teams' starting XI on a pitch with their real grid coords + a live event timeline overlay. That demo is impossible without `/fixtures/lineups` because ESPN doesn't give grid coordinates.

## Validation

- JSON parses (`python3 -c "import json; json.load(open('...'))"`) ✅
- 13 paths total now (was 10) ✅
- No changes to existing endpoint shapes — additive only ✅
- All 3 endpoints declared under the existing `x-apisports-key` security scheme ✅

## Test plan

- [ ] Merge.
- [ ] On a customer pod with the api-football connector installed, re-run the connector install / sync so the new paths show up in `pod_mcp_call(connector_search)`.
- [ ] Smoke-test each endpoint via the pod with a real fixture id (e.g. a recent Premier League match).
- [ ] Then merge the matching gallery-card PR in machina-factory-customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)