### PR TITLE
fix(api-football): document live↔date mutual exclusion on /fixtures

### DIFF
--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -731,7 +731,7 @@
           {
             "name": "live",
             "in": "query",
-            "description": "Live fixtures - use 'all' for all live fixtures or league IDs separated by hyphens (returns events)",
+            "description": "Live fixtures - use 'all' for all live fixtures or league IDs separated by hyphens (returns events). MUTUALLY EXCLUSIVE with `date`, `from`, `to`, `next`, `last` — pick one filter family per request; combining returns HTTP 400 'The Date field cannot be used with live field.' (and similar).",
             "required": false,
             "schema": {
               "type": "string",
@@ -741,7 +741,7 @@
           {
             "name": "date",
             "in": "query",
-            "description": "Date in YYYY-MM-DD format",
+            "description": "Date in YYYY-MM-DD format. MUTUALLY EXCLUSIVE with `live` — combining returns HTTP 400. Pair with `league`/`season`/`team` to narrow.",
             "required": false,
             "schema": {
               "type": "string",


### PR DESCRIPTION
## Summary

Tactical Match Center demo ([machina-factory-customer#59](https://github.com/machina-sports/machina-factory-customer/pull/59)) shipped a UI that sent `{date, live: "all"}` together to `/fixtures` and got back HTTP 400 *"The Date field cannot be used with live field."* API-Football treats `live` and `date`/`from`/`to`/`next`/`last` as mutually exclusive filter families, but the param descriptions in our OpenAPI spec didn't say so — the agent just composed them like normal optional params.

This PR adds explicit "MUTUALLY EXCLUSIVE" callouts on the `live` and `date` param descriptions, so the next agent that reads this connector via `pod_mcp_call(connector_search)` sees the constraint inline.

## Companion fix

machina-factory-customer#60 patches the showcase prompt to split the Tactical Match Center's fixture fetch into TWO parallel calls (one for live, one for upcoming). The connector hint here + the prompt split there together prevent the same HTTP 400 from recurring on future builds.

## Test plan

- [ ] Merge.
- [ ] Re-sync the api-football connector on test pods so the updated descriptions show up in `connector_search`.
- [ ] Verify the next Tactical Match Center build (after machina-factory-customer#60 lands) does two parallel calls, not one combined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)