### PR TITLE
fix(api-football): flag next/last as PAID-tier and document free-safe fallback

### DIFF
--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -699,7 +699,7 @@
     "/fixtures": {
       "get": {
         "summary": "Get fixtures",
-        "description": "Retrieve football fixtures based on various filters. Supports single/multiple fixture IDs, live fixtures, date ranges, league/team filtering, and venue-specific queries. Returns events, lineups, and statistics for specific fixture requests.",
+        "description": "Retrieve football fixtures based on various filters. Supports single/multiple fixture IDs, live fixtures, date ranges, league/team filtering, and venue-specific queries. Returns events, lineups, and statistics for specific fixture requests. TIER NOTES: `next` and `last` are PAID-only (Free returns HTTP 400). On Free, use `{date: \"YYYY-MM-DD\"}` for both upcoming and recent lookups, optionally narrowed by `league`/`team`/`season`. FILTER FAMILIES are mutually exclusive: combining `live` with `date`/`from`/`to`/`next`/`last` returns HTTP 400 — pick ONE filter per request.",
         "operationId": "get-fixtures",
         "security": [
           {
@@ -779,7 +779,7 @@
           {
             "name": "last",
             "in": "query",
-            "description": "Number of last fixtures to retrieve",
+            "description": "Number of last fixtures to retrieve. PAID-TIER ONLY — Free plans get HTTP 400 'Free plans do not have access to the Last parameter.' On Free, use `{date: \"YYYY-MM-DD\"}` (optionally narrowed by `league`/`team`/`season`) to look up recently-played fixtures instead.",
             "required": false,
             "schema": {
               "type": "integer"
@@ -788,7 +788,7 @@
           {
             "name": "next",
             "in": "query",
-            "description": "Number of next fixtures to retrieve",
+            "description": "Number of next fixtures to retrieve. PAID-TIER ONLY — Free plans get HTTP 400 'Free plans do not have access to the Next parameter.' On Free, use `{date: \"YYYY-MM-DD\"}` (optionally narrowed by `league`/`team`/`season`) to look up upcoming fixtures on a specific day instead.",
             "required": false,
             "schema": {
               "type": "integer"


### PR DESCRIPTION
## Summary

Second iteration of the Tactical Match Center build (after #210 split live/date into two calls) hit HTTP 400:

> *Free plans do not have access to the Next parameter.*

The agent picked `{next: 10}` for the Upcoming tab — reasonable from the OpenAPI spec we shipped, but Free tier blocks both `next` and `last`.

Patching the spec so the next agent (or any prompt that touches this endpoint) sees the constraint inline:

| change | where |
|---|---|
| `next` param description: PAID-TIER ONLY callout + free-safe fallback (`{date}` instead) | param-level |
| `last` param description: same callout — preempts the symmetric failure for "recent fixtures" lookups | param-level |
| `/fixtures` top-level description: TIER NOTES block so `connector_search` surfaces the constraint at first read | endpoint-level |

## Companion fix

[machina-factory-customer#61](https://github.com/machina-sports/machina-factory-customer/pull/61) pivots the Tactical Match Center showcase prompt's Upcoming tab from `{next: 10}` to `{date: <today>}` (with a tomorrow fallback). Together: connector docs make the constraint visible, showcase prompt encodes the free-safe pattern from the start.

## Test plan

- [ ] Merge both PRs.
- [ ] Resync the api-football connector on test pods.
- [ ] Click Tactical Match Center fresh → confirm both tabs populate (Live likely empty unless games are in-progress; Upcoming should fill with today's fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)