### PR TITLE
feat(stats-perform): sync-players workflow for sport:Player

### DIFF
--- a/connectors/stats-perform/_install.yml
+++ b/connectors/stats-perform/_install.yml
@@ -29,6 +29,9 @@ datasets:
   - type: mappings
     path: mappings/iptc-team.yml
 
+  - type: mappings
+    path: mappings/iptc-player.yml
+
   # workflows
 
   - type: workflow
@@ -60,6 +63,9 @@ datasets:
 
   - type: workflow
     path: workflows/sync-teams.yml
+
+  - type: workflow
+    path: workflows/sync-players.yml
 
   - type: workflow
     path: workflows/sync-update-live.yml

--- a/connectors/stats-perform/mappings/iptc-player.yml
+++ b/connectors/stats-perform/mappings/iptc-player.yml
@@ -1,0 +1,65 @@
+mappings:
+
+  # iptc-opta-player-mapping
+  # JOIN squads + per-team seasonstats by personId and emit one IPTC Sport
+  # Schema document per player. Squads (TM3) carry biographical fields plus the
+  # contestant the player belongs to; seasonstats (TM4) carries aggregated
+  # match stats as a name/value list. The squad task already filters out
+  # non-players (coaches / staff) and the seasonstats task already aggregates
+  # one entry per personId across all teams of the season.
+  - type: mapping
+    title: "IPTC | Stats Perform Opta Player Mapping"
+    name: "iptc-opta-player-mapping"
+    description: "Mapping data from Stats Perform Opta squads + seasonstats to IPTC Sport Schema player format"
+    outputs:
+      sport_schema_players: |
+        [
+          {
+            "@context": {
+              "sport": "https://www.sportschema.org/ontologies/sport#",
+              "schema": "https://schema.org/"
+            },
+            "@id": f"urn:opta:player:{person.get('id')}",
+            "@type": ["sport:Player", "schema:Person"],
+            "name": person.get('matchName', person.get('knownName', f"{person.get('firstName','')} {person.get('lastName','')}".strip())),
+            "schema:name": person.get('matchName', person.get('knownName', f"{person.get('firstName','')} {person.get('lastName','')}".strip())),
+            "schema:givenName": person.get('firstName', ''),
+            "schema:familyName": person.get('lastName', ''),
+            "sport:knownName": person.get('knownName', ''),
+            "sport:matchName": person.get('matchName', ''),
+            "sport:position": person.get('position', ''),
+            "sport:shirtNumber": person.get('shirtNumber', ''),
+            "sport:nationality": person.get('nationality', ''),
+            "sport:nationalityId": person.get('nationalityId', ''),
+            "sport:secondNationality": person.get('secondNationality', ''),
+            "sport:placeOfBirth": person.get('placeOfBirth', ''),
+            "schema:birthDate": person.get('dateOfBirth', ''),
+            "sport:gender": person.get('gender', ''),
+            "sport:club": person.get('_contestantName', ''),
+            "sport:clubId": person.get('_contestantId', ''),
+            "sport:clubCode": person.get('_contestantCode', ''),
+            "sport:competitionId": person.get('_competitionId', ''),
+            "sport:competitionName": person.get('_competitionName', ''),
+            "sport:seasonId": person.get('_seasonId', ''),
+            "sport:active": person.get('active', '') == 'yes',
+            "sport:startDate": person.get('startDate', ''),
+            "sport:endDate": person.get('endDate', ''),
+            "sport:type": person.get('type', 'player'),
+            "stats": {
+              "goals": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Goals'), 0),
+              "shots": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Total Shots'), 0),
+              "shots_on_target": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Shots On Target ( inc goals )'), 0),
+              "chances_created": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Big Chances Created'), 0),
+              "key_passes": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Total Successful Key Passes'), 0),
+              "final_third_passes": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Successful Final Third Passes'), 0),
+              "expected_goals": next((float(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Expected Goals (xG)'), 0.0),
+              "minutes_played": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Time Played'), 0),
+              "appearances": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Appearances'), 0),
+              "games_played": next((int(s.get('value', 0)) for s in person.get('_stats', []) if s.get('name') == 'Games Played'), 0)
+            },
+            "lastUpdated": person.get('_lastUpdated', ''),
+            "title": person.get('matchName', person.get('knownName', f"{person.get('firstName','')} {person.get('lastName','')}".strip()))
+          }
+          for person in $.get('players_raw', [])
+          if person.get('id') and person.get('type', 'player') == 'player'
+        ]

--- a/connectors/stats-perform/workflows/sync-players.yml
+++ b/connectors/stats-perform/workflows/sync-players.yml
@@ -1,0 +1,168 @@
+workflow:
+  name: "sp-opta-sync-players"
+  title: "Stats Perform Opta - Players"
+  description: "Workflow to synchronize players (with squad bio + per-season aggregated stats) from Stats Perform Opta API to Machina sport:Player documents. Pass season_id (tournament calendar) to import bio for ALL squads of the season; pass team_id additionally to enrich one team's players with seasonstats (goals, shots, xG, key passes, …)."
+  context-variables:
+    debugger:
+      enabled: true
+    opta:
+      outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
+      secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
+  inputs:
+    season_id: "$.get('season_id')"
+    team_id: "$.get('team_id', '')"
+  outputs:
+    players: "$.get('iptc_players', [])"
+    workflow-status: "len($.get('all_player_ids', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+
+    # Get OAuth access token
+    - type: "connector"
+      name: "get-access-token"
+      description: "Get OAuth access token from Stats Perform Opta API."
+      condition: "$.get('season_id') is not None"
+      connector:
+        name: "opta"
+        command: "authorization"
+      outputs:
+        access_token: "$.get('access_token')"
+
+    # Load squads (TM3) for ALL teams of the tournament calendar (season).
+    # Returns squad[].person[] grouped per contestant. We pass competition_id=""
+    # so the connector skips appending `comp=` to the URL — TM3 only accepts
+    # tmcl / ctst / prsn filters and rejects comp with Opta error 10201.
+    - type: "connector"
+      name: "load-squads"
+      description: "Get all squads (bio per player) for the season from Stats Perform Opta squads endpoint (TM3)."
+      condition: "$.get('access_token') is not None and $.get('season_id') is not None"
+      connector:
+        name: "opta"
+        command: "invoke_request"
+      inputs:
+        access_token: "$.get('access_token')"
+        endpoint: "'squads'"
+        competition_id: "''"
+        query_params: |
+          {
+            'tmcl': str($.get('season_id'))
+          }
+      outputs:
+        squads_raw: "$.get('squad', [])"
+        squads_last_updated: "$.get('lastUpdated', '')"
+
+    # Load per-team season-aggregated player stats (TM4 seasonstats).
+    # seasonstats REQUIRES a `ctst` (contestant) — there's no season-wide
+    # call available in the standard subscription. If team_id is omitted
+    # this task is skipped and stats default to zero for every player.
+    # The data shape is `{player: [{id, stat: [{name,value}], …}]}`.
+    - type: "connector"
+      name: "load-player-stats"
+      description: "Get season-aggregated player stats from Stats Perform Opta seasonstats endpoint (TM4) for a single team."
+      condition: "$.get('access_token') is not None and $.get('season_id') is not None and $.get('team_id', '') != ''"
+      connector:
+        name: "opta"
+        command: "invoke_request"
+      inputs:
+        access_token: "$.get('access_token')"
+        endpoint: "'seasonstats'"
+        competition_id: "''"
+        query_params: |
+          {
+            'tmcl': str($.get('season_id')),
+            'ctst': str($.get('team_id'))
+          }
+      outputs:
+        stats_players_raw: "$.get('player', [])"
+
+    # Flatten squad[].person[] into a single list and JOIN per personId with
+    # the stats payload (when present). Done inline (no extra connector) so
+    # the resulting `players_raw` already carries the squad context fields
+    # (_contestantId, _contestantName, _competitionId, …) plus the player's
+    # `_stats` array, ready for the IPTC mapping.
+    - type: "mapping"
+      name: "iptc-opta-player-mapping"
+      description: "Convert squads + stats join to IPTC Sport Schema player format."
+      condition: "$.get('squads_raw') is not None"
+      inputs:
+        players_raw: |
+          [
+            {
+              **person,
+              '_contestantId': squad.get('contestantId', ''),
+              '_contestantName': squad.get('contestantName', ''),
+              '_contestantCode': squad.get('contestantCode', ''),
+              '_competitionId': squad.get('competitionId', ''),
+              '_competitionName': squad.get('competitionName', ''),
+              '_seasonId': squad.get('tournamentCalendarId', str($.get('season_id', ''))),
+              '_lastUpdated': $.get('squads_last_updated', ''),
+              '_stats': next(
+                (p.get('stat', []) for p in $.get('stats_players_raw', []) if p.get('id') == person.get('id')),
+                []
+              )
+            }
+            for squad in $.get('squads_raw', [])
+            for person in squad.get('person', [])
+            if person is not None
+              and person.get('id')
+              and person.get('type', 'player') == 'player'
+          ]
+      outputs:
+        iptc_players: "$.get('sport_schema_players', [])"
+        all_player_ids: |
+          [str(p.get('@id', '')) for p in $.get('sport_schema_players', [])]
+
+    # Load existing player documents by ID so we only insert/update what changed.
+    - type: "document"
+      name: "load-players-by-ids"
+      description: "Load existing players by Opta IDs to compute deltas."
+      condition: "$.get('all_player_ids') is not None and len($.get('all_player_ids', [])) > 0"
+      config:
+        action: "search"
+        search-limit: 10000
+        search-vector: false
+      filters:
+        metadata.player_code: |
+          {'$in': $.(all_player_ids)}
+      inputs:
+        name: "'sport:Player'"
+      outputs:
+        existing_player_ids: |
+          [
+            doc.get('metadata', {}).get('player_code', '')
+            for doc in $.get('documents', [])
+          ]
+
+    # Bulk save players. embed-vector: false to avoid the current
+    # invoke_embedding bug on this project (same workaround used by
+    # sync-match-stats and sync-competitions).
+    - type: "document"
+      name: "bulk-save-players"
+      description: "Bulk save the individual players as sport:Player documents."
+      condition: "$.get('all_player_ids') is not None and len($.get('all_player_ids', [])) > 0"
+      config:
+        action: "bulk-save"
+        embed-vector: false
+        force-update: true
+      document_name: "'sport:Player'"
+      documents:
+        items: "$.get('new_players_list')"
+      inputs:
+        new_players_list: |
+          [
+            {
+              **p,
+              'metadata': {
+                'player_code': str(p.get('@id', '')),
+                'club_id': str(p.get('sport:clubId', '')),
+                'club_code': str(p.get('sport:clubCode', '')),
+                'competition_id': str(p.get('sport:competitionId', '')),
+                'season_id': str(p.get('sport:seasonId', '')),
+                'position': str(p.get('sport:position', '')),
+                'nationality': str(p.get('sport:nationality', ''))
+              },
+              'title': p.get('title', p.get('name', ''))
+            }
+            for p in $.get('iptc_players', [])
+          ]
+      metadata:
+        document_type: "'sp-player'"


### PR DESCRIPTION
Ports the sp-opta-sync-players workflow + iptc-player mapping that Factory generated for the r10 Copa portal. Workflow joins Opta squads (TM3, biographical fields) with playerseasonstats (TM4, aggregated match stats) on personId and emits one IPTC Sport Schema document per player as `sport:Player`. Pass season_id (tournament calendar) to import bios for ALL squads of the season; optional team_id additionally enriches one team's players with goals / shots / xG / key passes.

Unblocks Section 2 (Comparador de jogadores) of the r10 site — once the workflow is dispatched against a populated season, the autocomplete
+ stats grid have real data to render instead of the "Sincronizando jogadores…" fallback.

Source: github.com/machina-sports/crie-um-novo-template-no-mpiwj9hn PR #1 (Factory misnamed the repo; this commit lands the same files in the canonical stats-perform connector path).

# Pull Request

## What

<!-- Short description of what this PR does. -->

## Why

<!-- The motivation: which problem does it solve? Link issues / tickets. -->

## How

<!-- Brief notes on the approach, key decisions, and trade-offs. -->

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `perf:`, `revert:`)
- [ ] No `.env` / secrets / credentials committed (gitleaks will block)
- [ ] Lint, typecheck, tests, and build pass locally
- [ ] Targeting `staging` (default) — direct PRs to `main` only for hotfixes
- [ ] Updated `CHANGELOG.md` / docs if user-facing behavior changed
- [ ] Added or updated tests for new behavior

## Deploy notes

<!-- Anything special the deploy needs to know (env vars, migrations, feature flags)? -->

## Screenshots / videos

<!-- Optional, for UI changes. -->
