### PR TITLE
feat: futebol-brasil coverage enrich (api-football)

### DIFF
--- a/agent-templates/futebol-brasil/coverage/enrich/README.md
+++ b/agent-templates/futebol-brasil/coverage/enrich/README.md
@@ -1,0 +1,124 @@
+# Futebol Brasil — Coverage / Enrich
+
+Performant, incremental coverage module for the 5 pinned Brazilian
+football targets. Reuses the existing `api-football` connector — does
+NOT install a duplicate source.
+
+## Scope (5 targets, data-driven)
+
+| key                  | id            | source                | written docs                                   |
+| -------------------- | ------------- | --------------------- | ---------------------------------------------- |
+| `brasileirao-serie-a`| league 71     | api-football          | competition, fixture, standings, leaders, roster, competitor |
+| `libertadores`       | league 13     | api-football          | competition, fixture, standings, leaders, competitor          |
+| `copa-do-brasil`     | league 73     | api-football          | competition, fixture, leaders, competitor                     |
+| `sudamericana`       | league 11     | api-football          | competition, fixture, standings, leaders, competitor          |
+| `selecao`            | team 6        | api-football          | fixture, roster, competitor                                   |
+
+Competition ids are seeded by `load-leagues-config.yml` and stored in the
+`futebol-brasil-coverage-config` document so they can be reconfigured
+without redeploying the template.
+
+## Documents written (brand-agnostic, `brasil-*` namespace)
+
+| document name              | shape                                                                                            | key metadata                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| `futebol-brasil-coverage-config` | seed config: pinned competitions + national teams + per-resource stale_hours              | `scope`                               |
+| `futebol-brasil-competition` | per-league control plane: `version_control` (`*_synced_at`), `staleness_policy`, `has_*` flags | `league_id`, `season`, `key`          |
+| `brasil-fixture`           | slim fixture: status, teams, goals, score, venue, league                                         | `fixture_id`, `league_id`, `season`, `home_team_id`, `away_team_id`, `status_short`, `date`, `competition`, `updated_at` |
+| `brasil-standings`         | league table: rows[] with rank, points, goalsDiff, form, all/home/away                           | `league_id`, `season`, `competition`, `updated_at` |
+| `brasil-leaders`           | team-leader categories computed from standings: top_points, top_attack, top_defense, top_goal_diff, top_form | `league_id`, `season` |
+| `brasil-roster`            | squad of ONE team: players[], players_count, synced_at                                            | `team_id`, `league_id`, `season`      |
+| `brasil-competitor`        | per-team rollup: standings row + roster summary + last 5 + next 5 fixtures                       | `team_id`, `league_id`, `season`      |
+
+The two `futebol-brasil-*` documents (`coverage-config`, `competition`)
+are the **control plane** — they're not consumed by frontends. Everything
+a UI or downstream agent needs reads from the `brasil-*` namespace.
+
+## Architecture (per tick)
+
+```
+                ┌─── futebol-brasil-coverage-checkin
+                │      (pick least-recently checked-out league, lock)
+                ▼
+        futebol-brasil-coverage-gateway
+                │      (zero-API; reads version_control + staleness_policy)
+                ▼
+   ┌────────────┼────────────┬────────────┐
+   ▼            ▼            ▼            ▼
+load-fixtures  load-      load-season-  load-rosters (foreach team)
+               standings  leaders
+               (derived from standings; cheap re-projection)
+   │            │            │            │
+   └────────────┴─────┬──────┴────────────┘
+                     ▼
+            enrich-competitor (foreach team — joins standings + roster + fixtures)
+                     │
+                     ▼
+        futebol-brasil-coverage-checkout
+                (release lock + stamp last_full_refresh_at)
+```
+
+The agent runs ONE competition per tick, auto-rotating via the
+check-in's "least-recently checked-out" sort. Combined with
+`config-frequency: 1` (minute), that gives the 4 league agents a
+~4-minute end-to-end refresh ceiling — well below the
+`fixtures_stale_hours: 1` budget.
+
+The national team (Seleção) runs on a separate agent
+(`futebol-brasil-coverage-selecao`) at 6h cadence — rosters are slow-moving
+and fixtures are sparse outside FIFA windows.
+
+## Performance discipline
+
+- **Incremental**: every load-* checks the competition doc's
+  `version_control.<resource>_synced_at` and skips when fresher than
+  the per-resource `staleness_policy.<resource>_stale_hours`.
+- **Batch**: every persistence is `bulk-update` with a deterministic
+  `title` key; one round-trip per resource per league.
+- **Idempotent**: re-running any workflow is a no-op when nothing
+  drifted. Force-refresh via `force: True` input.
+- **Soft-locked**: `processing` flag on the competition doc prevents
+  two concurrent ticks racing the same league. The checkout always
+  runs (no condition) so stuck locks self-heal.
+- **Zero LLM, zero mock**: every document is a deterministic
+  projection of an api-football response.
+
+## First-run bootstrap
+
+```bash
+# Seed the config doc (5 pinned competitions)
+machina workflow run futebol-brasil-coverage-load-leagues-config
+
+# Seed the 4 competition control docs
+machina workflow run futebol-brasil-coverage-load-competitions
+
+# Run one tick of the league agent (auto-picks the first competition)
+machina agent run futebol-brasil-coverage-enrich --sync
+
+# Run one tick of the Seleção agent
+machina agent run futebol-brasil-coverage-selecao --sync
+
+# Enable the agents to run on schedule (Studio: set status to active)
+```
+
+## Notes / known limitations
+
+- **Player-level season leaders** (top-scorers, top-assists) require
+  the `/players/topscorers` and `/players/topassists` endpoints. They
+  are NOT exposed by the api-football connector in this project, so
+  `brasil-leaders` falls back to **team-level** leaders aggregated
+  from the standings (top_points / top_attack / top_defense /
+  top_goal_diff / top_form). When the connector gains player-level
+  top* commands, swap the `aggregate-leaders` task in
+  `load-season-leaders.yml` for a connector fetch — the document
+  shape and consumers stay the same.
+- **Copa do Brasil** is `has_standings: False` (single-elimination
+  cup); the gateway always emits `should-load-standings: False` for it.
+  Leaders for Copa do Brasil are therefore empty until the connector
+  exposes top-scorers.
+- **Roster freshness** uses the value-level `synced_at` on the
+  `brasil-roster` doc (not the competition's `version_control`), so
+  national-team rosters can be tracked independently of any league.
+- **No odds**: this module is a pure data-acquisition layer.
+  Connect an odds connector and a separate enrich-* workflow if odds
+  are needed downstream.

--- a/agent-templates/futebol-brasil/coverage/enrich/_install.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/_install.yml
@@ -1,0 +1,70 @@
+setup:
+  title: Futebol Brasil - Coverage Enrich
+  description: |
+    Performant, incremental coverage module for the 5 pinned Brazilian
+    football targets (Brasileirão Série A, Libertadores, Copa do Brasil,
+    Sudamericana, Seleção Brasileira). Uses the existing api-football
+    connector — does NOT install a duplicate source. No odds, no mocks.
+
+    Writes brand-agnostic brasil-* documents (fixture, standings,
+    leaders, roster, competitor) with version_control + staleness
+    policy so downstream consumers can render without re-fetching.
+  category:
+    - data-acquisition
+    - football
+  estimatedTime: 5 minutes
+  features:
+    - "5 pinned competitions (Brasileirão A, Libertadores, Copa do Brasil, Sudamericana, Seleção)"
+    - "Incremental loaders — per-resource staleness policy skips fresh data"
+    - "Soft-lock check-in/check-out — safe for high-frequency scheduling"
+    - "Brand-agnostic brasil-* documents (fixture, standings, leaders, roster, competitor)"
+    - "Reuses the existing api-football connector — no duplicate source"
+    - "Zero-LLM, zero-mock — deterministic projection from the api response"
+  integrations:
+    - api-football
+  status: available
+  value: agent-templates/futebol-brasil/coverage/enrich
+  version: 1.0.0
+
+datasets:
+
+  # config workflow (seeds the 5 pinned competitions)
+  - type: "workflow"
+    path: "load-leagues-config.yml"
+
+  # gateway / check-in / check-out
+  - type: "workflow"
+    path: "workflows/coverage-gateway.yml"
+
+  - type: "workflow"
+    path: "workflows/checkin.yml"
+
+  - type: "workflow"
+    path: "workflows/checkout.yml"
+
+  # load-* workflows (api-football → brasil-* documents)
+  - type: "workflow"
+    path: "workflows/load-competitions.yml"
+
+  - type: "workflow"
+    path: "workflows/load-fixtures.yml"
+
+  - type: "workflow"
+    path: "workflows/load-standings.yml"
+
+  - type: "workflow"
+    path: "workflows/load-rosters.yml"
+
+  - type: "workflow"
+    path: "workflows/load-season-leaders.yml"
+
+  # enrich-* workflows (pure document joins, no API)
+  - type: "workflow"
+    path: "workflows/enrich-competitor.yml"
+
+  # agents
+  - type: "agent"
+    path: "agent.yml"
+
+  - type: "agent"
+    path: "agent-selecao.yml"

--- a/agent-templates/futebol-brasil/coverage/enrich/agent-selecao.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/agent-selecao.yml
@@ -1,0 +1,42 @@
+agent:
+  name: futebol-brasil-coverage-selecao
+  title: Futebol Brasil - Coverage Seleção
+  description: |
+    Per-tick coverage agent for the Brazilian national team
+    (team_id=6). National teams don't fit the league/season gateway
+    pattern (no standings, no leaders) so they get a dedicated agent:
+      - load-fixtures in team mode (last 20 + next 20)
+      - load-rosters (squad)
+      - enrich-competitor (recent + upcoming + roster summary)
+
+    Lighter than the league agent — runs in a fixed 6h cadence by default.
+    Start status=inactive; operator enables in Studio.
+  context:
+    config-frequency: 360
+    status: "inactive"
+  workflows:
+
+    # 1. Fixtures for the national team
+    - name: futebol-brasil-coverage-load-fixtures
+      description: Last 20 + next 20 fixtures for Seleção (team_id=6).
+      inputs:
+        team_id: 6
+      outputs:
+        fixtures-status: $.get('workflow-status', 'skipped')
+        fixtures-upserted: $.get('fixtures-upserted', 0)
+
+    # 2. Roster (squad)
+    - name: futebol-brasil-coverage-load-rosters
+      description: Current squad for Seleção (team_id=6).
+      inputs:
+        team_id: 6
+      outputs:
+        rosters-status: $.get('workflow-status', 'skipped')
+
+    # 3. Build brasil-competitor doc for Seleção
+    - name: futebol-brasil-coverage-enrich-competitor
+      description: Aggregate brasil-competitor for Seleção.
+      inputs:
+        team_id: 6
+      outputs:
+        competitor-status: $.get('workflow-status', 'skipped')

--- a/agent-templates/futebol-brasil/coverage/enrich/agent.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/agent.yml
@@ -1,0 +1,119 @@
+agent:
+  name: futebol-brasil-coverage-enrich
+  title: Futebol Brasil - Coverage Enrich
+  description: |
+    Per-tick coverage agent for the 5 pinned Brazilian football targets
+    (Brasileirão Série A, Libertadores, Copa do Brasil, Sudamericana,
+    Seleção Brasileira). One tick processes ONE competition selected by
+    futebol-brasil-coverage-checkin (auto-rotates least-recently
+    checked-out), runs the gateway to decide which resources are
+    stale, dispatches conditional load-* workflows, then releases the
+    lock via checkout.
+
+    Lean, incremental, idempotent — safe to schedule every minute.
+    Start status=inactive; operator enables in Studio.
+
+    First-run bootstrap:
+      1. Run futebol-brasil-coverage-load-leagues-config (seeds config).
+      2. Run futebol-brasil-coverage-load-competitions (seeds 4 competition docs).
+      3. Enable this agent.
+  context:
+    config-frequency: 1
+    status: "inactive"
+  workflows:
+
+    # 1. Pick a competition for this tick
+    - name: futebol-brasil-coverage-checkin
+      description: Pick ONE competition to process this tick.
+      outputs:
+        selected-league_id: $.get('selected-league_id')
+        selected-season: $.get('selected-season')
+        selected-competition: $.get('selected-competition', {})
+
+    # 2. Decide what's stale (zero API cost)
+    - name: futebol-brasil-coverage-gateway
+      description: Emit should-load-* signals for the picked competition.
+      condition: $.get('selected-league_id') is not None
+      inputs:
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        should-load-fixtures: $.get('should-load-fixtures', False)
+        should-load-standings: $.get('should-load-standings', False)
+        should-load-leaders: $.get('should-load-leaders', False)
+        should-load-rosters: $.get('should-load-rosters', False)
+
+    # 3. Load fixtures (api-football)
+    - name: futebol-brasil-coverage-load-fixtures
+      description: Load fixtures for the picked league/season.
+      condition: $.get('should-load-fixtures') is True
+      inputs:
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        fixtures-status: $.get('workflow-status', 'skipped')
+        fixtures-upserted: $.get('fixtures-upserted', 0)
+
+    # 4. Load standings (api-football)
+    - name: futebol-brasil-coverage-load-standings
+      description: Load standings for the picked league/season.
+      condition: $.get('should-load-standings') is True
+      inputs:
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        standings-status: $.get('workflow-status', 'skipped')
+        teams-in-table: $.get('teams-in-table', 0)
+        standings-rows: $.get('standings-rows', [])
+
+    # 5. Load season-leaders (derived from standings; cheap re-projection)
+    - name: futebol-brasil-coverage-load-season-leaders
+      description: Recompute leaders from the freshly-loaded standings.
+      condition: $.get('should-load-leaders') is True
+      inputs:
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        leaders-status: $.get('workflow-status', 'skipped')
+
+    # 6. Load rosters for every team in the standings (foreach)
+    - name: futebol-brasil-coverage-load-rosters
+      description: Load roster for each team in the standings table.
+      condition: $.get('should-load-rosters') is True and len($.get('standings-rows', [])) > 0
+      foreach:
+        name: row
+        expr: $
+        value: $.get('standings-rows', []) or []
+      inputs:
+        team_id: $.get('row').get('team', {}).get('id')
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        rosters-status: $.get('workflow-status', 'skipped')
+
+    # 7. Enrich competitor doc per team (cross-doc join, no API)
+    - name: futebol-brasil-coverage-enrich-competitor
+      description: Build a brasil-competitor doc per team in the table.
+      condition: $.get('should-load-standings') is True and len($.get('standings-rows', [])) > 0
+      foreach:
+        name: row
+        expr: $
+        value: $.get('standings-rows', []) or []
+      inputs:
+        team_id: $.get('row').get('team', {}).get('id')
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+      outputs:
+        competitor-status: $.get('workflow-status', 'skipped')
+
+    # 8. Release lock + stamp last_full_refresh_at
+    - name: futebol-brasil-coverage-checkout
+      description: Release the soft lock and stamp last_full_refresh_at.
+      condition: $.get('selected-league_id') is not None
+      inputs:
+        league_id: $.get('selected-league_id')
+        season: $.get('selected-season')
+        any_load_executed: |
+          ($.get('fixtures-status') == 'executed') or ($.get('standings-status') == 'executed') or ($.get('leaders-status') == 'executed') or ($.get('rosters-status') == 'executed')
+      outputs:
+        checked-out: $.get('checked-out', False)

--- a/agent-templates/futebol-brasil/coverage/enrich/load-leagues-config.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/load-leagues-config.yml
@@ -1,0 +1,154 @@
+workflow:
+
+  # futebol-brasil-coverage-load-leagues-config
+  name: "futebol-brasil-coverage-load-leagues-config"
+  title: "Futebol Brasil - Coverage Load Leagues Config"
+  description: |
+    Seeds the futebol-brasil-coverage-config document with the 5 pinned
+    Brazilian football targets (Seleção + Brasileirão A + Libertadores +
+    Copa do Brasil + Sudamericana). Idempotent — only writes when missing
+    or when force=True.
+
+    Each competition entry carries:
+    - league_id / season (api-football identifiers)
+    - key / short_name / logo (display)
+    - has_standings / has_leaders / has_rosters (capability flags)
+    - *_stale_hours (per-resource freshness policy, drives gateway)
+    - enabled (master switch per competition)
+
+    National teams use team_id instead of league_id (Seleção has no
+    standings, only fixtures + roster).
+  inputs:
+    force: "$.get('force', False)"
+  outputs:
+    config-exists: "$.get('config-exists', False)"
+    workflow-status: "'executed' if $.get('seeded') or $.get('force', False) else 'skipped'"
+  tasks:
+
+    # check-existing-config
+    - type: "document"
+      name: "check-existing-config"
+      description: "Look for an existing futebol-brasil-coverage-config document."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-coverage-config'"
+      outputs:
+        config-exists: "len($.get('documents', [])) > 0"
+
+    # seed-config
+    - type: "document"
+      name: "seed-config"
+      description: "Seed the futebol-brasil-coverage-config document if it doesn't exist (or force=True)."
+      condition: "$.get('config-exists') is not True or $.get('force', False) is True"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'futebol-brasil-coverage-config'"
+      documents:
+        futebol-brasil-coverage-config: |
+          {
+            'scope': 'futebol-brasil',
+            'competitions': [
+              {
+                'key': 'brasileirao-serie-a',
+                'league_id': 71,
+                'season': 2026,
+                'name': 'Brasileirão Série A',
+                'short_name': 'Brasileirão',
+                'country': 'Brazil',
+                'type': 'League',
+                'logo': 'https://media.api-sports.io/football/leagues/71.png',
+                'has_standings': True,
+                'has_leaders': True,
+                'has_rosters': True,
+                'enabled': True,
+                'fixtures_stale_hours': 1,
+                'standings_stale_hours': 1,
+                'leaders_stale_hours': 6,
+                'rosters_stale_hours': 168,
+                'competition_stale_hours': 24
+              },
+              {
+                'key': 'libertadores',
+                'league_id': 13,
+                'season': 2026,
+                'name': 'CONMEBOL Libertadores',
+                'short_name': 'Libertadores',
+                'country': 'World',
+                'type': 'Cup',
+                'logo': 'https://media.api-sports.io/football/leagues/13.png',
+                'has_standings': True,
+                'has_leaders': True,
+                'has_rosters': False,
+                'enabled': True,
+                'fixtures_stale_hours': 1,
+                'standings_stale_hours': 2,
+                'leaders_stale_hours': 12,
+                'rosters_stale_hours': 168,
+                'competition_stale_hours': 24
+              },
+              {
+                'key': 'copa-do-brasil',
+                'league_id': 73,
+                'season': 2026,
+                'name': 'Copa do Brasil',
+                'short_name': 'Copa do Brasil',
+                'country': 'Brazil',
+                'type': 'Cup',
+                'logo': 'https://media.api-sports.io/football/leagues/73.png',
+                'has_standings': False,
+                'has_leaders': True,
+                'has_rosters': False,
+                'enabled': True,
+                'fixtures_stale_hours': 1,
+                'standings_stale_hours': 0,
+                'leaders_stale_hours': 12,
+                'rosters_stale_hours': 168,
+                'competition_stale_hours': 24
+              },
+              {
+                'key': 'sudamericana',
+                'league_id': 11,
+                'season': 2026,
+                'name': 'CONMEBOL Sudamericana',
+                'short_name': 'Sudamericana',
+                'country': 'World',
+                'type': 'Cup',
+                'logo': 'https://media.api-sports.io/football/leagues/11.png',
+                'has_standings': True,
+                'has_leaders': True,
+                'has_rosters': False,
+                'enabled': True,
+                'fixtures_stale_hours': 1,
+                'standings_stale_hours': 2,
+                'leaders_stale_hours': 12,
+                'rosters_stale_hours': 168,
+                'competition_stale_hours': 24
+              }
+            ],
+            'national_teams': [
+              {
+                'key': 'selecao',
+                'team_id': 6,
+                'name': 'Brasil',
+                'short_name': 'Seleção',
+                'country': 'Brazil',
+                'logo': 'https://media.api-sports.io/football/teams/6.png',
+                'has_rosters': True,
+                'enabled': True,
+                'fixtures_stale_hours': 1,
+                'rosters_stale_hours': 168
+              }
+            ],
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      metadata:
+        document_type: "'config'"
+        scope: "'futebol-brasil'"
+      outputs:
+        seeded: "True"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/checkin.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/checkin.yml
@@ -1,0 +1,94 @@
+workflow:
+
+  # futebol-brasil-coverage-checkin
+  name: "futebol-brasil-coverage-checkin"
+  title: "Futebol Brasil - Coverage Check-In"
+  description: |
+    Picks ONE competition to process this tick and marks it as
+    processing=True (soft lock). Two selection modes:
+      - Manual: caller passes league_id -> use that doc if not locked.
+      - Auto: pick the least-recently checked-out enabled competition.
+
+    The processing flag is cleared by the checkout workflow at the end
+    of the tick.
+  inputs:
+    league_id: "$.get('league_id')"
+  outputs:
+    selected-competition: "$.get('selected-competition', {})"
+    selected-league_id: "$.get('selected-league_id')"
+    selected-season: "$.get('selected-season')"
+    workflow-status: "($.get('selected-league_id') is not None) and 'executed' or 'skipped'"
+  tasks:
+
+    # search-manual
+    - type: "document"
+      name: "search-manual"
+      description: "Manual override: pick the doc for the given league_id (if not locked)."
+      condition: "$.get('league_id') is not None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        value.version_control.processing: "{'$ne': True}"
+      outputs:
+        manual-doc: "$.get('documents', [{}])[0] if $.get('documents') else None"
+
+    # search-auto
+    - type: "document"
+      name: "search-auto"
+      description: "Auto-select the least-recently checked-out enabled competition."
+      condition: "$.get('league_id') is None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+        search-sorters: [["value.version_control.last_checkout_at", 1]]
+      filters:
+        name: "'futebol-brasil-competition'"
+        value.version_control.processing: "{'$ne': True}"
+      outputs:
+        auto-doc: "$.get('documents', [{}])[0] if $.get('documents') else None"
+
+    # resolve-selection
+    - type: "document"
+      name: "resolve-selection"
+      description: "Resolve manual vs auto pick (manual wins)."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'__futebol_brasil_noop__'"
+      outputs:
+        chosen-doc: "$.get('manual-doc') or $.get('auto-doc')"
+        chosen-document_id: "($.get('manual-doc') or $.get('auto-doc') or {}).get('_id')"
+        chosen-value: "($.get('manual-doc') or $.get('auto-doc') or {}).get('value', {})"
+        selected-competition: "($.get('manual-doc') or $.get('auto-doc') or {}).get('value', {})"
+        selected-league_id: "($.get('manual-doc') or $.get('auto-doc') or {}).get('metadata', {}).get('league_id')"
+        selected-season: "($.get('manual-doc') or $.get('auto-doc') or {}).get('metadata', {}).get('season')"
+
+    # mark-processing
+    - type: "document"
+      name: "mark-processing"
+      description: "Set processing=True and stamp last_checkin_at."
+      condition: "$.get('chosen-document_id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        document_id: "$.get('chosen-document_id')"
+      documents:
+        futebol-brasil-competition: |
+          {
+            **$.get('chosen-value', {}),
+            'version_control': {
+              **$.get('chosen-value', {}).get('version_control', {}),
+              'processing': True,
+              'last_checkin_at': datetime.utcnow().isoformat() + 'Z'
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/checkout.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/checkout.yml
@@ -1,0 +1,64 @@
+workflow:
+
+  # futebol-brasil-coverage-checkout
+  name: "futebol-brasil-coverage-checkout"
+  title: "Futebol Brasil - Coverage Check-Out"
+  description: |
+    Release the soft lock (processing=False) on the competition doc.
+    Stamps last_checkout_at; sets last_full_refresh_at when at least
+    one load-* workflow executed during this tick.
+
+    Should ALWAYS run at the tail of the coverage agent (no condition),
+    to guarantee locks get released even when individual load-*
+    workflows fail or skip.
+  inputs:
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+    any_load_executed: "$.get('any_load_executed', False)"
+    lock_timeout_minutes: "$.get('lock_timeout_minutes', 30)"
+  outputs:
+    checked-out: "$.get('checked-out', False)"
+    workflow-status: "'executed'"
+  tasks:
+
+    # load-current-doc
+    - type: "document"
+      name: "load-current-doc"
+      description: "Pull competition doc."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        comp-document_id: "$.get('documents', [{}])[0].get('_id') if $.get('documents') else None"
+        comp-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+
+    # release-lock
+    - type: "document"
+      name: "release-lock"
+      description: "Clear processing=True and stamp last_checkout_at."
+      condition: "$.get('comp-document_id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        document_id: "$.get('comp-document_id')"
+      documents:
+        futebol-brasil-competition: |
+          {
+            **$.get('comp-value', {}),
+            'version_control': {
+              **$.get('comp-value', {}).get('version_control', {}),
+              'processing': False,
+              'last_checkout_at': datetime.utcnow().isoformat() + 'Z',
+              'last_full_refresh_at': (datetime.utcnow().isoformat() + 'Z' if $.get('any_load_executed', False) is True else $.get('comp-value', {}).get('version_control', {}).get('last_full_refresh_at'))
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      outputs:
+        checked-out: "True"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/coverage-gateway.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/coverage-gateway.yml
@@ -1,0 +1,43 @@
+workflow:
+
+  # futebol-brasil-coverage-gateway
+  name: "futebol-brasil-coverage-gateway"
+  title: "Futebol Brasil - Coverage Gateway"
+  description: |
+    Zero-API decision step: reads the competition doc's
+    version_control + staleness_policy and emits should-load-* signals
+    for fixtures / standings / leaders / rosters. The coverage agent
+    uses these signals to decide which load-* workflows to run.
+
+    All four signals respect the per-resource stale_hours window from
+    the competition doc's staleness_policy (seeded by load-leagues-config).
+  inputs:
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+    force: "$.get('force', False)"
+  outputs:
+    should-load-fixtures: "$.get('should-load-fixtures', False)"
+    should-load-standings: "$.get('should-load-standings', False)"
+    should-load-leaders: "$.get('should-load-leaders', False)"
+    should-load-rosters: "$.get('should-load-rosters', False)"
+    workflow-status: "'executed'"
+  tasks:
+
+    # load-competition
+    - type: "document"
+      name: "load-competition"
+      description: "Read the competition doc."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        comp-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        should-load-fixtures: "($.get('force', False) is True or not $.get('documents') or not $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('fixtures_synced_at') or ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('fixtures_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 >= $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('fixtures_stale_hours', 1)))"
+        should-load-standings: "($.get('documents', [{}])[0].get('value', {}).get('has_standings', False) and ($.get('force', False) is True or not $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('standings_synced_at') or ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('standings_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 >= $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('standings_stale_hours', 1)))) if $.get('documents') else False"
+        should-load-leaders: "($.get('documents', [{}])[0].get('value', {}).get('has_leaders', False) and ($.get('force', False) is True or not $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('leaders_synced_at') or ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('leaders_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 >= $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('leaders_stale_hours', 6)))) if $.get('documents') else False"
+        should-load-rosters: "($.get('documents', [{}])[0].get('value', {}).get('has_rosters', False) and ($.get('force', False) is True or not $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('rosters_synced_at') or ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('rosters_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 >= $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('rosters_stale_hours', 168)))) if $.get('documents') else False"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/enrich-competitor.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/enrich-competitor.yml
@@ -1,0 +1,158 @@
+workflow:
+
+  # futebol-brasil-coverage-enrich-competitor
+  name: "futebol-brasil-coverage-enrich-competitor"
+  title: "Futebol Brasil - Coverage Enrich Competitor"
+  description: |
+    Build one consolidated brasil-competitor document per team by
+    joining data already loaded by the load-* workflows:
+      - brasil-standings (rank, points, goals_for/against, form)
+      - brasil-roster    (squad, players_count)
+      - brasil-fixture   (last 5 + next 5 matches for the team)
+
+    Pure document workflow — does NOT hit api-football. Cheap and
+    idempotent: safe to schedule per team after the loaders fill the
+    upstream docs. Caller passes team_id (+ optional league_id/season
+    to scope the standings + fixtures join).
+
+    Inputs:
+      team_id    - api-football team id (required)
+      league_id  - scope standings + fixtures lookup
+      season     - scope standings + fixtures lookup
+  inputs:
+    team_id: "$.get('team_id')"
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+  outputs:
+    competitor-written: "$.get('competitor-written', False)"
+    workflow-status: "$.get('competitor-written') and 'executed' or 'skipped'"
+  tasks:
+
+    # load-standings (find this team's row)
+    - type: "document"
+      name: "load-standings"
+      description: "Read the league's brasil-standings doc."
+      condition: "$.get('team_id') is not None and $.get('league_id') is not None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'brasil-standings'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        standings-row: "[r for r in $.get('documents', [{}])[0].get('value', {}).get('rows', []) if r.get('team', {}).get('id') == $.get('team_id')][:1] if $.get('documents') else []"
+        league-name: "$.get('documents', [{}])[0].get('value', {}).get('league_name') if $.get('documents') else None"
+
+    # load-roster
+    - type: "document"
+      name: "load-roster"
+      description: "Read brasil-roster doc for the team."
+      condition: "$.get('team_id') is not None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'brasil-roster'"
+        metadata.team_id: "$.get('team_id')"
+      outputs:
+        roster-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+
+    # load-recent-fixtures
+    - type: "document"
+      name: "load-recent-fixtures"
+      description: "Last 5 fixtures (any status: finished, postponed, …)."
+      condition: "$.get('team_id') is not None"
+      config:
+        action: "search"
+        search-limit: 5
+        search-vector: false
+        search-sorters: [["value.timestamp", -1]]
+      filters:
+        name: "'brasil-fixture'"
+        '$or': "[{'metadata.home_team_id': $.get('team_id')}, {'metadata.away_team_id': $.get('team_id')}]"
+        value.timestamp: "{'$lte': int(datetime.utcnow().timestamp())}"
+      outputs:
+        recent-fixtures: |
+          [
+            {
+              'fixture_id': d.get('value', {}).get('fixture_id'),
+              'date': d.get('value', {}).get('date'),
+              'status': d.get('value', {}).get('status', {}).get('short'),
+              'home': d.get('value', {}).get('teams', {}).get('home', {}),
+              'away': d.get('value', {}).get('teams', {}).get('away', {}),
+              'goals': d.get('value', {}).get('goals', {}),
+              'league': d.get('value', {}).get('league', {}).get('name')
+            }
+            for d in $.get('documents', [])
+          ]
+
+    # load-upcoming-fixtures
+    - type: "document"
+      name: "load-upcoming-fixtures"
+      description: "Next 5 fixtures."
+      condition: "$.get('team_id') is not None"
+      config:
+        action: "search"
+        search-limit: 5
+        search-vector: false
+        search-sorters: [["value.timestamp", 1]]
+      filters:
+        name: "'brasil-fixture'"
+        '$or': "[{'metadata.home_team_id': $.get('team_id')}, {'metadata.away_team_id': $.get('team_id')}]"
+        value.timestamp: "{'$gt': int(datetime.utcnow().timestamp())}"
+      outputs:
+        upcoming-fixtures: |
+          [
+            {
+              'fixture_id': d.get('value', {}).get('fixture_id'),
+              'date': d.get('value', {}).get('date'),
+              'status': d.get('value', {}).get('status', {}).get('short'),
+              'home': d.get('value', {}).get('teams', {}).get('home', {}),
+              'away': d.get('value', {}).get('teams', {}).get('away', {}),
+              'league': d.get('value', {}).get('league', {}).get('name')
+            }
+            for d in $.get('documents', [])
+          ]
+
+    # upsert-competitor
+    - type: "document"
+      name: "upsert-competitor"
+      description: "Upsert one brasil-competitor doc per team."
+      condition: "$.get('team_id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'brasil-competitor'"
+        metadata.team_id: "$.get('team_id')"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      documents:
+        brasil-competitor: |
+          {
+            'team_id': $.get('team_id'),
+            'team': ($.get('standings-row', [{}])[0].get('team', {}) if $.get('standings-row') else {'id': $.get('team_id'), 'name': $.get('roster-value', {}).get('team_name'), 'logo': $.get('roster-value', {}).get('team_logo')}),
+            'league_id': $.get('league_id'),
+            'season': $.get('season'),
+            'league_name': $.get('league-name'),
+            'table': ($.get('standings-row', [{}])[0] if $.get('standings-row') else None),
+            'squad_summary': {
+              'players_count': $.get('roster-value', {}).get('players_count'),
+              'roster_synced_at': $.get('roster-value', {}).get('synced_at')
+            },
+            'recent': $.get('recent-fixtures', []),
+            'upcoming': $.get('upcoming-fixtures', []),
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      metadata:
+        scope: "'futebol-brasil'"
+        document_type: "'competitor'"
+        team_id: "$.get('team_id')"
+        league_id: "$.get('league_id')"
+        season: "$.get('season')"
+      outputs:
+        competitor-written: "True"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-competitions.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-competitions.yml
@@ -1,0 +1,165 @@
+workflow:
+
+  # futebol-brasil-coverage-load-competitions
+  name: "futebol-brasil-coverage-load-competitions"
+  title: "Futebol Brasil - Coverage Load Competitions"
+  description: |
+    Fetch league metadata for the 4 pinned tournaments from api-football
+    (get-leagues) and bulk-upsert futebol-brasil-competition documents
+    used by the gateway for staleness decisions. Reads
+    futebol-brasil-coverage-config (set by load-leagues-config).
+
+    Idempotent — safe to run every N hours. competition_stale_hours
+    controls minimum spacing per league.
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: "$TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
+  inputs:
+    force: "$.get('force', False)"
+  outputs:
+    competitions-upserted: "$.get('competitions_upserted_count', 0)"
+    workflow-status: "($.get('competitions_upserted_count', 0) > 0) and 'executed' or 'skipped'"
+  tasks:
+
+    # load-config
+    - type: "document"
+      name: "load-config"
+      description: "Load coverage config (pinned competitions)."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-coverage-config'"
+      outputs:
+        config-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        config-by-league: "{c.get('league_id'): c for c in ($.get('documents', [{}])[0].get('value', {}).get('competitions', []) if $.get('documents') else []) if c.get('league_id') is not None}"
+
+    # load-existing-competitions (merge version_control across runs)
+    - type: "document"
+      name: "load-existing-competitions"
+      description: "Pull existing competition docs to merge version_control."
+      config:
+        action: "search"
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+      outputs:
+        existing-by-league: "{doc.get('metadata', {}).get('league_id'): doc.get('value', {}) for doc in $.get('documents', []) if doc.get('metadata', {}).get('league_id') is not None}"
+
+    # fetch-brasileirao (id=71)
+    - type: "connector"
+      name: "fetch-brasileirao"
+      description: "Brasileirão Série A (71)."
+      connector:
+        name: "api-football"
+        command: "get-leagues"
+      inputs:
+        id: 71
+      outputs:
+        league-71: "(($.get('response') or [{}])[0] if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+
+    # fetch-libertadores (id=13)
+    - type: "connector"
+      name: "fetch-libertadores"
+      description: "Libertadores (13)."
+      connector:
+        name: "api-football"
+        command: "get-leagues"
+      inputs:
+        id: 13
+      outputs:
+        league-13: "(($.get('response') or [{}])[0] if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+
+    # fetch-copa-do-brasil (id=73)
+    - type: "connector"
+      name: "fetch-copa-do-brasil"
+      description: "Copa do Brasil (73)."
+      connector:
+        name: "api-football"
+        command: "get-leagues"
+      inputs:
+        id: 73
+      outputs:
+        league-73: "(($.get('response') or [{}])[0] if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+
+    # fetch-sudamericana (id=11)
+    - type: "connector"
+      name: "fetch-sudamericana"
+      description: "Sudamericana (11)."
+      connector:
+        name: "api-football"
+        command: "get-leagues"
+      inputs:
+        id: 11
+      outputs:
+        league-11: "(($.get('response') or [{}])[0] if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+
+    # bulk-upsert-competitions
+    - type: "document"
+      name: "bulk-upsert-competitions"
+      description: "Bulk upsert one futebol-brasil-competition document per enabled league."
+      config:
+        action: "bulk-update"
+        embed-selector: "$.get('title')"
+        embed-vector: false
+        force-update: true
+      document_name: "'futebol-brasil-competition'"
+      documents:
+        items: |
+          [
+            {
+              'key': $.get('config-by-league', {}).get(lid, {}).get('key'),
+              'league_id': lid,
+              'season': $.get('config-by-league', {}).get(lid, {}).get('season'),
+              'name': (api_doc.get('league', {}).get('name') or $.get('config-by-league', {}).get(lid, {}).get('name')),
+              'short_name': $.get('config-by-league', {}).get(lid, {}).get('short_name'),
+              'country': (api_doc.get('country', {}).get('name') or $.get('config-by-league', {}).get(lid, {}).get('country')),
+              'country_code': api_doc.get('country', {}).get('code'),
+              'flag': api_doc.get('country', {}).get('flag'),
+              'type': (api_doc.get('league', {}).get('type') or $.get('config-by-league', {}).get(lid, {}).get('type')),
+              'logo': (api_doc.get('league', {}).get('logo') or $.get('config-by-league', {}).get(lid, {}).get('logo')),
+              'current_season': [s for s in api_doc.get('seasons', []) if s.get('year') == $.get('config-by-league', {}).get(lid, {}).get('season')][:1],
+              'has_standings': $.get('config-by-league', {}).get(lid, {}).get('has_standings', False),
+              'has_leaders': $.get('config-by-league', {}).get(lid, {}).get('has_leaders', False),
+              'has_rosters': $.get('config-by-league', {}).get(lid, {}).get('has_rosters', False),
+              'staleness_policy': {
+                'fixtures_stale_hours': $.get('config-by-league', {}).get(lid, {}).get('fixtures_stale_hours', 1),
+                'standings_stale_hours': $.get('config-by-league', {}).get(lid, {}).get('standings_stale_hours', 1),
+                'leaders_stale_hours': $.get('config-by-league', {}).get(lid, {}).get('leaders_stale_hours', 6),
+                'rosters_stale_hours': $.get('config-by-league', {}).get(lid, {}).get('rosters_stale_hours', 168),
+                'competition_stale_hours': $.get('config-by-league', {}).get(lid, {}).get('competition_stale_hours', 24)
+              },
+              'version_control': {
+                **$.get('existing-by-league', {}).get(lid, {}).get('version_control', {}),
+                'competition_synced_at': datetime.utcnow().isoformat() + 'Z'
+              },
+              'updated_at': datetime.utcnow().isoformat() + 'Z',
+              'title': 'futebol-brasil-competition-' + str(lid) + '-' + str($.get('config-by-league', {}).get(lid, {}).get('season', '')),
+              'metadata': {
+                'scope': 'futebol-brasil',
+                'document_type': 'competition',
+                'league_id': lid,
+                'season': $.get('config-by-league', {}).get(lid, {}).get('season'),
+                'key': $.get('config-by-league', {}).get(lid, {}).get('key')
+              }
+            }
+            for lid, api_doc in [(71, $.get('league-71', {})), (13, $.get('league-13', {})), (73, $.get('league-73', {})), (11, $.get('league-11', {}))]
+            if $.get('config-by-league', {}).get(lid, {}).get('enabled', True)
+          ]
+
+    # stamp-count (capture for output)
+    - type: "document"
+      name: "stamp-count"
+      description: "Count enabled competitions for workflow output."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'__futebol_brasil_noop__'"
+      outputs:
+        competitions_upserted_count: "len([lid for lid in [71, 13, 73, 11] if $.get('config-by-league', {}).get(lid, {}).get('enabled', True)])"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-fixtures.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-fixtures.yml
@@ -1,0 +1,208 @@
+workflow:
+
+  # futebol-brasil-coverage-load-fixtures
+  name: "futebol-brasil-coverage-load-fixtures"
+  title: "Futebol Brasil - Coverage Load Fixtures"
+  description: |
+    Load fixtures for ONE league/season (or ONE national team) from
+    api-football, normalize the response and bulk-upsert
+    futebol-brasil-fixture documents.
+
+    Caller iterates per-competition (the agent's foreach over the
+    config doc). Incremental: skips when fixtures_synced_at is fresher
+    than staleness_policy.fixtures_stale_hours (force=True bypasses).
+
+    Inputs:
+      league_id  - api-football league id (mutually exclusive with team_id)
+      season     - api-football season (required when league_id is set)
+      team_id    - api-football team id (national team mode, no season)
+      force      - bypass staleness check
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: "$TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
+  inputs:
+    force: "$.get('force', False)"
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+    team_id: "$.get('team_id')"
+  outputs:
+    fixtures-upserted: "$.get('fixtures-count', 0)"
+    workflow-status: "($.get('fixtures-count', 0) > 0) and 'executed' or 'skipped'"
+  tasks:
+
+    # load-competition-doc (staleness check by league_id+season)
+    - type: "document"
+      name: "load-competition-doc"
+      description: "Look up competition doc for staleness policy + last sync time."
+      condition: "$.get('league_id') is not None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        competition-document-id: "$.get('documents', [{}])[0].get('_id') if $.get('documents') else None"
+        competition-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        fixtures-fresh: "(not $.get('force', False) and $.get('documents') and $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('fixtures_synced_at') and ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('fixtures_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 < $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('fixtures_stale_hours', 1)))"
+
+    # fetch-fixtures-by-league
+    - type: "connector"
+      name: "fetch-fixtures-by-league"
+      description: "Fetch fixtures for the given league + season."
+      condition: "$.get('league_id') is not None and $.get('fixtures-fresh') is not True"
+      connector:
+        name: "api-football"
+        command: "get-fixtures"
+      inputs:
+        league: "$.get('league_id')"
+        season: "$.get('season')"
+      outputs:
+        raw-fixtures: "$.get('response', [])"
+
+    # fetch-fixtures-by-team (national team mode: last 20 + next 20)
+    - type: "connector"
+      name: "fetch-fixtures-by-team-last"
+      description: "National team mode: last 20 fixtures."
+      condition: "$.get('team_id') is not None and $.get('league_id') is None"
+      connector:
+        name: "api-football"
+        command: "get-fixtures"
+      inputs:
+        team: "$.get('team_id')"
+        last: 20
+      outputs:
+        raw-fixtures-last: "$.get('response', [])"
+
+    - type: "connector"
+      name: "fetch-fixtures-by-team-next"
+      description: "National team mode: next 20 fixtures."
+      condition: "$.get('team_id') is not None and $.get('league_id') is None"
+      connector:
+        name: "api-football"
+        command: "get-fixtures"
+      inputs:
+        team: "$.get('team_id')"
+        next: 20
+      outputs:
+        raw-fixtures-next: "$.get('response', [])"
+
+    # parse-and-merge (handles both modes: league or team)
+    - type: "document"
+      name: "parse-and-merge"
+      description: "Normalize the api-football fixture payload into a slim shape ready for upsert."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'__futebol_brasil_noop__'"
+      outputs:
+        fixtures-parsed: |
+          [
+            {
+              'fixture_id': f.get('fixture', {}).get('id'),
+              'league_id': f.get('league', {}).get('id'),
+              'season': f.get('league', {}).get('season'),
+              'date': f.get('fixture', {}).get('date'),
+              'timestamp': f.get('fixture', {}).get('timestamp'),
+              'timezone': f.get('fixture', {}).get('timezone'),
+              'status': {
+                'long': f.get('fixture', {}).get('status', {}).get('long'),
+                'short': f.get('fixture', {}).get('status', {}).get('short'),
+                'elapsed': f.get('fixture', {}).get('status', {}).get('elapsed')
+              },
+              'venue': f.get('fixture', {}).get('venue', {}),
+              'referee': f.get('fixture', {}).get('referee'),
+              'league': {
+                'id': f.get('league', {}).get('id'),
+                'name': f.get('league', {}).get('name'),
+                'country': f.get('league', {}).get('country'),
+                'logo': f.get('league', {}).get('logo'),
+                'flag': f.get('league', {}).get('flag'),
+                'season': f.get('league', {}).get('season'),
+                'round': f.get('league', {}).get('round')
+              },
+              'teams': {
+                'home': {
+                  'id': f.get('teams', {}).get('home', {}).get('id'),
+                  'name': f.get('teams', {}).get('home', {}).get('name'),
+                  'logo': f.get('teams', {}).get('home', {}).get('logo'),
+                  'winner': f.get('teams', {}).get('home', {}).get('winner')
+                },
+                'away': {
+                  'id': f.get('teams', {}).get('away', {}).get('id'),
+                  'name': f.get('teams', {}).get('away', {}).get('name'),
+                  'logo': f.get('teams', {}).get('away', {}).get('logo'),
+                  'winner': f.get('teams', {}).get('away', {}).get('winner')
+                }
+              },
+              'goals': f.get('goals', {}),
+              'score': f.get('score', {}),
+              'updated_at': datetime.utcnow().isoformat() + 'Z'
+            }
+            for f in ($.get('raw-fixtures', []) + $.get('raw-fixtures-last', []) + $.get('raw-fixtures-next', []))
+            if f.get('fixture', {}).get('id') is not None
+          ]
+        fixtures-count: "len([f for f in ($.get('raw-fixtures', []) + $.get('raw-fixtures-last', []) + $.get('raw-fixtures-next', [])) if f.get('fixture', {}).get('id') is not None])"
+
+    # bulk-save-fixtures
+    - type: "document"
+      name: "bulk-save-fixtures"
+      description: "Bulk upsert futebol-brasil-fixture documents (one per fixture_id)."
+      condition: "$.get('fixtures-count', 0) > 0"
+      config:
+        action: "bulk-update"
+        embed-selector: "$.get('title')"
+        embed-vector: false
+        force-update: true
+      document_name: "'brasil-fixture'"
+      documents:
+        items: |
+          [
+            {
+              **f,
+              'title': 'brasil-fixture-' + str(f.get('fixture_id', '')),
+              'metadata': {
+                'scope': 'futebol-brasil',
+                'document_type': 'fixture',
+                'fixture_id': f.get('fixture_id'),
+                'league_id': f.get('league_id'),
+                'season': f.get('season'),
+                'home_team_id': f.get('teams', {}).get('home', {}).get('id'),
+                'away_team_id': f.get('teams', {}).get('away', {}).get('id'),
+                'status_short': f.get('status', {}).get('short'),
+                'date': f.get('date'),
+                'competition': f.get('league', {}).get('name'),
+                'updated_at': datetime.utcnow().isoformat() + 'Z'
+              }
+            }
+            for f in $.get('fixtures-parsed', [])
+          ]
+
+    # stamp-competition (bump fixtures_synced_at)
+    - type: "document"
+      name: "stamp-competition"
+      description: "Bump fixtures_synced_at on the competition doc (league mode only)."
+      condition: "$.get('fixtures-count', 0) > 0 and $.get('competition-document-id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        document_id: "$.get('competition-document-id')"
+      documents:
+        futebol-brasil-competition: |
+          {
+            **$.get('competition-value', {}),
+            'version_control': {
+              **$.get('competition-value', {}).get('version_control', {}),
+              'fixtures_synced_at': datetime.utcnow().isoformat() + 'Z',
+              'fixtures_count': $.get('fixtures-count', 0)
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-rosters.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-rosters.yml
@@ -1,0 +1,108 @@
+workflow:
+
+  # futebol-brasil-coverage-load-rosters
+  name: "futebol-brasil-coverage-load-rosters"
+  title: "Futebol Brasil - Coverage Load Rosters"
+  description: |
+    Load the squad (roster) for ONE team from api-football
+    (get-players/squad) and upsert a single futebol-brasil-roster
+    document per team.
+
+    Caller iterates per-team. Two entry modes:
+      - league mode: caller passes league_id + season + team_id; the
+        workflow stamps roster_synced_at on the league's competition doc.
+      - national-team mode: caller passes team_id only; staleness
+        check is against value.rosters_synced_at on the
+        futebol-brasil-national-team document (looked up via team_id).
+
+    Squads are slow-moving — default rosters_stale_hours is 168h (1 week).
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: "$TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
+  inputs:
+    force: "$.get('force', False)"
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+    team_id: "$.get('team_id')"
+  outputs:
+    players-in-squad: "$.get('squad-count', 0)"
+    workflow-status: "($.get('squad-count', 0) > 0) and 'executed' or 'skipped'"
+  tasks:
+
+    # load-existing-roster (for freshness check + version_control merge)
+    - type: "document"
+      name: "load-existing-roster"
+      description: "Look up existing roster doc to merge version_control."
+      condition: "$.get('team_id') is not None"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'brasil-roster'"
+        metadata.team_id: "$.get('team_id')"
+      outputs:
+        roster-document-id: "$.get('documents', [{}])[0].get('_id') if $.get('documents') else None"
+        roster-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        roster-fresh: "(not $.get('force', False) and $.get('documents') and $.get('documents', [{}])[0].get('value', {}).get('synced_at') and ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 < 168))"
+
+    # fetch-squad
+    - type: "connector"
+      name: "fetch-squad"
+      description: "Pull squad from api-football."
+      condition: "$.get('team_id') is not None and $.get('roster-fresh') is not True"
+      connector:
+        name: "api-football"
+        command: "get-players/squad"
+      inputs:
+        team: "$.get('team_id')"
+      outputs:
+        squad-team: "(($.get('response') or [{}])[0].get('team', {}) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+        squad-players: |
+          [
+            {
+              'id': p.get('id'),
+              'name': p.get('name'),
+              'age': p.get('age'),
+              'number': p.get('number'),
+              'position': p.get('position'),
+              'photo': p.get('photo')
+            }
+            for p in (($.get('response') or [{}])[0].get('players', []) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else [])
+            if p.get('id') is not None
+          ]
+        squad-count: "len([p for p in (($.get('response') or [{}])[0].get('players', []) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else []) if p.get('id') is not None])"
+
+    # upsert-roster
+    - type: "document"
+      name: "upsert-roster"
+      description: "Upsert one futebol-brasil-roster doc per team."
+      condition: "$.get('squad-count', 0) > 0"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'brasil-roster'"
+        metadata.team_id: "$.get('team_id')"
+      documents:
+        brasil-roster: |
+          {
+            'team_id': $.get('team_id'),
+            'team_name': $.get('squad-team', {}).get('name'),
+            'team_logo': $.get('squad-team', {}).get('logo'),
+            'league_id': $.get('league_id'),
+            'season': $.get('season'),
+            'players': $.get('squad-players', []),
+            'players_count': $.get('squad-count', 0),
+            'synced_at': datetime.utcnow().isoformat() + 'Z',
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      metadata:
+        scope: "'futebol-brasil'"
+        document_type: "'roster'"
+        team_id: "$.get('team_id')"
+        league_id: "$.get('league_id')"
+        season: "$.get('season')"

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-season-leaders.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-season-leaders.yml
@@ -1,0 +1,160 @@
+workflow:
+
+  # futebol-brasil-coverage-load-season-leaders
+  name: "futebol-brasil-coverage-load-season-leaders"
+  title: "Futebol Brasil - Coverage Load Season Leaders"
+  description: |
+    Aggregate "team leaders" (top of the table proxy: points scored,
+    goals scored, goals conceded, goal difference, form) for ONE
+    league/season from the already-loaded futebol-brasil-standings
+    document. Writes a single futebol-brasil-leaders doc.
+
+    NOTE: api-football's /players/topscorers and /players/topassists
+    endpoints are NOT exposed by the api-football connector in this
+    project, so true player-level leaders aren't available without
+    a connector extension. This workflow computes TEAM-LEVEL leaders
+    from standings (the cheapest proxy that requires no extra API call).
+    When the connector gains player-level top* commands, swap the
+    aggregate-leaders task for a connector fetch.
+
+    Incremental: skips when leaders_synced_at is fresher than
+    staleness_policy.leaders_stale_hours. Skips when has_leaders=False.
+  inputs:
+    force: "$.get('force', False)"
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+  outputs:
+    leader-rows: "$.get('leaders-count', 0)"
+    workflow-status: "($.get('leaders-count', 0) > 0) and 'executed' or 'skipped'"
+  tasks:
+
+    # load-competition-doc
+    - type: "document"
+      name: "load-competition-doc"
+      description: "Read competition staleness."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        competition-document-id: "$.get('documents', [{}])[0].get('_id') if $.get('documents') else None"
+        competition-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        has-leaders: "$.get('documents', [{}])[0].get('value', {}).get('has_leaders', False) if $.get('documents') else False"
+        leaders-fresh: "(not $.get('force', False) and $.get('documents') and $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('leaders_synced_at') and ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('leaders_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 < $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('leaders_stale_hours', 6)))"
+
+    # load-standings (source of truth for team leaders)
+    - type: "document"
+      name: "load-standings"
+      description: "Read the standings document populated by load-standings."
+      condition: "$.get('has-leaders') is True and $.get('leaders-fresh') is not True"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'brasil-standings'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        standings-rows: "$.get('documents', [{}])[0].get('value', {}).get('rows', []) if $.get('documents') else []"
+
+    # aggregate-leaders (compute top-N per category from standings rows)
+    - type: "document"
+      name: "aggregate-leaders"
+      description: "Compute team-leader categories from standings rows."
+      condition: "len($.get('standings-rows', [])) > 0"
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'__futebol_brasil_noop__'"
+      outputs:
+        top-attack: |
+          sorted(
+            [{'team': r.get('team', {}), 'goals_for': (r.get('all', {}) or {}).get('goals', {}).get('for', 0), 'played': (r.get('all', {}) or {}).get('played', 0)} for r in $.get('standings-rows', [])],
+            key=lambda x: (-(x.get('goals_for') or 0), -(x.get('played') or 0))
+          )[:10]
+        top-defense: |
+          sorted(
+            [{'team': r.get('team', {}), 'goals_against': (r.get('all', {}) or {}).get('goals', {}).get('against', 0), 'played': (r.get('all', {}) or {}).get('played', 0)} for r in $.get('standings-rows', [])],
+            key=lambda x: ((x.get('goals_against') or 0), -(x.get('played') or 0))
+          )[:10]
+        top-goal-diff: |
+          sorted(
+            [{'team': r.get('team', {}), 'goalsDiff': r.get('goalsDiff', 0)} for r in $.get('standings-rows', [])],
+            key=lambda x: -(x.get('goalsDiff') or 0)
+          )[:10]
+        top-points: |
+          sorted(
+            [{'team': r.get('team', {}), 'points': r.get('points', 0), 'rank': r.get('rank')} for r in $.get('standings-rows', [])],
+            key=lambda x: -(x.get('points') or 0)
+          )[:10]
+        top-form: |
+          [
+            {'team': r.get('team', {}), 'form': r.get('form', '')}
+            for r in $.get('standings-rows', [])
+            if r.get('form')
+          ][:10]
+        leaders-count: "len($.get('standings-rows', []))"
+
+    # upsert-leaders
+    - type: "document"
+      name: "upsert-leaders"
+      description: "Upsert one futebol-brasil-leaders doc per (league, season)."
+      condition: "$.get('leaders-count', 0) > 0"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'brasil-leaders'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      documents:
+        brasil-leaders: |
+          {
+            'league_id': $.get('league_id'),
+            'season': $.get('season'),
+            'source': 'standings-aggregate',
+            'categories': {
+              'top_points': $.get('top-points', []),
+              'top_attack': $.get('top-attack', []),
+              'top_defense': $.get('top-defense', []),
+              'top_goal_diff': $.get('top-goal-diff', []),
+              'top_form': $.get('top-form', [])
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      metadata:
+        scope: "'futebol-brasil'"
+        document_type: "'leaders'"
+        league_id: "$.get('league_id')"
+        season: "$.get('season')"
+
+    # stamp-competition
+    - type: "document"
+      name: "stamp-competition"
+      description: "Mark leaders_synced_at on competition doc."
+      condition: "$.get('leaders-count', 0) > 0 and $.get('competition-document-id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        document_id: "$.get('competition-document-id')"
+      documents:
+        futebol-brasil-competition: |
+          {
+            **$.get('competition-value', {}),
+            'version_control': {
+              **$.get('competition-value', {}).get('version_control', {}),
+              'leaders_synced_at': datetime.utcnow().isoformat() + 'Z',
+              'leaders_rows_count': $.get('leaders-count', 0)
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-standings.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-standings.yml
@@ -1,0 +1,137 @@
+workflow:
+
+  # futebol-brasil-coverage-load-standings
+  name: "futebol-brasil-coverage-load-standings"
+  title: "Futebol Brasil - Coverage Load Standings"
+  description: |
+    Load standings for ONE league/season from api-football
+    (get-standings) and upsert a single futebol-brasil-standings document.
+
+    Incremental: skips when standings_synced_at is fresher than
+    staleness_policy.standings_stale_hours. Skips entirely when the
+    competition's has_standings flag is False (cups in elimination
+    phase, e.g. Copa do Brasil).
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: "$TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY"
+  inputs:
+    force: "$.get('force', False)"
+    league_id: "$.get('league_id')"
+    season: "$.get('season')"
+  outputs:
+    teams-in-table: "$.get('standings-rows-count', 0)"
+    standings-rows: "$.get('standings-rows', [])"
+    workflow-status: "($.get('standings-rows-count', 0) > 0) and 'executed' or 'skipped'"
+  tasks:
+
+    # load-competition-doc
+    - type: "document"
+      name: "load-competition-doc"
+      description: "Read competition staleness."
+      config:
+        action: "search"
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'futebol-brasil-competition'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      outputs:
+        competition-document-id: "$.get('documents', [{}])[0].get('_id') if $.get('documents') else None"
+        competition-value: "$.get('documents', [{}])[0].get('value', {}) if $.get('documents') else {}"
+        has-standings: "$.get('documents', [{}])[0].get('value', {}).get('has_standings', False) if $.get('documents') else False"
+        standings-fresh: "(not $.get('force', False) and $.get('documents') and $.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('standings_synced_at') and ((datetime.utcnow() - datetime.fromisoformat($.get('documents', [{}])[0].get('value', {}).get('version_control', {}).get('standings_synced_at', '1970-01-01T00:00:00').replace('Z', ''))).total_seconds() / 3600.0 < $.get('documents', [{}])[0].get('value', {}).get('staleness_policy', {}).get('standings_stale_hours', 1)))"
+
+    # fetch-standings
+    - type: "connector"
+      name: "fetch-standings"
+      description: "Pull standings from api-football."
+      condition: "$.get('has-standings') is True and $.get('standings-fresh') is not True"
+      connector:
+        name: "api-football"
+        command: "get-standings"
+      inputs:
+        league: "$.get('league_id')"
+        season: "$.get('season')"
+      outputs:
+        standings-league: "(($.get('response') or [{}])[0].get('league', {}) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else {})"
+        standings-rows: |
+          [
+            {
+              'rank': r.get('rank'),
+              'team': {
+                'id': r.get('team', {}).get('id'),
+                'name': r.get('team', {}).get('name'),
+                'logo': r.get('team', {}).get('logo')
+              },
+              'points': r.get('points'),
+              'goalsDiff': r.get('goalsDiff'),
+              'group': r.get('group'),
+              'form': r.get('form'),
+              'status': r.get('status'),
+              'description': r.get('description'),
+              'all': r.get('all'),
+              'home': r.get('home'),
+              'away': r.get('away'),
+              'update': r.get('update')
+            }
+            for group in (($.get('response') or [{}])[0].get('league', {}).get('standings', []) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else [])
+            for r in group
+          ]
+        standings-rows-count: "sum(len(group) for group in (($.get('response') or [{}])[0].get('league', {}).get('standings', []) if isinstance($.get('response'), list) and len($.get('response') or []) > 0 else []))"
+
+    # upsert-standings
+    - type: "document"
+      name: "upsert-standings"
+      description: "Upsert one futebol-brasil-standings doc per (league, season)."
+      condition: "$.get('standings-rows-count', 0) > 0"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'brasil-standings'"
+        metadata.league_id: "$.get('league_id')"
+        metadata.season: "$.get('season')"
+      documents:
+        brasil-standings: |
+          {
+            'league_id': $.get('league_id'),
+            'season': $.get('season'),
+            'league_name': $.get('standings-league', {}).get('name'),
+            'logo': $.get('standings-league', {}).get('logo'),
+            'rows': $.get('standings-rows', []),
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      metadata:
+        scope: "'futebol-brasil'"
+        document_type: "'standings'"
+        league_id: "$.get('league_id')"
+        season: "$.get('season')"
+        competition: "$.get('standings-league', {}).get('name')"
+        updated_at: "datetime.utcnow().isoformat() + 'Z'"
+
+    # stamp-competition
+    - type: "document"
+      name: "stamp-competition"
+      description: "Mark standings_synced_at on competition doc."
+      condition: "$.get('standings-rows-count', 0) > 0 and $.get('competition-document-id') is not None"
+      config:
+        action: "update"
+        embed-vector: false
+        force-update: true
+      filters:
+        document_id: "$.get('competition-document-id')"
+      documents:
+        futebol-brasil-competition: |
+          {
+            **$.get('competition-value', {}),
+            'version_control': {
+              **$.get('competition-value', {}).get('version_control', {}),
+              'standings_synced_at': datetime.utcnow().isoformat() + 'Z',
+              'standings_rows_count': $.get('standings-rows-count', 0)
+            },
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }


### PR DESCRIPTION
## O que é

Novo módulo de **enrich** em `agent-templates/futebol-brasil/coverage/enrich/` que mantém dados de futebol brasileiro atualizados como documents (pra outros pods consumirem via `import_template_from_git`):

- **Seleção Brasileira**, **Brasileirão Série A**, **Copa Libertadores**, **Copa do Brasil**, **Copa Sul-Americana**.

## Como

- Fonte: o connector que já existe `connectors/api-football` (sem nova fonte, sem mock).
- Segue o padrão de enrich do entain (coverage): `load-*` (config, competitions, fixtures, rosters, season-leaders, standings) + `enrich-competitor` + `coverage-gateway` + `checkin`/`checkout`, com `_install.yml` + `agent.yml`/`agent-selecao.yml`.
- Data-driven via `load-leagues-config` (league IDs pináveis) — fácil estender/ajustar competições.

## Contexto

Portado pra o catálogo a partir do build do Factory que o scaffoldou (estava num repo throwaway). Já foi importado e validado no pod `sbot-stg` (17 workflows `futebol-brasil-*` instalados).

Parte do estudo de migrar a cobertura de futebol de Sportradar → api-football (mesma paridade de ligas, quota api-football ociosa) — ver `enrich-cost-study.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)