### PR TITLE
fix(google-genai): honor recency_days in invoke_search

### DIFF
--- a/connectors/google-genai/google-genai.py
+++ b/connectors/google-genai/google-genai.py
@@ -490,7 +490,8 @@ def invoke_search(request_data):
     end_date = params.get("end_date")  # YYYY-MM-DD
     start_date_iso = params.get("startDate")  # ISO8601 datetime
     end_date_iso = params.get("endDate")  # ISO8601 datetime
-    days_back = params.get("days_back", 3)  # used when start_date is missing but end is present
+    days_back = params.get("days_back")  # window size before an explicit end date
+    recency_days = params.get("recency_days")  # rolling window of the last N days, anchored to today
 
     def _parse_date_or_datetime(value, field_name):
         """
@@ -570,7 +571,11 @@ def invoke_search(request_data):
 
     try:
         try:
-            days_back_n = _parse_days_back(days_back, "days_back")
+            # recency_days (preferred) and days_back share the same window size.
+            # Default of 3 only matters when an end date is present (explicit or anchored).
+            days_back_n = _parse_days_back(
+                recency_days if recency_days is not None else days_back, "recency_days"
+            )
 
             # Direct params take precedence
             start_dt = _parse_date_or_datetime(start_date, "start_date")
@@ -586,6 +591,10 @@ def invoke_search(request_data):
                 anchor_end_dt = _parse_date_or_datetime(start_date_iso, "startDate")
                 if end_dt is None:
                     end_dt = anchor_end_dt
+
+            # recency_days: anchor the rolling window to today when no explicit dates were given
+            if recency_days is not None and end_dt is None and start_dt is None:
+                end_dt = datetime.datetime.utcnow().date()
 
             # If we have an end date but no start date, derive start_dt = end_dt - days_back
             if end_dt is not None and start_dt is None:
@@ -643,6 +652,7 @@ def invoke_search(request_data):
                 "startDate": start_date_iso,    # echo input (ISO8601)
                 "endDate": end_date_iso,        # echo input (ISO8601)
                 "days_back": days_back,         # echo input
+                "recency_days": recency_days,   # echo input
                 "derived_start_date": start_dt.isoformat() if start_dt else None,
                 "derived_end_date": end_dt.isoformat() if end_dt else None,
                 "answer": response.content,


### PR DESCRIPTION
## Problem

`invoke_search` (Gemini Google Search grounding) read `days_back` (default 3) and only applied a date window when an explicit **end date** was present. Every workflow caller passes **`recency_days`** (e.g. `recency_days: 30/14/7`) with no start/end date — so the recency window was **silently ignored** and grounded searches were never date-constrained.

This affects ~20 workflows across sportingbot, blog-br, botandwin, and sports-interaction templates (chat news lookups + coverage/enrichment).

## Fix

- Read `recency_days` and treat it as a rolling window **anchored to today**: when no explicit dates are given, `end = today`, `start = today − recency_days`, producing `after:/before:` query operators.
- `days_back` keeps its prior meaning (offset before an explicit end date).
- The no-date / no-recency path stays **unfiltered**, so all other callers are unaffected.
- Echo `recency_days` in the response for debuggability.

## Verification

Simulated all call patterns against the real date-resolution logic:

| Call pattern | Before | After |
|---|---|---|
| `recency_days: 30` | ignored — no filter | `after:<today−30> before:<today+1>` ✅ |
| `recency_days: 7` | ignored | last 7 days ✅ |
| no date params | unfiltered | unfiltered (unchanged) |
| `days_back` alone, no dates | no-op | no-op (unchanged) |
| explicit `end_date` + `days_back` | window before end | identical (unchanged) |
| explicit `start_date`+`end_date` | fixed window | identical (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)