### PR TITLE
fix(api-football): squad endpoint /players/squad → /players/squads

### DIFF
--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -2376,7 +2376,7 @@
         }
       }
     },
-    "/players/squad": {
+    "/players/squads": {
       "get": {
         "summary": "Get squad",
         "description": "Get the squad of a team",


### PR DESCRIPTION
API-Football's endpoint is `players/squads` (plural). The connector declared `/players/squad` (singular) → every roster call returned `The Players/squad endpoint does not exist.`, surfacing in apps as a false "not available in your API plan" message (the key + credits were always fine).

Fixes the path key only; keeps `operationId: get-players/squad` so existing `command: "get-players/squad"` references (futebol-brasil load-rosters, corinthians-twitter soccer-embeddings) keep resolving — **reimporting just the connector fixes rosters**, no workflow reimport needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)