### PR TITLE
fix(api-football): squad command plural (get-players/squad → get-players/squads)

### DIFF
--- a/agent-templates/corinthians-twitter/workflows/soccer-embeddings.yml
+++ b/agent-templates/corinthians-twitter/workflows/soccer-embeddings.yml
@@ -225,7 +225,7 @@ workflow:
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
         name: "api-football"
-        command: "get-players/squad"
+        command: "get-players/squads"
       inputs:
         team: "$.get('team_home_id')"
       outputs:
@@ -238,7 +238,7 @@ workflow:
       condition: "$.get('event_exists') is True and $.get('season') is not None"
       connector:
         name: "api-football"
-        command: "get-players/squad"
+        command: "get-players/squads"
       inputs:
         team: "$.get('team_away_id')"
       outputs:

--- a/agent-templates/futebol-brasil/coverage/enrich/workflows/load-rosters.yml
+++ b/agent-templates/futebol-brasil/coverage/enrich/workflows/load-rosters.yml
@@ -5,7 +5,7 @@ workflow:
   title: "Futebol Brasil - Coverage Load Rosters"
   description: |
     Load the squad (roster) for ONE team from api-football
-    (get-players/squad) and upsert a single futebol-brasil-roster
+    (get-players/squads) and upsert a single futebol-brasil-roster
     document per team.
 
     Caller iterates per-team. Two entry modes:
@@ -55,7 +55,7 @@ workflow:
       condition: "$.get('team_id') is not None and $.get('roster-fresh') is not True"
       connector:
         name: "api-football"
-        command: "get-players/squad"
+        command: "get-players/squads"
       inputs:
         team: "$.get('team_id')"
       outputs:

--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -2380,7 +2380,7 @@
       "get": {
         "summary": "Get squad",
         "description": "Get the squad of a team",
-        "operationId": "get-players/squad",
+        "operationId": "get-players/squads",
         "security": [
           {
             "x-apisports-key": []


### PR DESCRIPTION
Follow-up to #220 (path fix). The connector builds the request from the `command` (`{method}-{path}`), so the **command** — not only the OpenAPI path key — must be `players/squads`. Left singular, the call still hit `/players/squad` → "The Players/squad endpoint does not exist."

Now everything is plural & consistent: connector operationId + commands in futebol-brasil `load-rosters` and corinthians-twitter `soccer-embeddings`. **Reimport the futebol-brasil template + api-football connector** to apply. (API-Football v3: `GET /players/squads?team=`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)