### PR TITLE
feat(google-genai): Vertex invoke_embedding + re-enable bwin-sync-markets embeddings

### DIFF
--- a/connectors/bwin/workflows/sync-markets.yml
+++ b/connectors/bwin/workflows/sync-markets.yml
@@ -69,12 +69,13 @@ workflow:
       name: bulk-save-fixtures
       description: Bulk save the fixtures.
       config:
-        # embed-vector left disabled — engine eval bug on invoke_embedding
-        # when true (NameError: name 'invoke_embedding' is not defined).
-        # Markets don't need vector embeddings for the Bruxo/Comparator
-        # surfaces; revisit when semantic search over game-market matters.
         action: bulk-update
-        embed-vector: false
+        embed-vector: true
+        embed-selector: $.get('title')
+        connector:
+          name: google-genai
+          command: invoke_embedding
+          model: text-embedding-004
         force-update: true
       document_name: "'game-market'"
       documents:

--- a/connectors/google-genai/google-genai.py
+++ b/connectors/google-genai/google-genai.py
@@ -6,7 +6,7 @@ from google.oauth2 import service_account
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-from langchain_google_vertexai import ChatVertexAI
+from langchain_google_vertexai import ChatVertexAI, VertexAIEmbeddings
 
 from io import BytesIO
 
@@ -178,6 +178,61 @@ def invoke_prompt(params):
             "status": False,
             "message": f"Invalid provider: {provider}. Must be 'ai_studio' or 'vertex_ai'.",
         }
+
+
+def invoke_embedding(params):
+    """
+    Vertex AI text embeddings (default: text-embedding-004).
+
+    Mirrors the Vertex auth convention used by invoke_prompt (provider=vertex_ai):
+    reads `credential` (service account JSON, string or dict) and `project_id`
+    from the connector context-variables. OpenAI model names
+    (text-embedding-3-*, *ada*) are remapped to text-embedding-004 so existing
+    workflows keep working without touching the `model` they pass.
+
+    Parameters:
+    - model_name: Model to use (default: "text-embedding-004")
+    - project_id: GCP Project ID (from context-variables)
+    - location:   GCP location (default: "us-central1")
+    - credential: Service account JSON (string or dict). Falls back to ADC.
+    """
+    model_name = params.get("model_name") or ""
+    if (not model_name) or ("text-embedding-3" in model_name) or ("ada" in model_name):
+        model_name = "text-embedding-004"
+
+    project_id = params.get("project_id") or params.get("project")
+    location = params.get("location", "us-central1")
+    credential = params.get("credential")
+
+    try:
+        credentials = None
+        if credential:
+            if isinstance(credential, str):
+                try:
+                    credential = json.loads(credential)
+                except json.JSONDecodeError as e:
+                    return {"status": False, "message": f"credential must be valid JSON: {e}"}
+            credentials = service_account.Credentials.from_service_account_info(
+                credential, scopes=["https://www.googleapis.com/auth/cloud-platform"]
+            )
+
+        kwargs = {"model_name": model_name}
+        if project_id:
+            kwargs["project"] = project_id
+        if location:
+            kwargs["location"] = location
+        if credentials:
+            kwargs["credentials"] = credentials
+
+        llm = VertexAIEmbeddings(**kwargs)
+
+        return {
+            "status": True,
+            "data": llm,
+            "message": f"VertexAI embeddings loaded: {model_name}",
+        }
+    except Exception as e:
+        return {"status": False, "message": f"Exception when creating embedding model: {e}"}
 
 
 def invoke_image(request_data):

--- a/connectors/google-genai/google-genai.yml
+++ b/connectors/google-genai/google-genai.yml
@@ -7,6 +7,9 @@ connector:
     - name: Prompt
       value: invoke_prompt
 
+    - name: Embedding
+      value: invoke_embedding
+
     - name: Image
       value: invoke_image
 


### PR DESCRIPTION
## Problem
`bwin-sync-markets` had `embed-vector` **disabled** on `bulk-save-fixtures` with the comment _"engine eval bug on invoke_embedding (NameError: name 'invoke_embedding' is not defined)"_. Root cause: the workflow's embedding was wired to the **`google-genai`** connector (Vertex creds already injected via context-variables), but `google-genai` **never had an `invoke_embedding` command** — hence the NameError. Markets were saved **without embeddings**, blocking semantic search / the Sports-Interaction "Computer Picks" event matching in the `sports-interaction-v2` pod.

We are **off OpenAI** for this path — Vertex only.

## Changes
1. **`connectors/google-genai/google-genai.py`** — add `invoke_embedding` (the missing command). Uses `VertexAIEmbeddings`, default `text-embedding-004`, and **remaps legacy OpenAI model names** (`text-embedding-3-*`, `*ada*`) → `text-embedding-004` so existing workflows that still pass the old `model` keep working untouched. Reuses the connector's existing Vertex auth convention (`credential` + `project_id` from context-variables), same as `invoke_prompt` (`provider=vertex_ai`).
2. **`connectors/google-genai/google-genai.yml`** — declare the `Embedding → invoke_embedding` command.
3. **`connectors/bwin/workflows/sync-markets.yml`** — re-enable `embed-vector: true` on `bulk-save-fixtures`, pointing the embed connector at `google-genai` / `invoke_embedding` / `text-embedding-004` (`embed-selector: $.get('title')`). Vertex creds were already wired in the workflow's `context-variables`.

## Blast radius
- `google-genai`: **additive only** (new command); existing commands untouched.
- `bwin-sync-markets`: flips embeddings back on for `game-market` docs. Output dimension differs from the old OpenAI path (768 vs 1536), but these are freshly (re)saved docs — no mixed-dimension index.

## Validation
- `ast.parse` on `google-genai.py` ✓
- YAML parse on both touched yml files ✓
- Post-merge: reimport `google-genai` + `bwin-sync-markets` into `sports-interaction-v2`, re-run sync, confirm `game-market` docs carry embeddings → event matcher / picks populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)