### PR TITLE
feat: add World Cup intelligence template scaffold

### DIFF
--- a/agent-templates/world-cup-intelligence/_folders.yml
+++ b/agent-templates/world-cup-intelligence/_folders.yml
@@ -1,0 +1,15 @@
+folders:
+  - name: World Cup Intelligence
+    description: World Cup 2026 market intelligence workflows and MCP-facing tools.
+    workflows:
+      - worldcup-health
+      - worldcup-ingest-fixtures
+      - worldcup-sync-market-sources
+      - worldcup-search-markets
+      - worldcup-get-iptc-event-context
+      - worldcup-get-event-context
+      - worldcup-compare-market-sources
+      - worldcup-find-market-edges
+      - worldcup-generate-market-brief
+      - worldcup-fan-sentiment-context
+      - worldcup-refresh-prematch-enrichment

--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -1,0 +1,84 @@
+setup:
+  title: World Cup Intelligence
+  description: Hosted World Cup market-intelligence workflows combining API-Football match truth, IPTC semantic mapping, Sports Skills context, Kalshi/Polymarket markets, Google GenAI reasoning/grounding, and xAI/Grok fan sentiment/news.
+  category:
+    - sports
+    - prediction-markets
+    - world-cup
+    - market-intelligence
+  estimatedTime: 3 minutes
+  features:
+    - API-Football fixture ingestion normalized to IPTC Sport Schema and Machina URNs.
+    - World Cup market search across Kalshi and Polymarket.
+    - Event context using Sports Skills, API-Football, and semantic-layer cache.
+    - Google GenAI grounded reasoning for structured market briefs.
+    - xAI/Grok fan sentiment and live news pulse.
+    - Market edge and arbitrage-candidate analysis for agent workflows.
+    - Read-only workflows suitable for API/MCP productization.
+  integrations:
+    - api-football
+    - sports-skills
+    - kalshi
+    - polymarket
+    - google-genai
+    - xai
+    - grok
+    - pod-document-store
+    - machina-search
+    - machina-urn-resolver
+  status: available
+  value: agent-templates/world-cup-intelligence
+  version: 0.1.0
+
+datasets:
+  - type: agent
+    path: agents/world-cup-intelligence-agent.yml
+  - type: agent
+    path: agents/world-cup-market-analyst-agent.yml
+
+  - type: workflow
+    path: workflows/worldcup-health.yml
+  - type: workflow
+    path: workflows/worldcup-ingest-fixtures.yml
+  - type: workflow
+    path: workflows/worldcup-sync-market-sources.yml
+  - type: workflow
+    path: workflows/worldcup-search-markets.yml
+  - type: workflow
+    path: workflows/worldcup-get-iptc-event-context.yml
+  - type: workflow
+    path: workflows/worldcup-get-event-context.yml
+  - type: workflow
+    path: workflows/worldcup-compare-market-sources.yml
+  - type: workflow
+    path: workflows/worldcup-find-market-edges.yml
+  - type: workflow
+    path: workflows/worldcup-generate-market-brief.yml
+  - type: workflow
+    path: workflows/worldcup-fan-sentiment-context.yml
+  - type: workflow
+    path: workflows/worldcup-refresh-prematch-enrichment.yml
+  - type: workflow
+    path: _folders.yml
+
+  - type: prompts
+    path: prompts/worldcup-market-brief.yml
+  - type: prompts
+    path: prompts/worldcup-market-comparison.yml
+  - type: prompts
+    path: prompts/worldcup-market-edge-analysis.yml
+  - type: prompts
+    path: prompts/worldcup-event-context-summary.yml
+  - type: prompts
+    path: prompts/worldcup-fan-sentiment-extract.yml
+
+  - type: mappings
+    path: mappings/worldcup-api-football-event-to-iptc.yml
+  - type: mappings
+    path: mappings/worldcup-iptc-event-to-api-response.yml
+  - type: mappings
+    path: mappings/worldcup-market-normalization.yml
+  - type: mappings
+    path: mappings/worldcup-market-entity-linking.yml
+  - type: mappings
+    path: mappings/worldcup-brief-response-envelope.yml

--- a/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
@@ -1,0 +1,48 @@
+agent:
+  name: world-cup-intelligence-agent
+  title: World Cup Intelligence Agent
+  description: Read-only agent for FIFA World Cup fixture context, semantic event lookup, prediction-market discovery, grounded market intelligence, and market-edge analysis.
+  context:
+    config-frequency: 60
+    status: "inactive"
+  context-agent:
+    query: "$.get('query', 'FIFA World Cup 2026')"
+    event_urn: "$.get('event_urn', '')"
+  workflows:
+    - name: worldcup-search-markets
+      description: Search Kalshi/Polymarket World Cup markets
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        markets: "$.get('markets', [])"
+
+    - name: worldcup-get-event-context
+      description: Resolve enriched match context
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        event_context: "$.get('event_context', {})"
+
+    - name: worldcup-find-market-edges
+      description: Identify informational market-edge and arbitrage candidates
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        edge_candidates: "$.get('edge_candidates', [])"
+        edge_analysis: "$.get('analysis', {})"
+
+    - name: worldcup-generate-market-brief
+      description: Generate a grounded World Cup market-intelligence brief
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        brief: "$.get('brief', {})"
+
+  instructions: |
+    Use canonical match truth from API-Football, IPTC mappings, and Machina URNs before reasoning over markets.
+    Use Google GenAI for grounded structured briefs and xAI/Grok for social/news pulse.
+    You may surface market-edge or arbitrage candidates as informational analysis, but do not place trades, execute bets, promise profit, or present personalized financial advice.
+    Always include evidence, uncertainty, and source attribution when available.

--- a/agent-templates/world-cup-intelligence/agents/world-cup-market-analyst-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/world-cup-market-analyst-agent.yml
@@ -1,0 +1,40 @@
+agent:
+  name: world-cup-market-analyst-agent
+  title: World Cup Market Analyst
+  description: Analyst agent focused on Kalshi/Polymarket comparison, market-edge discovery, and grounded match-context briefs.
+  context:
+    config-frequency: 60
+    status: "inactive"
+  context-agent:
+    query: "$.get('query', 'FIFA World Cup 2026')"
+    event_urn: "$.get('event_urn', '')"
+  workflows:
+    - name: worldcup-compare-market-sources
+      description: Compare normalized markets by source
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        comparison: "$.get('comparison', {})"
+
+    - name: worldcup-find-market-edges
+      description: Identify informational arbitrage/edge candidates
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        edge_candidates: "$.get('edge_candidates', [])"
+        analysis: "$.get('analysis', {})"
+
+    - name: worldcup-generate-market-brief
+      description: Generate a grounded market-intelligence brief
+      inputs:
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        brief: "$.get('brief', {})"
+
+  instructions: |
+    Compare market data across Kalshi and Polymarket using normalized prices, liquidity, volume, close times, and linked Machina event URNs.
+    Call out candidate price dislocations or arbitrage-style opportunities only as analysis for a human/agent to evaluate independently.
+    Do not execute trades or provide personalized financial advice.

--- a/agent-templates/world-cup-intelligence/docs/api-contracts.md
+++ b/agent-templates/world-cup-intelligence/docs/api-contracts.md
@@ -1,0 +1,15 @@
+# World Cup Intelligence API Contracts
+
+MCP/public gateway routes should call only allowlisted workflows from this template. Do not expose raw workflow or connector execution.
+
+Launch workflow set:
+
+- `worldcup-search-markets`
+- `worldcup-get-event-context`
+- `worldcup-get-iptc-event-context`
+- `worldcup-compare-market-sources`
+- `worldcup-find-market-edges`
+- `worldcup-generate-market-brief`
+- `worldcup-fan-sentiment-context`
+
+All market-edge/arbitrage outputs are informational analysis only. Execution, betting placement, trading, and portfolio actions are out of scope.

--- a/agent-templates/world-cup-intelligence/docs/credit-cost-classes.md
+++ b/agent-templates/world-cup-intelligence/docs/credit-cost-classes.md
@@ -1,0 +1,10 @@
+# Credit Cost Classes
+
+Suggested classes for Core/API gateway metering:
+
+- `health`: free
+- `data`: cheap read endpoints
+- `market`: market search/comparison
+- `social`: xAI/Grok social/news pulse
+- `reasoning`: Google GenAI market brief
+- `edge`: arbitrage/market-edge candidate analysis

--- a/agent-templates/world-cup-intelligence/docs/mcp-tools.md
+++ b/agent-templates/world-cup-intelligence/docs/mcp-tools.md
@@ -1,0 +1,17 @@
+# MCP Tools
+
+Public tools:
+
+- `worldcup_search_markets`
+- `worldcup_get_event_context`
+- `worldcup_get_iptc_event_context`
+- `worldcup_compare_market_sources`
+- `worldcup_find_market_edges`
+- `worldcup_generate_market_brief`
+- `worldcup_fan_sentiment_context`
+
+Internal/admin tools:
+
+- `worldcup_ingest_fixtures`
+- `worldcup_sync_market_sources`
+- `worldcup_refresh_prematch_enrichment`

--- a/agent-templates/world-cup-intelligence/docs/sources-and-disclaimers.md
+++ b/agent-templates/world-cup-intelligence/docs/sources-and-disclaimers.md
@@ -1,0 +1,15 @@
+# Sources and Disclaimers
+
+Canonical truth hierarchy:
+
+1. API-Football fixture truth
+2. IPTC/Sportschema normalized event data
+3. Machina URNs and same-pod document cache
+4. Sports Skills context
+5. Kalshi/Polymarket market data
+6. Google GenAI grounded reasoning
+7. xAI/Grok social/news pulse
+
+Required disclaimer:
+
+> Informational sports market intelligence only. Not betting, trading, financial, or investment advice.

--- a/agent-templates/world-cup-intelligence/mappings/worldcup-api-football-event-to-iptc.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-api-football-event-to-iptc.yml
@@ -1,0 +1,27 @@
+mappings:
+  - type: mapping
+    name: worldcup-api-football-event-to-iptc
+    title: World Cup | API-Football Event to IPTC
+    description: Normalize API-Football fixtures to IPTC/Sportschema event shape with provider crosswalks.
+    outputs:
+      sport_schema_events: |
+        [
+          {
+            "@context": {"sport": "https://www.sportschema.org/ontologies/sport#", "schema": "https://schema.org/"},
+            "@id": f"urn:apifootball:sport_event:{f.get('fixture', {}).get('id')}",
+            "@type": ["sport:Event", "schema:SportsEvent"],
+            "name": f"{f.get('teams', {}).get('home', {}).get('name')} vs {f.get('teams', {}).get('away', {}).get('name')} - {f.get('league', {}).get('name')}",
+            "schema:startDate": f.get('fixture', {}).get('date'),
+            "sport:status": f.get('fixture', {}).get('status', {}).get('short'),
+            "sport:competition": {"@id": f"urn:apifootball:league:{f.get('league', {}).get('id')}", "@type": "sport:Competition", "name": f.get('league', {}).get('name')},
+            "sport:venue": {"@type": "sport:Venue", "@id": f"urn:apifootball:venue:{f.get('fixture', {}).get('venue', {}).get('id')}", "name": f.get('fixture', {}).get('venue', {}).get('name'), "schema:addressLocality": f.get('fixture', {}).get('venue', {}).get('city')},
+            "sport:competitors": [
+              {"@type": "sport:Team", "@id": f"urn:apifootball:team:{f.get('teams', {}).get('home', {}).get('id')}", "name": f.get('teams', {}).get('home', {}).get('name'), "sport:qualifier": "home", "schema:logo": f.get('teams', {}).get('home', {}).get('logo')},
+              {"@type": "sport:Team", "@id": f"urn:apifootball:team:{f.get('teams', {}).get('away', {}).get('id')}", "name": f.get('teams', {}).get('away', {}).get('name'), "sport:qualifier": "away", "schema:logo": f.get('teams', {}).get('away', {}).get('logo')}
+            ],
+            "provider_ids": {"api_football_fixture_id": str(f.get('fixture', {}).get('id', '')), "api_football_league_id": str(f.get('league', {}).get('id', '')), "api_football_home_team_id": str(f.get('teams', {}).get('home', {}).get('id', '')), "api_football_away_team_id": str(f.get('teams', {}).get('away', {}).get('id', ''))},
+            "machina_competition_slug": "world-cup-2026",
+            "raw_provider": "api-football"
+          }
+          for f in $.get('fixtures', [])
+        ]

--- a/agent-templates/world-cup-intelligence/mappings/worldcup-brief-response-envelope.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-brief-response-envelope.yml
@@ -1,0 +1,18 @@
+mappings:
+  - type: mapping
+    name: worldcup-brief-response-envelope
+    title: World Cup | Brief Response Envelope
+    description: Standard product response envelope for reasoning endpoints.
+    outputs:
+      response: |
+        {
+          "status": True,
+          "data": $.get('brief', {}),
+          "meta": {
+            "product": "world_cup_market_intelligence",
+            "endpoint": $.get('endpoint', 'worldcup-generate-market-brief'),
+            "credits_class": $.get('credits_class', 'reasoning')
+          },
+          "evidence": $.get('evidence', []),
+          "disclaimer": "Informational sports market intelligence only. Not betting, trading, financial, or investment advice."
+        }

--- a/agent-templates/world-cup-intelligence/mappings/worldcup-iptc-event-to-api-response.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-iptc-event-to-api-response.yml
@@ -1,0 +1,26 @@
+mappings:
+  - type: mapping
+    name: worldcup-iptc-event-to-api-response
+    title: World Cup | IPTC Event API Response
+    description: Convert canonical event document into stable API response envelope.
+    outputs:
+      event: |
+        {
+          "machina_urn": $.get('event_document', {}).get('_id', $.get('event_document', {}).get('@id', '')),
+          "provider_ids": $.get('event_document', {}).get('provider_ids', {}),
+          "iptc": $.get('event_document', {}),
+          "name": $.get('event_document', {}).get('name', ''),
+          "competition": $.get('event_document', {}).get('competition_name', $.get('event_document', {}).get('sport:competition', {}).get('name', 'FIFA World Cup 2026')),
+          "start_date": $.get('event_document', {}).get('start_date', $.get('event_document', {}).get('schema:startDate', '')),
+          "status": $.get('event_document', {}).get('status', $.get('event_document', {}).get('sport:status', 'unknown')),
+          "teams": $.get('event_document', {}).get('teams', $.get('event_document', {}).get('sport:competitors', [])),
+          "venue": $.get('event_document', {}).get('venue', $.get('event_document', {}).get('sport:venue', {}))
+        }
+      event_context: |
+        {
+          "event": $.get('event', $.get('event_document', {})),
+          "sports_context": $.get('sports_context', {}),
+          "markets": $.get('linked_markets', []),
+          "prematch_research": $.get('event_document', {}).get('prematch_research', {}),
+          "social_pulse": $.get('event_document', {}).get('prematch_social_pulse', {})
+        }

--- a/agent-templates/world-cup-intelligence/mappings/worldcup-market-entity-linking.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-market-entity-linking.yml
@@ -1,0 +1,15 @@
+mappings:
+  - type: mapping
+    name: worldcup-market-entity-linking
+    title: World Cup | Market Entity Linking
+    description: Attach Machina event/team URNs to markets when confident; preserve unlinked markets for search.
+    outputs:
+      linked_markets: |
+        [
+          dict(m, **{
+            "cache_id": m.get('cache_id') or f"{m.get('source', 'unknown')}:{m.get('source_market_id', m.get('id', 'unknown'))}",
+            "machina_event_urn": m.get('machina_event_urn', ''),
+            "linking_notes": m.get('linking_notes', [])
+          })
+          for m in $.get('markets', $.get('normalized_markets', []))
+        ]

--- a/agent-templates/world-cup-intelligence/mappings/worldcup-market-normalization.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-market-normalization.yml
@@ -1,0 +1,32 @@
+mappings:
+  - type: mapping
+    name: worldcup-market-normalization
+    title: World Cup | Market Normalization
+    description: Normalize cached, Sports Skills, Kalshi, and Polymarket market payloads into a stable product shape.
+    outputs:
+      normalized_markets: |
+        $.get('cached_markets', []) or $.get('markets', []) or $.get('sports_skills_markets', {}).get('markets', []) or []
+      markets: |
+        ($.get('cached_markets', []) or $.get('markets', []) or $.get('normalized_markets', []))[:int($.get('limit', 50))]
+      comparison: |
+        {
+          "markets": $.get('markets', []),
+          "markets_by_source": {
+            "kalshi": [m for m in $.get('markets', []) if m.get('source') == 'kalshi'],
+            "polymarket": [m for m in $.get('markets', []) if m.get('source') == 'polymarket']
+          },
+          "data_quality_notes": []
+        }
+      edge_candidates: |
+        [
+          {
+            "candidate_type": "cross_source_price_dislocation",
+            "markets": [m],
+            "edge_bps": 0,
+            "confidence": "needs_pairing",
+            "notes": ["Scaffold placeholder: replace with paired outcome comparison once market normalization preserves comparable outcome keys."]
+          }
+          for m in $.get('markets', [])[:int($.get('limit', 50))]
+        ]
+      warnings: |
+        []

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-event-context-summary.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-event-context-summary.yml
@@ -1,0 +1,26 @@
+prompts:
+  - type: prompt
+    name: worldcup-event-context-summary
+    title: World Cup Event Context Summary
+    description: Summarize canonical event context and match truth for agent/app consumption.
+    instruction: |
+      Summarize the provided World Cup event context using only the supplied IPTC, API-Football, Sports Skills, and cached research data. Do not invent unavailable facts.
+    schema:
+      title: WorldCupEventContextSummary
+      type: object
+      required: [summary, teams, competition, kickoff_context, evidence]
+      properties:
+        summary:
+          type: string
+        teams:
+          type: array
+          items:
+            type: object
+        competition:
+          type: string
+        kickoff_context:
+          type: string
+        evidence:
+          type: array
+          items:
+            type: object

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-fan-sentiment-extract.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-fan-sentiment-extract.yml
@@ -1,0 +1,30 @@
+prompts:
+  - type: prompt
+    name: worldcup-fan-sentiment-extract
+    title: World Cup Fan Sentiment Extract
+    description: Extract fan sentiment and live narrative context from xAI/Grok social/news results.
+    instruction: |
+      Extract fan sentiment, buzz, breaking news, and narrative threads from the provided X/Twitter and news context. Attribute claims and mark uncertainty.
+    schema:
+      title: WorldCupFanSentimentExtract
+      type: object
+      required: [buzz_level, overall_sentiment, narrative_threads, confidence]
+      properties:
+        buzz_level:
+          type: number
+        overall_sentiment:
+          type: string
+        home_fan_narrative:
+          type: string
+        away_fan_narrative:
+          type: string
+        breaking_news:
+          type: array
+          items:
+            type: object
+        narrative_threads:
+          type: array
+          items:
+            type: string
+        confidence:
+          type: number

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-market-brief.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-market-brief.yml
@@ -1,0 +1,45 @@
+prompts:
+  - type: prompt
+    name: worldcup-market-brief
+    title: World Cup Market Brief
+    description: Generate a structured World Cup market intelligence brief from match context, market data, and grounded research.
+    instruction: |
+      You are a sports market-intelligence analyst for FIFA World Cup 2026.
+      Use only the provided event context, market data, prematch research, and grounding sources.
+      You may identify market-edge hypotheses, price dislocations, or arbitrage candidates, but frame them as informational analysis only.
+      Do not instruct the user to place a bet or trade. Do not promise profit. Include uncertainty and data-quality caveats.
+    schema:
+      title: WorldCupMarketBrief
+      type: object
+      required: [headline, summary, market_snapshot, key_factors, risks_and_uncertainties, evidence, disclaimer]
+      properties:
+        headline:
+          type: string
+        summary:
+          type: string
+        market_snapshot:
+          type: array
+          items:
+            type: object
+        key_factors:
+          type: array
+          items:
+            type: string
+        market_edge_hypotheses:
+          type: array
+          items:
+            type: object
+        risks_and_uncertainties:
+          type: array
+          items:
+            type: string
+        watch_items:
+          type: array
+          items:
+            type: string
+        evidence:
+          type: array
+          items:
+            type: object
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-market-comparison.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-market-comparison.yml
@@ -1,0 +1,26 @@
+prompts:
+  - type: prompt
+    name: worldcup-market-comparison
+    title: World Cup Market Comparison
+    description: Compare Kalshi and Polymarket markets using normalized data.
+    instruction: |
+      Compare the provided World Cup market data across sources. Focus on probability differences, liquidity, volume, market status, and source coverage. Avoid financial advice.
+    schema:
+      title: WorldCupMarketComparison
+      type: object
+      required: [summary, markets_by_source, notable_differences, data_quality_notes, disclaimer]
+      properties:
+        summary:
+          type: string
+        markets_by_source:
+          type: object
+        notable_differences:
+          type: array
+          items:
+            type: object
+        data_quality_notes:
+          type: array
+          items:
+            type: string
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-market-edge-analysis.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-market-edge-analysis.yml
@@ -1,0 +1,28 @@
+prompts:
+  - type: prompt
+    name: worldcup-market-edge-analysis
+    title: World Cup Market Edge Analysis
+    description: Explain informational arbitrage/edge candidates found across World Cup market sources.
+    instruction: |
+      Analyze the provided edge candidates. Explain why each may be a price dislocation or arbitrage-style candidate, what assumptions must hold, what fees/liquidity/settlement risks matter, and what data should be checked before any external action. Do not execute trades. Do not provide personalized financial advice.
+    schema:
+      title: WorldCupMarketEdgeAnalysis
+      type: object
+      required: [summary, edge_candidates, caveats, evidence, disclaimer]
+      properties:
+        summary:
+          type: string
+        edge_candidates:
+          type: array
+          items:
+            type: object
+        caveats:
+          type: array
+          items:
+            type: string
+        evidence:
+          type: array
+          items:
+            type: object
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml
@@ -1,0 +1,48 @@
+workflow:
+  name: worldcup-compare-market-sources
+  title: World Cup Intelligence - Compare Market Sources
+  description: Compare Kalshi and Polymarket market data without executing trades or giving personalized financial advice.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    query: "$.get('query', '')"
+    event_urn: "$.get('event_urn', '')"
+    market_type: "$.get('market_type', 'all')"
+    include_reasoning: "$.get('include_reasoning', False)"
+  outputs:
+    comparison: "$.get('comparison', {})"
+    workflow-status: "$.get('comparison', {}) != {} and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: lookup-markets
+      description: Load normalized linked markets for comparison from the same pod document store.
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.machina_event_urn: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
+      outputs:
+        markets: "[d.get('value', {}) for d in $.get('documents', [])]"
+
+    - type: mapping
+      name: worldcup-market-normalization
+      title: World Cup | Market Comparison Shape
+      inputs:
+        markets: "$.get('markets', [])"
+        market_type: "$.get('market_type', 'all')"
+      outputs:
+        comparison: "$.get('comparison', {'markets': $.get('markets', []), 'data_quality_notes': []})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml
@@ -1,0 +1,76 @@
+workflow:
+  name: worldcup-fan-sentiment-context
+  title: World Cup Intelligence - Fan Sentiment Context
+  description: Use xAI/Grok social/news search to extract fan sentiment and save pulse in same-pod state.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    event_urn: "$.get('event_urn', '')"
+    query: "$.get('query', '')"
+    lookback_hours: "$.get('lookback_hours', 48)"
+    force_live: "$.get('force_live', False)"
+  outputs:
+    fan_sentiment: "$.get('fan_sentiment', {})"
+    citations: "$.get('citations', [])"
+    workflow-status: "$.get('fan_sentiment', {}) != {} and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: lookup-event
+      description: Lookup event/team names for sentiment query construction from same-pod state.
+      condition: "$.get('event_urn', '') != ''"
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('event_urn')"
+      outputs:
+        event_context: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: connector
+      name: social-search
+      description: Search X/Twitter and news via xAI/Grok for fan sentiment and narratives.
+      connector:
+        name: machina-search
+        command: social_search
+      inputs:
+        entity_id: "$.get('event_urn', '')"
+        entity_name: "$.get('query') or $.get('event_context', {}).get('name', '')"
+        search_prompt: >
+          f"Analyze fan sentiment, live narratives, breaking news, and X/Twitter discussion for {$.get('query') or $.get('event_context', {}).get('name', 'FIFA World Cup 2026')}. Focus on the last {$.get('lookback_hours', 48)} hours. Return JSON with keys: buzz_level, overall_sentiment, home_fan_narrative, away_fan_narrative, breaking_news, narrative_threads, confidence. Attribute claims to sources."
+      outputs:
+        fan_sentiment: "$.get('parsed_data', {})"
+        citations: "$.get('citations', [])"
+
+    - type: document
+      name: save-social-cache
+      description: Cache social pulse in same-pod document state for reuse.
+      condition: "$.get('event_urn', '') != '' and $.get('fan_sentiment', {}) != {}"
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      documents:
+        worldcup:social-cache: |
+          {
+            'event_urn': $.get('event_urn'),
+            'fan_sentiment': $.get('fan_sentiment', {}),
+            'citations': $.get('citations', []),
+            'updated_at': datetime.utcnow().isoformat() + 'Z'
+          }
+      filters:
+        name: "'worldcup:social-cache'"
+        value.event_urn: "$.get('event_urn')"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml
@@ -1,0 +1,69 @@
+workflow:
+  name: worldcup-find-market-edges
+  title: World Cup Intelligence - Find Market Edges
+  description: Identify informational price dislocations, arbitrage candidates, and market-edge hypotheses across Kalshi/Polymarket. Does not execute trades.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    query: "$.get('query', 'FIFA World Cup 2026')"
+    event_urn: "$.get('event_urn', '')"
+    min_edge_bps: "$.get('min_edge_bps', 100)"
+    include_reasoning: "$.get('include_reasoning', True)"
+    limit: "$.get('limit', 50)"
+  outputs:
+    edge_candidates: "$.get('edge_candidates', [])"
+    analysis: "$.get('analysis', {})"
+    workflow-status: "'executed'"
+  tasks:
+    - type: document
+      name: load-market-cache
+      description: Load normalized markets for candidate edge detection from the same pod document store.
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.machina_event_urn: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
+      outputs:
+        markets: "[d.get('value', {}) for d in $.get('documents', [])][:int($.get('limit', 50))]"
+
+    - type: mapping
+      name: worldcup-market-normalization
+      title: World Cup | Market Edge Candidate Detection
+      description: Compute cross-source price dislocations and arbitrage-candidate gaps from normalized market data.
+      inputs:
+        markets: "$.get('markets', [])"
+        min_edge_bps: "$.get('min_edge_bps', 100)"
+      outputs:
+        edge_candidates: "$.get('edge_candidates', [])"
+
+    - type: prompt
+      name: worldcup-market-edge-analysis
+      description: Explain candidate market edges with caveats and source evidence.
+      condition: "$.get('include_reasoning', True) is True and len($.get('edge_candidates', [])) > 0"
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-2.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        query: "$.get('query')"
+        event_urn: "$.get('event_urn')"
+        edge_candidates: "$.get('edge_candidates', [])"
+        markets: "$.get('markets', [])"
+      outputs:
+        analysis: "$"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml
@@ -1,0 +1,95 @@
+workflow:
+  name: worldcup-generate-market-brief
+  title: World Cup Intelligence - Generate Market Brief
+  description: Generate a structured Google GenAI market-intelligence brief from same-pod event context, markets, prematch research, and optional xAI social pulse.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    query: "$.get('query', '')"
+    event_urn: "$.get('event_urn', '')"
+    market_ids: "$.get('market_ids', [])"
+    depth: "$.get('depth', 'standard')"
+    include_social_pulse: "$.get('include_social_pulse', True)"
+  outputs:
+    brief: "$.get('brief', {})"
+    evidence: "$.get('evidence', [])"
+    workflow-status: "$.get('brief', {}) != {} and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: lookup-event-context
+      description: Load event context from same-pod document store if event_urn is provided.
+      condition: "$.get('event_urn', '') != ''"
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('event_urn')"
+      outputs:
+        event_context: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: document
+      name: lookup-markets
+      description: Load linked market cache for the event or query from same-pod state.
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.machina_event_urn: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
+      outputs:
+        markets: "[d.get('value', {}) for d in $.get('documents', [])]"
+
+    - type: connector
+      name: grounded-prematch-research
+      description: Google GenAI grounded search/extract for latest match and market context.
+      condition: "$.get('query', '') != ''"
+      continue_on_error: true
+      connector:
+        name: machina-search
+        command: web_search_extract
+      inputs:
+        entity_id: "$.get('event_urn', '')"
+        entity_name: "$.get('query', '')"
+        search_query: "$.get('query', '') + ' FIFA World Cup 2026 team news odds market analysis'"
+        extraction_prompt: "Extract factual World Cup match context, team news, market-relevant factors, and source URLs. Return JSON with keys: match_context, team_news, key_factors, sources. Do not invent facts."
+        recency_days: "7"
+        model: "'gemini-2.5-flash'"
+        location: "'global'"
+      outputs:
+        prematch_research: "$.get('extraction', {})"
+        grounding_sources: "$.get('search_results', [])"
+
+    - type: prompt
+      name: worldcup-market-brief
+      description: Generate the structured market brief with Google GenAI.
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-2.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        query: "$.get('query', '')"
+        event_context: "$.get('event_context', {})"
+        markets: "$.get('markets', [])"
+        prematch_research: "$.get('prematch_research', {})"
+        grounding_sources: "$.get('grounding_sources', [])"
+        depth: "$.get('depth', 'standard')"
+      outputs:
+        brief: "$"
+        evidence: "$.get('evidence', [])"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
@@ -1,0 +1,79 @@
+workflow:
+  name: worldcup-get-event-context
+  title: World Cup Intelligence - Event Context
+  description: Return enriched World Cup event context from same-pod state, match truth, Sports Skills context, linked markets, and optional social pulse.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    event_urn: "$.get('event_urn', '')"
+    provider_event_id: "$.get('provider_event_id', '')"
+    include_markets: "$.get('include_markets', True)"
+    include_prematch_research: "$.get('include_prematch_research', True)"
+    include_social_pulse: "$.get('include_social_pulse', False)"
+  outputs:
+    event_context: "$.get('event_context', {})"
+    workflow-status: "$.get('event_context', {}) != {} and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: lookup-event
+      description: Lookup canonical event context from the same pod document store.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
+        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+      outputs:
+        event_document: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: connector
+      name: fetch-event-summary
+      description: Optional Sports Skills football event summary if a provider event id is available.
+      condition: "$.get('provider_event_id', '') != ''"
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_football
+      inputs:
+        command: "'get_event_summary'"
+        event_id: "$.get('provider_event_id')"
+      outputs:
+        sports_context: "$.get('data', {}) if $.get('status') else {}"
+
+    - type: document
+      name: lookup-linked-markets
+      description: Pull markets linked to this Machina event from the same pod document store.
+      condition: "$.get('include_markets', True) is True and $.get('event_urn', '') != ''"
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.machina_event_urn: "$.get('event_urn')"
+      outputs:
+        linked_markets: "[d.get('value', {}) for d in $.get('documents', [])]"
+
+    - type: mapping
+      name: worldcup-iptc-event-to-api-response
+      title: World Cup | Event Context Envelope
+      inputs:
+        event_document: "$.get('event_document', {})"
+        sports_context: "$.get('sports_context', {})"
+        linked_markets: "$.get('linked_markets', [])"
+      outputs:
+        event_context: "$.get('event_context', {'event': $.get('event_document', {}), 'sports_context': $.get('sports_context', {}), 'markets': $.get('linked_markets', [])})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
@@ -1,0 +1,47 @@
+workflow:
+  name: worldcup-get-iptc-event-context
+  title: World Cup Intelligence - IPTC Event Context
+  description: Return canonical IPTC/Sportschema and Machina URN context from the same pod document store.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    machina_urn: "$.get('machina_urn', '')"
+    provider_event_id: "$.get('provider_event_id', '')"
+    provider: "$.get('provider', 'api-football')"
+  outputs:
+    event: "$.get('event', {})"
+    workflow-status: "$.get('event', {}) != {} and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: lookup-event
+      description: Lookup canonical Machina event by URN/provider id.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('machina_urn') if $.get('machina_urn') else {'$exists': True}"
+        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+      outputs:
+        event_document: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: mapping
+      name: worldcup-iptc-event-to-api-response
+      title: World Cup | IPTC Event API Response
+      inputs:
+        event_document: "$.get('event_document', {})"
+      outputs:
+        event: "$.get('event', $.get('event_document', {}))"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-health.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-health.yml
@@ -1,0 +1,20 @@
+workflow:
+  name: worldcup-health
+  title: World Cup Intelligence - Health
+  description: Cheap smoke test for the World Cup Intelligence template.
+  inputs:
+    include_connectors: "$.get('include_connectors', False)"
+  outputs:
+    product: "'world_cup_market_intelligence'"
+    version: "'0.1.0'"
+    workflow-status: "'executed'"
+  tasks:
+    - type: expression
+      name: health
+      description: Return template metadata.
+      inputs:
+        include_connectors: "$.get('include_connectors', False)"
+      outputs:
+        product: "'world_cup_market_intelligence'"
+        version: "'0.1.0'"
+        connectors: "['api-football', 'sports-skills', 'kalshi', 'polymarket', 'google-genai', 'grok'] if $.get('include_connectors') else []"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
@@ -1,0 +1,78 @@
+workflow:
+  name: worldcup-ingest-fixtures
+  title: World Cup Intelligence - Ingest Fixtures
+  description: Fetch World Cup fixtures from API-Football, normalize to IPTC Sport Schema, resolve Machina URNs, and save to the same pod document store.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    league: "$.get('league', '1')"
+    season: "$.get('season', '2026')"
+    provider: "$.get('provider', 'api-football')"
+    force: "$.get('force', False)"
+  outputs:
+    fixtures_count: "$.get('fixtures_count', 0)"
+    resolved_count: "$.get('resolved_count', 0)"
+    workflow-status: "$.get('fixtures_count', 0) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: connector
+      name: fetch-fixtures
+      description: Fetch fixtures from API-Football for the configured league/season.
+      connector:
+        name: api-football
+        command: get-fixtures
+      inputs:
+        league: "$.get('league')"
+        season: "$.get('season')"
+      outputs:
+        raw_fixtures: "$.get('response', [])"
+        fixtures_count: "len($.get('response', []))"
+
+    - type: mapping
+      name: worldcup-api-football-event-to-iptc
+      title: World Cup | API-Football Event to IPTC
+      description: Normalize API-Football fixtures to IPTC/Sportschema event documents.
+      condition: "len($.get('raw_fixtures', [])) > 0"
+      inputs:
+        fixtures: "$.get('raw_fixtures', [])"
+      outputs:
+        iptc_events: "$.get('sport_schema_events', [])"
+
+    - type: connector
+      name: resolve-machina-urns
+      description: Resolve provider/IPTC URNs to canonical Machina URNs.
+      condition: "len($.get('iptc_events', [])) > 0"
+      connector:
+        name: machina-urn-resolver
+        command: resolve_events
+      inputs:
+        events: "$.get('iptc_events', [])"
+        provider: "$.get('provider', 'api-football')"
+      outputs:
+        resolved_events: "$.get('events', [])"
+        resolved_count: "$.get('count', 0)"
+
+    - type: document
+      name: save-worldcup-events
+      description: Save resolved World Cup events in the same pod document store.
+      condition: "len($.get('resolved_events', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "worldcup:event"
+      documents:
+        items: "$.get('resolved_events', [])"
+      inputs:
+        resolved_events: "$.get('resolved_events', [])"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
@@ -1,0 +1,64 @@
+workflow:
+  name: worldcup-refresh-prematch-enrichment
+  title: World Cup Intelligence - Refresh Prematch Enrichment
+  description: Internal/admin workflow to refresh grounded prematch research and optional social pulse for upcoming fixtures from same-pod state.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    competition_urn: "$.get('competition_urn', 'urn:machina:soccer:competition:fifa-world-cup')"
+    limit: "$.get('limit', 10)"
+    include_social: "$.get('include_social', True)"
+    force: "$.get('force', False)"
+  outputs:
+    fixtures_enriched: "len($.get('search_results', []))"
+    workflow-status: "len($.get('search_results', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: find-fixtures-for-research
+      description: Find upcoming World Cup fixtures requiring fresh prematch research in same-pod state.
+      config:
+        action: search
+        search-limit: 10
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value.competition: "$.get('competition_urn')"
+      outputs:
+        fixtures: "[d.get('value', {}) for d in $.get('documents', [])][:int($.get('limit', 10))]"
+        has_fixtures: "len($.get('documents', [])) > 0"
+
+    - type: connector
+      name: search-and-extract-prematch
+      description: Search Google and extract structured pre-match analysis.
+      condition: "$.get('has_fixtures') is True"
+      continue_on_error: true
+      connector:
+        name: machina-search
+        command: web_search_extract
+      foreach:
+        concurrent: false
+        name: fixture_item
+        expr: $
+        value: "$.get('fixtures', [])"
+      inputs:
+        entity_id: "$.get('fixture_item', {}).get('_id', '')"
+        entity_name: "$.get('fixture_item', {}).get('name', '')"
+        search_query: >
+          $.get('fixture_item', {}).get('home_team_name', '') + ' vs ' + $.get('fixture_item', {}).get('away_team_name', '') + ' FIFA World Cup 2026 preview injuries lineups odds market context'
+        extraction_prompt: "Extract structured pre-match analysis with keys: team_form, injuries_suspensions, head_to_head, key_players, tactical_preview, prediction_context, sources. Only use sourced facts."
+        recency_days: 7
+      outputs:
+        search_results: |
+          [{'entity_id': $.get('entity_id', ''), 'extraction': $.get('extraction', {}), 'sources': $.get('search_results', [])}]

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-search-markets.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-search-markets.yml
@@ -1,0 +1,72 @@
+workflow:
+  name: worldcup-search-markets
+  title: World Cup Intelligence - Search Markets
+  description: Fast read workflow for searching World Cup markets across same-pod cached and live Kalshi/Polymarket sources.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    query: "$.get('query', 'World Cup')"
+    event_urn: "$.get('event_urn', '')"
+    team: "$.get('team', '')"
+    source: "$.get('source', 'all')"
+    status: "$.get('status', 'open')"
+    limit: "$.get('limit', 20)"
+    force_live: "$.get('force_live', False)"
+  outputs:
+    markets: "$.get('markets', [])"
+    warnings: "$.get('warnings', [])"
+    workflow-status: "'executed'"
+  tasks:
+    - type: document
+      name: lookup-market-cache
+      description: Search cached normalized World Cup markets in the same pod document store first.
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.status: "$.get('status', 'open')"
+        value.machina_event_urn: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
+      outputs:
+        cached_markets: "[d.get('value', {}) for d in $.get('documents', [])][:int($.get('limit', 20))]"
+        cache_count: "len($.get('documents', []))"
+
+    - type: connector
+      name: live-market-search
+      description: Live fallback through Sports Skills when cache is empty or force_live is set.
+      condition: "$.get('force_live', False) is True or $.get('cache_count', 0) == 0"
+      connector:
+        name: sports-skills
+        command: invoke_markets
+      inputs:
+        command: "'search_entity'"
+        entity: "$.get('query') or $.get('team') or 'FIFA World Cup 2026'"
+        sport: "'football'"
+        limit: "$.get('limit', 20)"
+      outputs:
+        live_markets: "$.get('data', {}) if $.get('status') else {}"
+
+    - type: mapping
+      name: worldcup-market-normalization
+      title: World Cup | Market Search Response Normalization
+      inputs:
+        cached_markets: "$.get('cached_markets', [])"
+        live_markets: "$.get('live_markets', {})"
+        source: "$.get('source', 'all')"
+        limit: "$.get('limit', 20)"
+      outputs:
+        markets: "$.get('markets', $.get('cached_markets', []))"
+        warnings: "$.get('warnings', [])"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
@@ -1,0 +1,103 @@
+workflow:
+  name: worldcup-sync-market-sources
+  title: World Cup Intelligence - Sync Market Sources
+  description: Refresh Kalshi and Polymarket World Cup market cache in the same pod document store.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      api_key: $TEMP_CONTEXT_VARIABLE_GOOGLE_GENERATIVE_AI_API_KEY
+    machina-search:
+      google_credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      google_project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+      xai_api_key: $TEMP_CONTEXT_VARIABLE_XAI_API_KEY
+  inputs:
+    query: "$.get('query', 'FIFA World Cup 2026')"
+    sport: "$.get('sport', 'football')"
+    status: "$.get('status', 'open')"
+    limit: "$.get('limit', 100)"
+  outputs:
+    markets_count: "len($.get('normalized_markets', []))"
+    linked_count: "len([m for m in $.get('linked_markets', []) if m.get('machina_event_urn')])"
+    workflow-status: "len($.get('normalized_markets', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: connector
+      name: fetch-sports-skills-markets
+      description: Fetch football/FIFA markets using the Sports Skills market orchestrator.
+      connector:
+        name: sports-skills
+        command: invoke_markets
+      inputs:
+        command: "'get_sport_markets'"
+        sport: "$.get('sport', 'football')"
+        status: "$.get('status', 'open')"
+        limit: "$.get('limit', 100)"
+      outputs:
+        sports_skills_markets: "$.get('data', {}) if $.get('status') else {}"
+
+    - type: connector
+      name: search-polymarket-fallback
+      description: Direct Polymarket fallback search for World Cup/FIFA markets.
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_polymarket
+      inputs:
+        command: "'search_markets'"
+        query: "$.get('query', 'FIFA World Cup 2026')"
+        limit: "$.get('limit', 100)"
+      outputs:
+        polymarket_markets: "$.get('data', {}) if $.get('status') else {}"
+
+    - type: connector
+      name: search-kalshi-fallback
+      description: Direct Kalshi fallback search for World Cup/FIFA markets.
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_kalshi
+      inputs:
+        command: "'get_events'"
+        search: "$.get('query', 'FIFA World Cup 2026')"
+        limit: "$.get('limit', 100)"
+      outputs:
+        kalshi_markets: "$.get('data', {}) if $.get('status') else {}"
+
+    - type: mapping
+      name: worldcup-market-normalization
+      title: World Cup | Market Normalization
+      description: Normalize Sports Skills, Kalshi, and Polymarket market payloads.
+      inputs:
+        sports_skills_markets: "$.get('sports_skills_markets', {})"
+        polymarket_markets: "$.get('polymarket_markets', {})"
+        kalshi_markets: "$.get('kalshi_markets', {})"
+      outputs:
+        normalized_markets: "$.get('normalized_markets', [])"
+
+    - type: mapping
+      name: worldcup-market-entity-linking
+      title: World Cup | Market Entity Linking
+      description: Link normalized markets to Machina URNs where confidence is high.
+      inputs:
+        markets: "$.get('normalized_markets', [])"
+      outputs:
+        linked_markets: "$.get('linked_markets', [])"
+
+    - type: document
+      name: save-market-cache
+      description: Save normalized linked market cache in the same pod document store.
+      condition: "len($.get('linked_markets', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "worldcup:market-cache"
+      documents:
+        items: "$.get('linked_markets', [])"
+      inputs:
+        linked_markets: "$.get('linked_markets', [])"


### PR DESCRIPTION
## Summary
- Add the world-cup-intelligence agent-template scaffold under machina-templates
- Add workflow contracts for fixture ingest, market sync/search, IPTC event context, market comparison, market-edge/arbitrage-candidate analysis, Google GenAI market briefs, and xAI/Grok fan sentiment
- Use the same pod native document store for World Cup event, market, and social-pulse state; no MongoDB Atlas dependency is included
- Add prompt, mapping, MCP/docs, source hierarchy, and disclaimer scaffolding for read-only market intelligence

## Notes
- This is a scaffold PR: workflows are wired as template contracts/stubs and should be validated against a hosted pod before public API exposure
- Market-edge/arbitrage outputs are framed as informational analysis only; no trading/betting execution is included
- Pod state is represented as native document tasks with document names like `worldcup:event`, `worldcup:market-cache`, and `worldcup:social-cache`

## Validation
- YAML parse check across 25 template YAML files
- _install.yml dataset reference check: 24/24 found
- Storage check: no mongodb-atlas / MongoDB Atlas / MONGODB_ATLAS references
- Secret pattern scan: 0 findings
- git diff --check: passed
