### PR TITLE
fix: register canonical-read workflows in _install.yml

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -52,6 +52,14 @@ datasets:
   - type: workflow
     path: workflows/worldcup-get-event-context.yml
   - type: workflow
+    path: workflows/worldcup-get-standings.yml
+  - type: workflow
+    path: workflows/worldcup-get-squads.yml
+  - type: workflow
+    path: workflows/worldcup-get-injuries.yml
+  - type: workflow
+    path: workflows/worldcup-get-schedule.yml
+  - type: workflow
     path: workflows/worldcup-compare-market-sources.yml
   - type: workflow
     path: workflows/worldcup-find-market-edges.yml


### PR DESCRIPTION
The four canonical reads (standings, squads, injuries, schedule) shipped in #225 with workflow files but weren't added to the `_install.yml` manifest, so git import skipped creating them on the pod. This registers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)