### PR TITLE
fix: canonical-read output envelope binding

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
@@ -61,4 +61,5 @@ workflow:
         home_team: "$.get('home_team_name', '')"
         away_team: "$.get('away_team_name', '')"
       outputs:
-        injuries: "$.get('data', {}) if $.get('status') else {}"
+        # runner strips our connector's {status,data} envelope -> $ is the data.
+        injuries: "$"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-schedule.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-schedule.yml
@@ -42,4 +42,5 @@ workflow:
         status: "$.get('status', '')"
         limit: "$.get('limit', 100)"
       outputs:
-        schedule: "$.get('data', {}) if $.get('status') else {}"
+        # runner strips our connector's {status,data} envelope -> $ is the data.
+        schedule: "$"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
@@ -137,4 +137,5 @@ workflow:
         home_team: "$.get('home_team_name', '')"
         away_team: "$.get('away_team_name', '')"
       outputs:
-        squads: "$.get('data', {}) if $.get('status') else {}"
+        # runner strips our connector's {status,data} envelope -> $ is the data.
+        squads: "$"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
@@ -72,4 +72,6 @@ workflow:
         league_id: "$.get('resolved_league') or $.get('league') or '1'"
         season: "$.get('resolved_year') or $.get('season') or '2026'"
       outputs:
-        standings: "$.get('data', {}) if $.get('status') else {}"
+        # worldcup-market-intelligence returns {status,data}; the runner strips
+        # that envelope, so $ is already the data dict (groups/warnings/...).
+        standings: "$"


### PR DESCRIPTION
The four canonical reads bound their final connector output as `$.get('data') if $.get('status')`, but the runner strips our connector's {status,data} envelope so `$` is already the data dict — making the binding evaluate to {} and the workflows return `skipped`. Bind `"$"` instead (matching the market workflows). sports-skills `$.data` fallback bindings unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)