### PR TITLE
fix: injuries team names from sport:competitors

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
@@ -30,8 +30,8 @@ workflow:
       outputs:
         home_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_home_team_id')"
         away_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_away_team_id')"
-        home_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('teams', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
-        away_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('teams', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
+        home_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
+        away_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
         resolved_league: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_league_id')"
         resolved_year: "((($.get('documents', []) or [{}])[0].get('value', {}).get('start_date') or '2026'))[:4]"
 


### PR DESCRIPTION
get-injuries' lookup-event read `value.teams`, but the event doc stores teams under `sport:competitors` — so home/away names came back blank (team_id was fine). squads masks the same path via api-football backfill; injuries has none. Points both name expressions at `sport:competitors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)