### PR TITLE
feat: team identity crosswalk producer (api-football + ESPN + Sportradar)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -64,6 +64,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-sync-identity-crosswalk.yml
   - type: workflow
+    path: workflows/worldcup-sync-team-crosswalk.yml
+  - type: workflow
     path: workflows/worldcup-compare-market-sources.yml
   - type: workflow
     path: workflows/worldcup-find-market-edges.yml

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -21,6 +21,7 @@ normalize_injuries = _module.normalize_injuries
 normalize_schedule = _module.normalize_schedule
 normalize_identity_crosswalk = _module.normalize_identity_crosswalk
 mint_event_identity = _module.mint_event_identity
+merge_provider_entities = _module.merge_provider_entities
 
 
 def _kalshi_record(**overrides):
@@ -819,3 +820,81 @@ class TestMintEventIdentity:
         r = mint_event_identity({"params": {"fixtures": [fx]}})
         assert r["data"]["events"] == []
         assert r["data"]["warnings"]
+
+
+# -- Provider entity merge (identity crosswalk producer) ---------------------
+
+
+class TestMergeProviderEntities:
+    def test_iso3_join_converges_name_variants(self):
+        r = merge_provider_entities({"params": {
+            "api_football_teams": [{"id": "17", "name": "Korea Republic"}, {"id": "7", "name": "Uruguay"}],
+            "espn_teams": [{"id": "451", "name": "South Korea"}, {"id": "212", "name": "Uruguay"}],
+        }})["data"]
+        assert r["count"] == 2
+        by_name = {it["name"]: it for it in r["items"]}
+        # canonical name comes from api_football ("Korea Republic", not "South Korea")
+        assert "Korea Republic" in by_name
+        assert by_name["Korea Republic"]["provider_ids"] == {"api_football": "17", "espn": "451"}
+        assert by_name["Uruguay"]["provider_ids"] == {"api_football": "7", "espn": "212"}
+        assert r["provider_summary"] == {"api_football": 2, "espn": 2}
+
+    def test_only_id_provider_creates_entity_when_api_football_missing(self):
+        r = merge_provider_entities({"params": {"espn_teams": [{"id": "99", "name": "Wales"}]}})["data"]
+        assert r["items"][0]["provider_ids"] == {"espn": "99"}
+        assert r["items"][0]["name"] == "Wales"
+
+    def test_unmapped_names_do_not_collide(self):
+        # Two distinct names that fall back to "unk" must not merge into one.
+        r = merge_provider_entities({"params": {"api_football_teams": [
+            {"id": "1", "name": "Zzzland"}, {"id": "2", "name": "Qqqstan"},
+        ]}})["data"]
+        assert r["count"] == 2
+
+    def test_skips_incomplete_rows_and_warns_when_empty(self):
+        r = merge_provider_entities({"params": {"api_football_teams": [{"id": "", "name": "X"}, {"name": "NoId"}]}})["data"]
+        assert r["count"] == 0
+        assert r["warnings"]
+
+
+# -- Provider entity merge (identity crosswalk producer) ---------------------
+
+
+class TestMergeProviderEntities:
+    def test_iso3_join_converges_name_variants(self):
+        r = merge_provider_entities({"params": {
+            "api_football_teams": [{"id": "17", "name": "Korea Republic"}, {"id": "7", "name": "Uruguay"}],
+            "espn_teams": [{"id": "451", "name": "South Korea"}, {"id": "212", "name": "Uruguay"}],
+        }})["data"]
+        by_name = {it["name"]: it for it in r["items"]}
+        assert r["count"] == 2
+        # canonical name from api_football ("Korea Republic", not ESPN's "South Korea")
+        assert by_name["Korea Republic"]["provider_ids"] == {"api_football": "17", "espn": "451"}
+        assert by_name["Uruguay"]["provider_ids"] == {"api_football": "7", "espn": "212"}
+
+    def test_enrich_only_provider_attaches_but_never_creates(self):
+        # Sportradar lists a superset (incl. teams not in the 48). It should only
+        # attach to existing canonical teams, never add new ones.
+        r = merge_provider_entities({"params": {
+            "api_football_teams": [{"id": "7", "name": "Uruguay"}],
+            "sportradar_teams": [
+                {"id": "sr:competitor:1", "name": "Uruguay"},      # matches -> attaches
+                {"id": "sr:competitor:9", "name": "Scotland"},     # not in 48 -> skipped
+            ],
+        }})["data"]
+        assert r["count"] == 1
+        assert r["items"][0]["provider_ids"] == {"api_football": "7", "sportradar": "sr:competitor:1"}
+
+    def test_canonical_provider_creates_entity(self):
+        r = merge_provider_entities({"params": {"espn_teams": [{"id": "99", "name": "Wales"}]}})["data"]
+        assert r["count"] == 1 and r["items"][0]["provider_ids"] == {"espn": "99"}
+
+    def test_unmapped_names_do_not_collide(self):
+        r = merge_provider_entities({"params": {"api_football_teams": [
+            {"id": "1", "name": "Zzzland"}, {"id": "2", "name": "Qqqstan"},
+        ]}})["data"]
+        assert r["count"] == 2
+
+    def test_warns_when_empty(self):
+        r = merge_provider_entities({"params": {}})["data"]
+        assert r["count"] == 0 and r["warnings"]

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
@@ -1,0 +1,109 @@
+workflow:
+  name: worldcup-sync-team-crosswalk
+  title: World Cup Intelligence - Sync Team Identity Crosswalk
+  description: |
+    Build the national-team identity crosswalk: canonical urn:machina:sport:soccer:team
+    URNs with provider_ids from api-football (canonical name authority) + ESPN
+    (sports-skills) + Sportradar, joined by country (iso3). Saves worldcup:identity-crosswalk
+    docs so the exposed API can resolve any provider's team id to the canonical URN.
+
+    api-football + ESPN define the 48-team set; Sportradar is enrich-only (its season
+    list is a 100+ qualifying-pool superset — only matches to the 48 attach). Opta/Entain
+    and Transfermarkt slots exist in the merge connector and fill in once their team-id
+    sources are wired (Opta connector not yet deployed; Entain/bwin has no team-list
+    endpoint; Transfermarkt is player-level only).
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    sportradar-soccer:
+      api_key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
+  inputs:
+    league: "$.get('league', '1')"
+    season: "$.get('season', '2026')"
+    sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
+  outputs:
+    saved_count: "len($.get('normalized_items', []))"
+    provider_summary: "$.get('provider_summary', {})"
+    workflow-status: "len($.get('normalized_items', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: connector
+      name: fetch-af-teams
+      description: Canonical World Cup teams from api-football (name authority + api_football id).
+      continue_on_error: true
+      connector:
+        name: api-football
+        command: get-teams
+      inputs:
+        league: "$.get('league', '1')"
+        season: "$.get('season', '2026')"
+      outputs:
+        af_teams: "[{'id': str((r.get('team') or {}).get('id') or ''), 'name': (r.get('team') or {}).get('name')} for r in $.get('response', []) if (r.get('team') or {}).get('id')]"
+
+    - type: connector
+      name: fetch-espn-teams
+      description: ESPN team ids for the World Cup season via sports-skills.
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_football
+      inputs:
+        command: "'get_season_teams'"
+        season_id: "'world-cup-2026'"
+      outputs:
+        espn_teams: "$.get('data', {}).get('teams', []) if $.get('status') else []"
+
+    - type: connector
+      name: fetch-sr-competitors
+      description: Sportradar competitors (sr:competitor ids) for the World Cup 2026 season (enrich-only).
+      continue_on_error: true
+      connector:
+        name: sportradar-soccer
+        command: get-seasons/{season_id}/competitors.json
+        command_attribute:
+          season_id: "$.get('sr_season_id', 'sr:season:101177')"
+      inputs:
+        api_key: "$.get('api_key')"
+      outputs:
+        sportradar_teams: "$.get('season_competitors', [])"
+
+    - type: connector
+      name: merge-entities
+      description: Join provider team lists by iso3 into crosswalk items (api-football/ESPN canonical, Sportradar enrich-only).
+      connector:
+        name: worldcup-market-intelligence
+        command: merge_provider_entities
+      inputs:
+        api_football_teams: "$.get('af_teams', [])"
+        espn_teams: "$.get('espn_teams', [])"
+        sportradar_teams: "$.get('sportradar_teams', [])"
+      outputs:
+        items: "$.get('items', [])"
+        provider_summary: "$.get('provider_summary', {})"
+
+    - type: connector
+      name: normalize-crosswalk
+      description: Mint canonical urn:machina team URNs + provider_ids for each merged item.
+      connector:
+        name: worldcup-market-intelligence
+        command: normalize_identity_crosswalk
+      inputs:
+        items: "$.get('items', [])"
+      outputs:
+        normalized_items: "$.get('normalized_items', [])"
+
+    - type: document
+      name: save-crosswalk
+      description: Save the team identity crosswalk to same-pod document state.
+      condition: "len($.get('normalized_items', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:identity-crosswalk'"
+      documents:
+        items: "$.get('normalized_items', [])"
+      inputs:
+        normalized_items: "$.get('normalized_items', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1833,3 +1833,69 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
         "status": True,
         "data": {"sport_schema_events": events, "events": events, "count": len(events), "warnings": warnings},
     }
+
+
+# Provider id sources for the team identity crosswalk. api_football is the
+# canonical NAME authority (it is the data source); every other provider
+# contributes ONLY its id, matched to the same national team by country (iso3).
+# espn/transfermarkt come via sports-skills; sportradar/opta/entain via their
+# own connectors (populate once their keys are configured).
+_CROSSWALK_PROVIDERS = ["api_football", "espn", "transfermarkt", "sportradar", "opta", "entain"]
+# Only these define the canonical entity SET (both list exactly the 48 WC teams).
+# Everyone else is enrich-only: they attach their id to an existing team but never
+# create new entities (e.g. Sportradar's season list is a 100+ qualifying-pool
+# superset; we don't want the extras polluting the crosswalk).
+_CANONICAL_CROSSWALK_PROVIDERS = {"api_football", "espn"}
+
+
+def merge_provider_entities(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Merge per-provider national-team lists into identity-crosswalk items.
+
+    Each `{provider}_teams` param is a list of {id, name}. Teams are joined
+    across providers by iso3 (so "Korea Republic"/"South Korea" converge), with
+    api_football's name as the canonical slug source. Output `items` feed
+    normalize_identity_crosswalk, which mints the canonical urn:machina team URN
+    and stores provider_ids = {api_football, espn, sportradar, opta, entain, …}.
+
+    api_football/espn define the canonical 48-team set; sportradar/opta/entain are
+    enrich-only (attach ids to existing teams; never create new ones).
+    """
+    params = _params(request_data)
+    canon: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    summary: dict[str, int] = {}
+
+    for provider in _CROSSWALK_PROVIDERS:
+        teams = _as_list(params.get(f"{provider}_teams"))
+        count = 0
+        for t in teams:
+            if not isinstance(t, dict):
+                continue
+            name = _text(t.get("name"))
+            tid = _text(t.get("id"))
+            if not name or not tid:
+                continue
+            iso = _to_iso3(name)
+            key = iso if iso != "unk" else _slugify(name)  # avoid unk-collisions
+            if key not in canon:
+                if provider not in _CANONICAL_CROSSWALK_PROVIDERS:
+                    continue  # enrich-only: skip teams not in the canonical set
+                canon[key] = {"name": name, "provider_ids": {}}
+                order.append(key)
+            if provider == "api_football":
+                canon[key]["name"] = name  # canonical name authority
+            canon[key]["provider_ids"][provider] = tid
+            count += 1
+        if teams:
+            summary[provider] = count
+
+    items = [
+        {"type": "team", "name": canon[k]["name"], "country": canon[k]["name"],
+         "provider_ids": canon[k]["provider_ids"]}
+        for k in order
+    ]
+    warnings = [] if items else ["No provider team lists supplied."]
+    return {
+        "status": True,
+        "data": {"items": items, "count": len(items), "provider_summary": summary, "warnings": warnings},
+    }

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -36,3 +36,5 @@ connector:
       value: "normalize_identity_crosswalk"
     - name: "Mint event identity"
       value: "mint_event_identity"
+    - name: "Merge provider entities"
+      value: "merge_provider_entities"


### PR DESCRIPTION
## What
Wires the id-only providers into the identity crosswalk so the exposed API can resolve any provider's team id → canonical `urn:machina:sport:soccer:team:…` URN. (Item 1 from the review.)

- **`merge_provider_entities`** connector command — joins per-provider national-team lists by **country (iso3)** so name variants converge (`Korea Republic`/`South Korea` → one team), api-football as the canonical name authority. api-football + ESPN define the 48-team set; **sportradar/opta/entain are enrich-only** (attach ids; never create — Sportradar's season list is a 100+ qualifying-pool superset).
- **`worldcup-sync-team-crosswalk`** workflow — api-football `get-teams` + ESPN `get_season_teams` + Sportradar competitors (`sr:competition:16` → `sr:season:101177`) → merge → `normalize_identity_crosswalk` → save `worldcup:identity-crosswalk`.

## Provider status (verified live: check_secrets + probes)
| Provider | Role | Status |
|---|---|---|
| api-football | data + canonical id | ✅ populated |
| ESPN (sports-skills) | id | ✅ populated |
| Sportradar | id (enrich-only) | ✅ populated (`sr:competitor:*`) |
| Opta | id | ⚠️ creds set, but stats-perform connector not deployed — slot ready |
| Entain/bwin | id | ⚠️ no team-list endpoint (odds only) |
| Transfermarkt | id | ⚠️ player-level only (no national-team ids) |

## Tests
76 pass (merge: iso3 convergence, canonical name authority, enrich-only never-creates, no-collision); `check-no-openai.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)