### PR TITLE
feat: Opta team ids in crosswalk + iso3 accent fix + Opta authorized feed

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -898,3 +898,31 @@ class TestMergeProviderEntities:
     def test_warns_when_empty(self):
         r = merge_provider_entities({"params": {}})["data"]
         assert r["count"] == 0 and r["warnings"]
+
+
+# -- iso3 accent normalization + Opta enrich convergence ---------------------
+
+_to_iso3 = _module._to_iso3
+
+
+class TestIso3AccentNormalization:
+    def test_accents_and_variants_converge(self):
+        assert _to_iso3("Cape Verde Islands") == _to_iso3("Cabo Verde") == "cpv"
+        assert _to_iso3("Ivory Coast") == _to_iso3("Côte d'Ivoire") == "civ"
+        assert _to_iso3("Türkiye") == _to_iso3("Turkey") == "tur"
+        assert _to_iso3("Korea Republic") == _to_iso3("South Korea") == "kor"
+
+    def test_opta_names_enrich_canonical_team_by_iso3(self):
+        # Opta's "Cabo Verde"/"Côte d'Ivoire" must attach to api-football's
+        # "Cape Verde Islands"/"Ivory Coast" — enrich-only, by iso3.
+        r = merge_provider_entities({"params": {
+            "api_football_teams": [{"id": "1533", "name": "Cape Verde Islands"},
+                                   {"id": "1501", "name": "Ivory Coast"}],
+            "opta_teams": [{"id": "opta-cpv", "name": "Cabo Verde"},
+                           {"id": "opta-civ", "name": "Côte d'Ivoire"},
+                           {"id": "opta-x", "name": "Kenya"}],  # not in 48 -> skipped
+        }})["data"]
+        by_name = {it["name"]: it for it in r["items"]}
+        assert r["count"] == 2
+        assert by_name["Cape Verde Islands"]["provider_ids"] == {"api_football": "1533", "opta": "opta-cpv"}
+        assert by_name["Ivory Coast"]["provider_ids"] == {"api_football": "1501", "opta": "opta-civ"}

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
@@ -20,10 +20,17 @@ workflow:
       x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
     sportradar-soccer:
       api_key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
+    opta:
+      outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
+      secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
   inputs:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
     sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
+    # Opta is licensed AFC+CAF only -> the WC-qualifier calendars supply Asian +
+    # African national-team Opta ids (enrich-only). Other confederations absent.
+    opta_caf_tmcl: "$.get('opta_caf_tmcl', '9ghm6cuz03lcz4fg8jl3n1uz8')"
+    opta_afc_tmcl: "$.get('opta_afc_tmcl', '8rlm9tgxmr9acaidre79xsjdg')"
   outputs:
     saved_count: "len($.get('normalized_items', []))"
     provider_summary: "$.get('provider_summary', {})"
@@ -70,8 +77,48 @@ workflow:
         sportradar_teams: "$.get('season_competitors', [])"
 
     - type: connector
+      name: opta-auth
+      description: Get an Opta OAuth access token (outlet licensed AFC + CAF only).
+      continue_on_error: true
+      connector:
+        name: opta
+        command: authorization
+      outputs:
+        opta_token: "$.get('access_token')"
+
+    - type: connector
+      name: fetch-opta-caf
+      description: Opta contestants (team ids) for the CAF World Cup Qualifiers 2026 calendar (African teams).
+      condition: "$.get('opta_token') is not None"
+      continue_on_error: true
+      connector:
+        name: opta
+        command: invoke_request
+      inputs:
+        access_token: "$.get('opta_token')"
+        endpoint: "'team'"
+        query_params: "{'tmcl': $.get('opta_caf_tmcl', '9ghm6cuz03lcz4fg8jl3n1uz8')}"
+      outputs:
+        opta_caf: "$.get('contestant', [])"
+
+    - type: connector
+      name: fetch-opta-afc
+      description: Opta contestants (team ids) for the AFC World Cup Qualifiers 2026 calendar (Asian teams).
+      condition: "$.get('opta_token') is not None"
+      continue_on_error: true
+      connector:
+        name: opta
+        command: invoke_request
+      inputs:
+        access_token: "$.get('opta_token')"
+        endpoint: "'team'"
+        query_params: "{'tmcl': $.get('opta_afc_tmcl', '8rlm9tgxmr9acaidre79xsjdg')}"
+      outputs:
+        opta_afc: "$.get('contestant', [])"
+
+    - type: connector
       name: merge-entities
-      description: Join provider team lists by iso3 into crosswalk items (api-football/ESPN canonical, Sportradar enrich-only).
+      description: Join provider team lists by iso3 into crosswalk items (api-football/ESPN canonical; Sportradar + Opta enrich-only).
       connector:
         name: worldcup-market-intelligence
         command: merge_provider_entities
@@ -79,6 +126,7 @@ workflow:
         api_football_teams: "$.get('af_teams', [])"
         espn_teams: "$.get('espn_teams', [])"
         sportradar_teams: "$.get('sportradar_teams', [])"
+        opta_teams: "($.get('opta_caf', []) or []) + ($.get('opta_afc', []) or [])"
       outputs:
         items: "$.get('items', [])"
         provider_summary: "$.get('provider_summary', {})"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1670,7 +1670,7 @@ _ISO3_MAP = {
     "TUR": "tur", "TURKIYE": "tur", "TÜRKIYE": "tur", "TURKEY": "tur",
     "URY": "ury", "URUGUAY": "ury", "USA": "usa", "UNITED STATES": "usa",
     "WAL": "wal", "WALES": "wal", "ZAF": "zaf", "SOUTH AFRICA": "zaf",
-    "CAPE VERDE": "cpv", "CAPE VERDE ISLANDS": "cpv", "CURACAO": "cuw", "CURAÇAO": "cuw",
+    "CAPE VERDE": "cpv", "CAPE VERDE ISLANDS": "cpv", "CABO VERDE": "cpv", "CURACAO": "cuw", "CURAÇAO": "cuw",
     "UZBEKISTAN": "uzb", "CONGO DR": "cod", "DR CONGO": "cod", "JORDAN": "jor",
     "BOSNIA HERZEGOVINA": "bih", "BOSNIA AND HERZEGOVINA": "bih", "BOSNIA  HERZEGOVINA": "bih",
     "PANAMA": "pan", "NORWAY": "nor", "SWEDEN": "swe", "PORTUGAL": "por",
@@ -1686,7 +1686,10 @@ def _clean_text(value: Any) -> str:
 
 
 def _to_iso3(country: Any) -> str:
-    cleaned = re.sub(r"[^A-Z ]", " ", _clean_text(country).upper())
+    # Strip accents first (NFKD) so cross-provider spellings converge:
+    # "Côte d'Ivoire" -> "COTE D IVOIRE", "Türkiye" -> "TURKIYE".
+    ascii_src = unicodedata.normalize("NFKD", _clean_text(country)).encode("ascii", "ignore").decode("ascii")
+    cleaned = re.sub(r"[^A-Z ]", " ", ascii_src.upper())
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     if cleaned in _ISO3_MAP:
         return _ISO3_MAP[cleaned]

--- a/connectors/stats-perform/opta.py
+++ b/connectors/stats-perform/opta.py
@@ -152,6 +152,12 @@ def invoke_request(request_data):
             # For matchstats and matchexpectedgoals, match ID goes in the URL path
             match_id = query_params.pop("matchId")
             base_url = f"https://api.performfeeds.com/soccerdata/{endpoint}/{outlet}/{match_id}"
+        elif endpoint.endswith("/authorized"):
+            # Opta "authorized" feeds put the suffix AFTER the outlet, e.g.
+            # soccerdata/tournamentcalendar/{outlet}/authorized — lists the
+            # competitions/calendars this outlet is actually entitled to.
+            feed = endpoint.rsplit("/authorized", 1)[0]
+            base_url = f"https://api.performfeeds.com/soccerdata/{feed}/{outlet}/authorized"
         else:
             base_url = f"https://api.performfeeds.com/soccerdata/{endpoint}/{outlet}"
         


### PR DESCRIPTION
Wires Opta (AFC+CAF WC-qualifier contestants) into the team crosswalk as enrich-only ids; NFKD accent-normalizes `_to_iso3` so cross-provider names converge (fixes 2 Sportradar misses, 46->48); adds `{feed}/authorized` support to opta.py to read the outlet's real entitlements. 78 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)