### PR TITLE
chore: trim provider-role narration from comments/descriptions

### DIFF
--- a/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
@@ -33,14 +33,14 @@ agent:
         event_context: "$.get('event_context', {})"
 
     - name: worldcup-get-standings
-      description: World Cup group tables / standings (api-football primary, sports-skills fallback)
+      description: World Cup group tables / standings
       inputs:
         event_urn: "$.get('event_urn', '')"
       outputs:
         standings: "$.get('standings', {})"
 
     - name: worldcup-get-squads
-      description: Official 26-man squads for both teams in a fixture (api-football)
+      description: Squads for both teams in a fixture
       inputs:
         event_urn: "$.get('event_urn', '')"
       outputs:
@@ -63,7 +63,7 @@ agent:
         schedule: "$.get('schedule', {})"
 
     - name: worldcup-get-player-performance-context
-      description: Player performance context for a fixture (official FIFA Power Ranking fields kept separate from Machina provisional 0-10 signals)
+      description: Player performance context for a fixture (FIFA Power Ranking + Machina provisional signals)
       inputs:
         event_urn: "$.get('event_urn', '')"
         player_id: "$.get('player_id', '')"
@@ -96,7 +96,7 @@ agent:
         brief: "$.get('brief', {})"
 
   instructions: |
-    Use canonical match truth from API-Football, IPTC mappings, and provider event URNs before reasoning over markets.
+    Use match truth from API-Football, IPTC mappings, and provider event URNs before reasoning over markets.
     Use Google GenAI for grounded structured briefs and xAI/Grok for social/news pulse.
     You may surface market-edge or arbitrage candidates as informational analysis, but do not place trades, execute bets, promise profit, or present personalized financial advice.
     Always include evidence, uncertainty, and source attribution when available.

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
@@ -17,7 +17,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Lookup canonical event context from the same pod document store. Requires an identifying input so an arbitrary event is never returned.
+      description: Lookup event context from the same pod document store. Requires an identifying input so an arbitrary event is never returned.
       condition: "$.get('event_urn', '') != '' or $.get('provider_event_id', '') != ''"
       config:
         action: search

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-get-injuries
   title: World Cup Intelligence - Injuries
-  description: Injuries and suspensions for both teams in a World Cup fixture, from api-football /injuries (the only structured WC source; sports-skills get_missing_players is Premier-League-only). Resolve the two teams from an event_urn. Returns empty pre-tournament and populates closer to matchday.
+  description: Injuries and suspensions for both teams in a World Cup fixture, from api-football /injuries. Resolve the two teams from an event_urn or provider_event_id.
 
   context-variables:
     debugger:
@@ -19,7 +19,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Resolve home/away api-football team ids/names, league id and season from the cached event, by canonical machina event_urn OR api-football provider_event_id (fixture id).
+      description: Resolve home/away api-football team ids/names, league id and season from the cached event, by machina event_urn or api-football provider_event_id (fixture id).
       condition: "$.get('event_urn', '') != '' or $.get('provider_event_id', '') != ''"
       config:
         action: search

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-get-iptc-event-context
   title: World Cup Intelligence - IPTC Event Context
-  description: Return canonical IPTC/Sportschema event context keyed by provider URN from the same pod document store.
+  description: Return IPTC/Sportschema event context keyed by provider URN from the same pod document store.
 
   context-variables:
     debugger:
@@ -16,7 +16,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Lookup canonical event by provider URN/provider id. Requires an identifying input so an arbitrary event is never returned.
+      description: Lookup event by provider URN/provider id. Requires an identifying input so an arbitrary event is never returned.
       condition: "$.get('event_urn', '') != '' or $.get('provider_event_id', '') != ''"
       config:
         action: search

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml
@@ -20,7 +20,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Resolve canonical event and API-Football fixture id from same-pod event state.
+      description: Resolve event and API-Football fixture id from same-pod event state.
       condition: "$.get('event_urn', '') != '' or $.get('fixture_id', '') != ''"
       config:
         action: search

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-get-squads
   title: World Cup Intelligence - Squads
-  description: Squads for both teams in a World Cup fixture. api-football is primary (official 26-man lists); sports-skills get_team_profile is the fallback (full player pool) when api-football is empty. Resolve the two teams from an event_urn, or pass api-football team ids directly.
+  description: Squads for both teams in a World Cup fixture from api-football, with sports-skills get_team_profile as fallback. Resolve from an event_urn or api-football team ids.
 
   context-variables:
     debugger:
@@ -19,7 +19,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Resolve home/away api-football team ids and names from the cached event, by canonical machina event_urn OR api-football provider_event_id (fixture id).
+      description: Resolve home/away api-football team ids and names from the cached event, by machina event_urn or api-football provider_event_id (fixture id).
       condition: "$.get('event_urn', '') != '' or $.get('provider_event_id', '') != ''"
       config:
         action: search
@@ -37,7 +37,7 @@ workflow:
 
     - type: connector
       name: fetch-home-squad-af
-      description: Official home-team squad from api-football (primary).
+      description: Home-team squad from api-football.
       condition: "($.get('home_team_id') or $.get('home_team')) not in (None, '')"
       continue_on_error: true
       connector:
@@ -51,7 +51,7 @@ workflow:
 
     - type: connector
       name: fetch-away-squad-af
-      description: Official away-team squad from api-football (primary).
+      description: Away-team squad from api-football.
       condition: "($.get('away_team_id') or $.get('away_team')) not in (None, '')"
       continue_on_error: true
       connector:
@@ -65,7 +65,7 @@ workflow:
 
     - type: connector
       name: resolve-home-ss
-      description: Resolve the home team's sports-skills id by name (fallback path only).
+      description: Resolve the home team's sports-skills id by name.
       condition: "$.get('home_af_count', 0) == 0 and ($.get('home_team_name') or '') != ''"
       continue_on_error: true
       connector:
@@ -80,7 +80,7 @@ workflow:
 
     - type: connector
       name: resolve-away-ss
-      description: Resolve the away team's sports-skills id by name (fallback path only).
+      description: Resolve the away team's sports-skills id by name.
       condition: "$.get('away_af_count', 0) == 0 and ($.get('away_team_name') or '') != ''"
       continue_on_error: true
       connector:
@@ -95,7 +95,7 @@ workflow:
 
     - type: connector
       name: fetch-home-squad-ss
-      description: Sports Skills home-team roster fallback when api-football is empty.
+      description: Sports Skills home-team roster (used when api-football is empty).
       condition: "$.get('home_af_count', 0) == 0 and ($.get('home_ss_id') or '') != ''"
       continue_on_error: true
       connector:
@@ -110,7 +110,7 @@ workflow:
 
     - type: connector
       name: fetch-away-squad-ss
-      description: Sports Skills away-team roster fallback when api-football is empty.
+      description: Sports Skills away-team roster (used when api-football is empty).
       condition: "$.get('away_af_count', 0) == 0 and ($.get('away_ss_id') or '') != ''"
       continue_on_error: true
       connector:
@@ -125,7 +125,7 @@ workflow:
 
     - type: connector
       name: normalize-squads
-      description: Unify api-football (primary) + sports-skills (fallback) squads into a stable shape.
+      description: Normalize api-football and sports-skills squads.
       connector:
         name: worldcup-market-intelligence
         command: normalize_squads

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-get-standings
   title: World Cup Intelligence - Standings
-  description: World Cup group tables / standings. api-football is primary (official points/GD); sports-skills is the fallback and backfills ESPN crests. Resolve by event_urn or league/season.
+  description: World Cup group tables / standings from api-football, with sports-skills fallback. Resolve by event_urn or league/season.
 
   context-variables:
     debugger:
@@ -19,7 +19,7 @@ workflow:
   tasks:
     - type: document
       name: lookup-event
-      description: Resolve league id + season year + sports-skills season slug from the cached event, by canonical machina event_urn OR api-football provider_event_id (fixture id).
+      description: Resolve league id + season year + sports-skills season slug from the cached event, by machina event_urn or api-football provider_event_id (fixture id).
       condition: "$.get('event_urn', '') != '' or $.get('provider_event_id', '') != ''"
       config:
         action: search
@@ -36,7 +36,7 @@ workflow:
 
     - type: connector
       name: fetch-standings-af
-      description: Official standings from api-football (primary).
+      description: Standings from api-football.
       continue_on_error: true
       connector:
         name: api-football
@@ -50,7 +50,7 @@ workflow:
 
     - type: connector
       name: fetch-standings-ss
-      description: Sports Skills (ESPN) standings fallback when api-football returns nothing.
+      description: Sports Skills (ESPN) standings fallback.
       condition: "$.get('af_group_count', 0) == 0"
       continue_on_error: true
       connector:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-ingest-fixtures
   title: World Cup Intelligence - Ingest Fixtures
-  description: Fetch World Cup fixtures from API-Football, mint canonical IPTC events with machina URNs (urn:machina:sport:soccer:event:…) + provider_ids, and save to the same pod document store.
+  description: Fetch World Cup fixtures from API-Football, build IPTC events with machina URNs + provider_ids, and save to the same pod document store.
 
   context-variables:
     debugger:
@@ -34,7 +34,7 @@ workflow:
 
     - type: connector
       name: mint-event-identity
-      description: Mint canonical IPTC event docs with machina URNs + provider_ids from the raw fixtures.
+      description: Build IPTC event docs with machina URNs + provider_ids from the raw fixtures.
       condition: "len($.get('raw_fixtures', [])) > 0"
       connector:
         name: worldcup-market-intelligence

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml
@@ -2,16 +2,9 @@ workflow:
   name: worldcup-sync-team-crosswalk
   title: World Cup Intelligence - Sync Team Identity Crosswalk
   description: |
-    Build the national-team identity crosswalk: canonical urn:machina:sport:soccer:team
-    URNs with provider_ids from api-football (canonical name authority) + ESPN
-    (sports-skills) + Sportradar + Opta, joined by country (iso3). Saves
-    worldcup:identity-crosswalk docs so the exposed API can resolve any provider's team
-    id to the canonical URN.
-
-    api-football + ESPN define the 48-team set; Sportradar (season competitors) and Opta
-    (FIFA World Cup 2026 tournament contestants) are enrich-only — they attach ids to the
-    48 but never create new teams. Entain/bwin has no team-list endpoint; Transfermarkt is
-    player-level only (both still available as provider_ids slots in the merge connector).
+    Build the national-team identity crosswalk: urn:machina:sport:soccer:team URNs with
+    provider_ids from api-football + ESPN + Sportradar + Opta, joined by country (iso3).
+    Saves worldcup:identity-crosswalk docs.
 
   context-variables:
     debugger:
@@ -27,8 +20,6 @@ workflow:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
     sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
-    # Opta FIFA World Cup 2026 tournament calendar (comp 70excpe… -> tmcl
-    # 873cbl…): the actual 48 contestants, all confederations (enrich-only).
     opta_wc_tmcl: "$.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')"
   outputs:
     saved_count: "len($.get('normalized_items', []))"
@@ -37,7 +28,7 @@ workflow:
   tasks:
     - type: connector
       name: fetch-af-teams
-      description: Canonical World Cup teams from api-football (name authority + api_football id).
+      description: World Cup teams from api-football.
       continue_on_error: true
       connector:
         name: api-football
@@ -63,7 +54,7 @@ workflow:
 
     - type: connector
       name: fetch-sr-competitors
-      description: Sportradar competitors (sr:competitor ids) for the World Cup 2026 season (enrich-only).
+      description: Sportradar competitors for the World Cup 2026 season.
       continue_on_error: true
       connector:
         name: sportradar-soccer
@@ -77,7 +68,7 @@ workflow:
 
     - type: connector
       name: opta-auth
-      description: Get an Opta OAuth access token (outlet licensed AFC + CAF only).
+      description: Get an Opta OAuth access token.
       continue_on_error: true
       connector:
         name: opta
@@ -87,7 +78,7 @@ workflow:
 
     - type: connector
       name: fetch-opta-wc
-      description: Opta contestants (team ids) for the FIFA World Cup 2026 tournament calendar — the actual 48 teams, all confederations.
+      description: Opta contestants for the FIFA World Cup 2026 tournament calendar.
       condition: "$.get('opta_token') is not None"
       continue_on_error: true
       connector:
@@ -102,7 +93,7 @@ workflow:
 
     - type: connector
       name: merge-entities
-      description: Join provider team lists by iso3 into crosswalk items (api-football/ESPN canonical; Sportradar + Opta enrich-only).
+      description: Join provider team lists by iso3 into crosswalk items.
       connector:
         name: worldcup-market-intelligence
         command: merge_provider_entities
@@ -117,7 +108,7 @@ workflow:
 
     - type: connector
       name: normalize-crosswalk
-      description: Mint canonical urn:machina team URNs + provider_ids for each merged item.
+      description: Mint urn:machina team URNs + provider_ids for each merged item.
       connector:
         name: worldcup-market-intelligence
         command: normalize_identity_crosswalk

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -858,12 +858,7 @@ def detect_price_move(request_data):
     }
 
 
-# -- Canonical reads: standings + squads -------------------------------------
-#
-# These pair api-football (official, authoritative) with sports-skills (ESPN,
-# crests, fallback) per the "both strengths where needed" split:
-#   - standings: api-football primary, sports-skills fallback + crest backfill
-#   - squads:    api-football only (official 26-man lists)
+# -- Standings + squads ------------------------------------------------------
 
 
 def _std_rows_af(af: Any) -> list[dict[str, Any]]:
@@ -937,14 +932,12 @@ def _std_rows_ss(ss: Any) -> list[dict[str, Any]]:
 
 
 def normalize_standings(request_data: dict[str, Any]) -> dict[str, Any]:
-    """Unify api-football (primary) + sports-skills (fallback) WC standings.
+    """Merge api-football and sports-skills standings into stable group tables.
 
     Params:
       - af: raw api-football /standings response
       - ss: raw sports-skills get_season_standings response
       - league_id, season: passthrough labels for the envelope
-    api-football carries official points/GD; sports-skills is the fallback and
-    backfills crests when api-football rows lack a logo.
     """
     params = _params(request_data)
     warnings: list[str] = []
@@ -1040,14 +1033,12 @@ def _squad_players_ss(ss: Any) -> list[dict[str, Any]]:
 
 
 def normalize_squads(request_data: dict[str, Any]) -> dict[str, Any]:
-    """Unify api-football (primary) + sports-skills (fallback) squads.
+    """Merge api-football and sports-skills squads.
 
     Params per side ("home"/"away"):
-      - {side}_af: raw api-football /players/squads response (official 26-man)
-      - {side}_ss: raw sports-skills get_team_profile response (full pool fallback)
+      - {side}_af: raw api-football /players/squads response
+      - {side}_ss: raw sports-skills get_team_profile response
       - {side}_team_id, {side}_team: resolved labels (optional; backfilled)
-    api-football is the official trimmed list; sports-skills is the fallback when
-    api-football is empty (e.g. unauthenticated or squad not yet published).
     """
     params = _params(request_data)
     teams: list[dict[str, Any]] = []
@@ -1103,8 +1094,6 @@ def normalize_injuries(request_data: dict[str, Any]) -> dict[str, Any]:
     Params:
       - af: api-football /injuries response (league-wide; body or list)
       - home_team_id, away_team_id, home_team, away_team
-    api-football is the only structured World Cup injury source — sports-skills
-    get_missing_players is Premier-League-only — so this read is af-backed.
     """
     params = _params(request_data)
     items = _injuries_items(params.get("af"))
@@ -1551,12 +1540,7 @@ def merge_official_and_provisional_performance(request_data: dict[str, Any]) -> 
 
 
 def normalize_identity_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
-    """Normalize identity crosswalk rows into MCP document-store values.
-
-    The connector only reshapes caller-provided provider ids; it never invents
-    missing provider ids. Provider mappings must come from verified upstream
-    payloads (API-Football, Entain, Sportradar, Opta, ESPN, Transfermarkt, etc.).
-    """
+    """Normalize identity crosswalk rows into document-store values."""
     params = _params(request_data)
     items = _as_list(params.get("items"))
     normalized_items: list[dict[str, Any]] = []
@@ -1644,10 +1628,7 @@ def normalize_identity_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]
     }
 
 
-# -- Canonical machina identity helpers (shared by crosswalk + event minting) --
-#
-# These were lifted out of normalize_identity_crosswalk so mint_event_identity
-# mints the SAME urn:machina:sport:soccer:... scheme from API-Football fixtures.
+# -- Identity helpers --------------------------------------------------------
 
 _ISO3_MAP = {
     "ARG": "arg", "ARGENTINA": "arg", "AUS": "aus", "AUSTRALIA": "aus",
@@ -1739,20 +1720,11 @@ def _stable_disambiguator(provider_ids: dict[str, Any]) -> str:
 
 
 def _machina_team_urn(name: Any) -> str:
-    # National-team country == team name for the World Cup.
     return f"urn:machina:sport:soccer:team:{_slugify(name)}:{_to_iso3(name)}"
 
 
 def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
-    """Mint canonical IPTC World Cup event docs with machina URNs from API-Football fixtures.
-
-    API-Football is the data source; the canonical id is the machina URN
-    (urn:machina:sport:soccer:event:{home}-vs-{away}:{YYYYMMDD}:wor) — the SAME
-    scheme normalize_identity_crosswalk mints, so events and the crosswalk agree.
-    provider_ids carry every provider key (incl. api_football_venue_id) so the
-    exposed API can join by the api-football fixture id (provider_event_id) — the
-    stable alternate key. Venue URN is null-safe (no urn:...:venue:None).
-    """
+    """Build IPTC World Cup event docs with machina URNs from API-Football fixtures."""
     params = _params(request_data)
     fixtures = _as_list(params.get("fixtures"))
     comp_slug = _text(params.get("competition_slug")) or "world-cup-2026"
@@ -1838,31 +1810,12 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-# Provider id sources for the team identity crosswalk. api_football is the
-# canonical NAME authority (it is the data source); every other provider
-# contributes ONLY its id, matched to the same national team by country (iso3).
-# espn/transfermarkt come via sports-skills; sportradar/opta/entain via their
-# own connectors (populate once their keys are configured).
 _CROSSWALK_PROVIDERS = ["api_football", "espn", "transfermarkt", "sportradar", "opta", "entain"]
-# Only these define the canonical entity SET (both list exactly the 48 WC teams).
-# Everyone else is enrich-only: they attach their id to an existing team but never
-# create new entities (e.g. Sportradar's season list is a 100+ qualifying-pool
-# superset; we don't want the extras polluting the crosswalk).
 _CANONICAL_CROSSWALK_PROVIDERS = {"api_football", "espn"}
 
 
 def merge_provider_entities(request_data: dict[str, Any]) -> dict[str, Any]:
-    """Merge per-provider national-team lists into identity-crosswalk items.
-
-    Each `{provider}_teams` param is a list of {id, name}. Teams are joined
-    across providers by iso3 (so "Korea Republic"/"South Korea" converge), with
-    api_football's name as the canonical slug source. Output `items` feed
-    normalize_identity_crosswalk, which mints the canonical urn:machina team URN
-    and stores provider_ids = {api_football, espn, sportradar, opta, entain, …}.
-
-    api_football/espn define the canonical 48-team set; sportradar/opta/entain are
-    enrich-only (attach ids to existing teams; never create new ones).
-    """
+    """Merge per-provider national-team lists ({provider}_teams) into crosswalk items, joined by iso3."""
     params = _params(request_data)
     canon: dict[str, dict[str, Any]] = {}
     order: list[str] = []
@@ -1879,14 +1832,14 @@ def merge_provider_entities(request_data: dict[str, Any]) -> dict[str, Any]:
             if not name or not tid:
                 continue
             iso = _to_iso3(name)
-            key = iso if iso != "unk" else _slugify(name)  # avoid unk-collisions
+            key = iso if iso != "unk" else _slugify(name)
             if key not in canon:
                 if provider not in _CANONICAL_CROSSWALK_PROVIDERS:
-                    continue  # enrich-only: skip teams not in the canonical set
+                    continue
                 canon[key] = {"name": name, "provider_ids": {}}
                 order.append(key)
             if provider == "api_football":
-                canon[key]["name"] = name  # canonical name authority
+                canon[key]["name"] = name
             canon[key]["provider_ids"][provider] = tid
             count += 1
         if teams:


### PR DESCRIPTION
Removes the explanatory provider-role prose (canonical authority / data source / both-strengths / primary-fallback / enrich-only / official-26-man) from connector docstrings+comments, workflow descriptions, and agent tool descriptions. Behavior unchanged; 78 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)