### PR TITLE
feat: player identity crosswalk (api-football source + Opta ids)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -66,6 +66,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-sync-team-crosswalk.yml
   - type: workflow
+    path: workflows/worldcup-sync-player-crosswalk.yml
+  - type: workflow
     path: workflows/worldcup-compare-market-sources.yml
   - type: workflow
     path: workflows/worldcup-find-market-edges.yml

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -22,6 +22,7 @@ normalize_schedule = _module.normalize_schedule
 normalize_identity_crosswalk = _module.normalize_identity_crosswalk
 mint_event_identity = _module.mint_event_identity
 merge_provider_entities = _module.merge_provider_entities
+build_player_crosswalk = _module.build_player_crosswalk
 
 
 def _kalshi_record(**overrides):
@@ -926,3 +927,36 @@ class TestIso3AccentNormalization:
         assert r["count"] == 2
         assert by_name["Cape Verde Islands"]["provider_ids"] == {"api_football": "1533", "opta": "opta-cpv"}
         assert by_name["Ivory Coast"]["provider_ids"] == {"api_football": "1501", "opta": "opta-civ"}
+
+
+# -- Player crosswalk (api-football canonical, others enrich by team+name) ----
+
+
+class TestBuildPlayerCrosswalk:
+    def _teams(self):
+        return [{"_id": "urn:machina:sport:soccer:team:spain:esp", "name": "Spain", "country": "Spain",
+                 "provider_ids": {"api_football": "9", "opta": "o-esp"}}]
+
+    def test_af_canonical_plus_opta_enrich(self):
+        af = [{"response": [{"team": {"id": 9}, "players": [
+            {"id": 386828, "name": "Lamine Yamal", "position": "Attacker"}]}]}]
+        opta = {"squad": [{"contestantId": "o-esp", "person": [
+            {"id": "o-yamal", "firstName": "Lamine", "lastName": "Yamal", "type": "player"}]}]}
+        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af, "opta_squads": opta}})["data"]
+        d = r["normalized_items"][0]
+        assert r["count"] == 1
+        assert d["_id"] == "urn:machina:sport:soccer:player:lamine-yamal:00000000:esp"
+        assert d["provider_ids"] == {"api_football": "386828", "opta": "o-yamal"}
+        assert d["team"]["@id"] == "urn:machina:sport:soccer:team:spain:esp"
+        assert "sport:Player" in d["@type"]
+
+    def test_unmatched_opta_name_leaves_af_only(self):
+        af = [{"response": [{"team": {"id": 9}, "players": [{"id": "44", "name": "Rodri"}]}]}]
+        opta = {"squad": [{"contestantId": "o-esp", "person": [
+            {"id": "o-r", "firstName": "Rodrigo", "lastName": "Hernandez", "type": "player"}]}]}
+        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af, "opta_squads": opta}})["data"]
+        assert r["normalized_items"][0]["provider_ids"] == {"api_football": "44"}
+
+    def test_empty_warns(self):
+        r = build_player_crosswalk({"params": {}})["data"]
+        assert r["count"] == 0 and r["warnings"]

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -1,0 +1,107 @@
+workflow:
+  name: worldcup-sync-player-crosswalk
+  title: World Cup Intelligence - Sync Player Identity Crosswalk
+  description: |
+    Build the squad-player identity crosswalk: urn:machina:sport:soccer:player URNs with
+    provider_ids from api-football + Opta, linked to the team URN. api-football squads are
+    the source; Opta ids attach by team + lastname + first-initial. Saves
+    worldcup:identity-crosswalk player docs.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+    opta:
+      outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
+      secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
+  inputs:
+    opta_wc_tmcl: "$.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')"
+  outputs:
+    saved_count: "len($.get('normalized_items', []))"
+    provider_summary: "$.get('provider_summary', {})"
+    workflow-status: "len($.get('normalized_items', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-teams
+      description: Load the team crosswalk for team-id maps + canonical team URNs.
+      config:
+        action: search
+        search-limit: 100
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: {"$regex": "^urn:machina:sport:soccer:team:"}
+      outputs:
+        teams: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: fetch-af-squads
+      description: api-football squad per team (one call per team via foreach).
+      condition: "len($.get('teams', [])) > 0"
+      continue_on_error: true
+      connector:
+        name: api-football
+        command: get-players/squads
+      foreach:
+        concurrent: false
+        name: team_item
+        expr: $
+        value: "$.get('teams', [])"
+      inputs:
+        team: "$.get('team_item', {}).get('provider_ids', {}).get('api_football')"
+      outputs:
+        af_squads: "[$]"
+
+    - type: connector
+      name: opta-auth
+      description: Get an Opta OAuth access token.
+      continue_on_error: true
+      connector:
+        name: opta
+        command: authorization
+      outputs:
+        opta_token: "$.get('access_token')"
+
+    - type: connector
+      name: fetch-opta-squads
+      description: Opta squads for the World Cup tournament (players per team).
+      condition: "$.get('opta_token') is not None"
+      continue_on_error: true
+      connector:
+        name: opta
+        command: invoke_request
+      inputs:
+        access_token: "$.get('opta_token')"
+        endpoint: "'squads'"
+        query_params: "{'tmcl': $.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo'), 'detailed': 'yes'}"
+      outputs:
+        opta_squads: "$"
+
+    - type: connector
+      name: build-players
+      description: Build player crosswalk docs (api-football source; Opta ids by team + name).
+      connector:
+        name: worldcup-market-intelligence
+        command: build_player_crosswalk
+      inputs:
+        teams: "$.get('teams', [])"
+        af_squads: "$.get('af_squads', [])"
+        opta_squads: "$.get('opta_squads', {})"
+      outputs:
+        normalized_items: "$.get('normalized_items', [])"
+        provider_summary: "$.get('provider_summary', {})"
+
+    - type: document
+      name: save-players
+      description: Save the player identity crosswalk to same-pod document state.
+      condition: "len($.get('normalized_items', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:identity-crosswalk'"
+      documents:
+        items: "$.get('normalized_items', [])"
+      inputs:
+        normalized_items: "$.get('normalized_items', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1855,3 +1855,126 @@ def merge_provider_entities(request_data: dict[str, Any]) -> dict[str, Any]:
         "status": True,
         "data": {"items": items, "count": len(items), "provider_summary": summary, "warnings": warnings},
     }
+
+
+def _name_tokens(name: Any) -> tuple[str, str]:
+    """(lastname_slug, first_initial) from a free-form player name."""
+    toks = [t for t in _slugify(name).split("-") if t]
+    if not toks:
+        return ("", "")
+    return (toks[-1], toks[0][:1])
+
+
+def _team_maps(teams: list[Any]) -> tuple[dict, dict]:
+    """Build api_football_id -> teaminfo and opta_id -> teaminfo from team-crosswalk docs."""
+    by_af: dict[str, dict[str, Any]] = {}
+    by_opta: dict[str, dict[str, Any]] = {}
+    for t in teams:
+        if not isinstance(t, dict):
+            continue
+        pids = t.get("provider_ids") or {}
+        info = {
+            "urn": _first(t, "_id", "@id", "id"),
+            "name": _text(t.get("name")),
+            "iso3": _to_iso3(t.get("country") or t.get("name")),
+        }
+        if pids.get("api_football"):
+            by_af[_text(pids["api_football"])] = info
+        if pids.get("opta"):
+            by_opta[_text(pids["opta"])] = info
+    return by_af, by_opta
+
+
+def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Build WC squad-player crosswalk docs (api-football is the source; other providers add ids).
+
+    Params:
+      - teams: team-crosswalk docs (for team-id -> team URN/iso3 maps)
+      - af_squads: list of api-football /players/squads responses (canonical player set)
+      - opta_squads: opta squads response (enrich opta ids by team + lastname + first-initial)
+    """
+    params = _params(request_data)
+    by_af, by_opta = _team_maps(_as_list(params.get("teams")))
+    canon: dict[tuple, dict[str, Any]] = {}
+    order: list[tuple] = []
+    summary = {"api_football": 0, "opta": 0}
+
+    raw_squads = params.get("af_squads")
+    if isinstance(raw_squads, dict):
+        raw_squads = [raw_squads]
+    flat_squads: list[Any] = []
+    for r in raw_squads or []:
+        flat_squads.extend(r) if isinstance(r, list) else flat_squads.append(r)
+    for resp in flat_squads:
+        data = _unwrap(resp)
+        response = data.get("response", []) if isinstance(data, dict) else []
+        for entry in response if isinstance(response, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            tinfo = by_af.get(_text((entry.get("team") or {}).get("id")))
+            if not tinfo:
+                continue
+            for p in entry.get("players", []) or []:
+                if not isinstance(p, dict):
+                    continue
+                name = _text(p.get("name"))
+                pid = _text(p.get("id"))
+                if not name or not pid:
+                    continue
+                last, fi = _name_tokens(name)
+                key = (tinfo["iso3"], last, fi)
+                if key not in canon:
+                    canon[key] = {"name": name, "team": tinfo,
+                                  "position": _text(p.get("position")), "provider_ids": {}}
+                    order.append(key)
+                canon[key]["provider_ids"]["api_football"] = pid
+                summary["api_football"] += 1
+
+    opta = _unwrap(params.get("opta_squads"))
+    for sq in (opta.get("squad", []) if isinstance(opta, dict) else []):
+        if not isinstance(sq, dict):
+            continue
+        tinfo = by_opta.get(_text(sq.get("contestantId")))
+        if not tinfo:
+            continue
+        for person in sq.get("person", []) or []:
+            if not isinstance(person, dict) or _lower(person.get("type")) not in ("player", ""):
+                continue
+            last = _slugify(person.get("lastName"))
+            fi = _slugify(person.get("firstName"))[:1]
+            key = (tinfo["iso3"], last, fi)
+            if key in canon and _text(person.get("id")):
+                canon[key]["provider_ids"]["opta"] = _text(person.get("id"))
+                summary["opta"] += 1
+
+    items: list[dict[str, Any]] = []
+    for k in order:
+        c = canon[k]
+        slug = _slugify(c["name"])
+        urn = f"urn:machina:sport:soccer:player:{slug}:{_parse_birth_date(None)}:{c['team']['iso3']}"
+        items.append({
+            "metadata": {"entity_urn": urn},
+            "@context": {
+                "sport": "https://www.sportschema.org/ontologies/sport#",
+                "schema": "https://schema.org/",
+                "machina": "https://schema.machina.gg/sports#",
+            },
+            "@id": urn,
+            "id": urn,
+            "_id": urn,
+            "@type": ["sport:IdentityCrosswalk", "sport:Player"],
+            "name": c["name"],
+            "position": c["position"] or None,
+            "team": {"@id": c["team"]["urn"], "name": c["team"]["name"]},
+            "provider_ids": c["provider_ids"],
+            "machina_competition_slug": "world-cup-2026",
+            "raw_provider": "api-football",
+            "mapping_status": {"verified_ids_only": True},
+        })
+
+    warnings = [] if items else ["No api-football squad players supplied."]
+    return {
+        "status": True,
+        "data": {"normalized_items": items, "count": len(items),
+                 "provider_summary": summary, "warnings": warnings},
+    }

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -38,3 +38,5 @@ connector:
       value: "mint_event_identity"
     - name: "Merge provider entities"
       value: "merge_provider_entities"
+    - name: "Build player crosswalk"
+      value: "build_player_crosswalk"


### PR DESCRIPTION
api-football squads = canonical player set (player URNs + api_football ids + team link); Opta person ids attach by (team, lastname, first-initial). New worldcup-sync-player-crosswalk workflow. 84 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)