### PR TITLE
fix(world-cup): player crosswalk foreach output binding

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -52,7 +52,7 @@ workflow:
       inputs:
         team: "$.get('team_item', {}).get('provider_ids', {}).get('api_football')"
       outputs:
-        af_squads: "[$]"
+        af_squads: "[{'response': $.get('response', [])}]"
 
     - type: connector
       name: fetch-af-players
@@ -72,7 +72,7 @@ workflow:
         season: "$.get('season', '2026')"
         page: "$.get('player_page', {}).get('page')"
       outputs:
-        af_players: "[$]"
+        af_players: "[{'response': $.get('response', [])}]"
 
     - type: connector
       name: fetch-espn-rosters


### PR DESCRIPTION
## Problem
`worldcup-sync-player-crosswalk` ran but produced **0 items** (`provider_summary` all zeros, workflow self-skipped). Root cause: the `fetch-af-squads` / `fetch-af-players` foreach tasks emitted `af_squads: "[$]"`. In a foreach output context, bare `$` does **not** bind to the connector body dict — it serialized to garbage strings (probe: 2 teams → 40 string entries), so `build_player_crosswalk` received empty `af_squads`/`af_players`.

## Fix
Emit an explicit dict using `$.get()` accessors, matching the working foreach pattern in `worldcup-refresh-prematch-enrichment.yml`:
`af_squads: "[{'response': $.get('response', [])}]"` (same for `af_players`).

## Verified via probes
- single squads call → 26 players, `results: 1` ✓
- foreach with `[$]` → `af_squads` = 40 strings (bug reproduced) ✗
- foreach with `[{'response': $.get('response', [])}]` → `af_squads_len: 2`, dicts, `team_id: 5530` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)