### PR TITLE
feat(world-cup): per-id player DOB + full names

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -976,3 +976,19 @@ class TestBuildPlayerCrosswalk:
         assert d["birth_date"] == "2007-07-13"
         assert d["provider_ids"] == {"api_football": "386828", "espn": "espn-yamal"}
         assert r["provider_summary"]["with_dob"] == 1
+
+    def test_players_full_name_overrides_abbreviated_squad_name(self):
+        teams = [{"_id": "urn:machina:sport:soccer:team:uruguay:ury", "name": "Uruguay", "country": "Uruguay",
+                  "provider_ids": {"api_football": "7"}}]
+        # Squad name is abbreviated; /players carries the full name.
+        af_squads = [{"response": [{"team": {"id": 7}, "players": [
+            {"id": "429", "name": "F. Muslera", "position": "Goalkeeper"}]}]}]
+        af_players = [{"response": [{"player": {
+            "id": 429, "firstname": "Fernando", "lastname": "Muslera",
+            "name": "Fernando Muslera", "birth": {"date": "1986-06-16"}, "nationality": "Uruguay"}}]}]
+        r = build_player_crosswalk({"params": {"teams": teams, "af_squads": af_squads,
+                                               "af_players": af_players}})["data"]
+        d = r["normalized_items"][0]
+        assert d["_id"] == "urn:machina:sport:soccer:player:fernando-muslera:19860616:ury"
+        assert d["name"] == "Fernando Muslera"
+        assert d["birth_date"] == "1986-06-16"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -56,21 +56,20 @@ workflow:
 
     - type: connector
       name: fetch-af-players
-      description: api-football /players (birth date + nationality), team x pages 1-2 via foreach.
-      condition: "len($.get('teams', [])) > 0"
+      description: api-football /players by player id (full name + birth date + nationality) for every squad player. /players?team requires recorded season stats, which most national teams lack pre-tournament; per-id resolves DOB reliably.
+      condition: "len($.get('af_squads', [])) > 0"
       continue_on_error: true
       connector:
         name: api-football
         command: get-players
       foreach:
         concurrent: false
-        name: player_page
+        name: af_player_item
         expr: $
-        value: "[{'team': t.get('provider_ids', {}).get('api_football'), 'page': p} for t in $.get('teams', []) if t.get('provider_ids', {}).get('api_football') for p in [1, 2]]"
+        value: "[{'id': p.get('id')} for resp in $.get('af_squads', []) if isinstance(resp, dict) for entry in (resp.get('response', []) or []) for p in (entry.get('players', []) or []) if p.get('id')]"
       inputs:
-        team: "$.get('player_page', {}).get('team')"
+        id: "$.get('af_player_item', {}).get('id')"
         season: "$.get('season', '2026')"
-        page: "$.get('player_page', {}).get('page')"
       outputs:
         af_players: "[{'response': $.get('response', [])}]"
 

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1934,7 +1934,7 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
                 canon[key]["provider_ids"]["api_football"] = pid
                 summary["api_football"] += 1
 
-    # Birth date + nationality from api-football /players, joined by player id.
+    # Birth date + nationality + full name from api-football /players, joined by id.
     dob_by_id: dict[str, dict[str, Any]] = {}
     for resp in _flatten_foreach(params.get("af_players")):
         data = _unwrap(resp)
@@ -1942,9 +1942,11 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             player = entry.get("player") if isinstance(entry, dict) else None
             if not isinstance(player, dict) or not player.get("id"):
                 continue
+            first, last = _text(player.get("firstname")), _text(player.get("lastname"))
             dob_by_id[_text(player["id"])] = {
                 "dob": _text((player.get("birth") or {}).get("date")),
                 "nationality": _text(player.get("nationality")),
+                "name": _text(player.get("name")) or (first + " " + last).strip(),
             }
 
     # Opta ids by team + lastname + first-initial.
@@ -1985,7 +1987,9 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
         dob8 = _parse_birth_date(meta.get("dob"))
         if dob8 != "00000000":
             summary["with_dob"] += 1
-        urn = f"urn:machina:sport:soccer:player:{_slugify(c['name'])}:{dob8}:{c['team']['iso3']}"
+        # Prefer the /players full name over the (sometimes abbreviated) squad name.
+        display_name = meta.get("name") or c["name"]
+        urn = f"urn:machina:sport:soccer:player:{_slugify(display_name)}:{dob8}:{c['team']['iso3']}"
         items.append({
             "metadata": {"entity_urn": urn},
             "@context": {
@@ -1997,7 +2001,7 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             "id": urn,
             "_id": urn,
             "@type": ["sport:IdentityCrosswalk", "sport:Player"],
-            "name": c["name"],
+            "name": display_name,
             "position": c["position"] or None,
             "birth_date": meta.get("dob") or None,
             "nationality": meta.get("nationality") or None,


### PR DESCRIPTION
## Why
The first DOB pass used `/players?team&season`, which only returns players who have **recorded stats for that national team in the season**. Pre-tournament, most teams have none — Uruguay and Cape Verde came back with **0 DOB** (full squads), and 41 teams had gaps (325 players on `00000000` placeholder URNs → duplicates vs the existing full-name docs).

## Fix
- `fetch-af-players` now looks up **`/players?id={squad_player_id}&season=2026`** for every squad player (exact-id join; season is required by the API but the per-id call resolves the player profile + DOB reliably). Probe on Uruguay+France: `with_dob 46/52` vs 0 before.
- `build_player_crosswalk` prefers the **`/players` full name** (`firstname`+`lastname`/`name`) over the sometimes-abbreviated squad name (`F. Muslera` → `fernando-muslera`) for the display name and URN slug. Better URNs, and they align with the existing full-name player docs so a re-run overwrites instead of duplicating.

## Test
- `pytest agent-templates/world-cup-intelligence/tests/ -q` → 83 passed (adds `test_players_full_name_overrides_abbreviated_squad_name`).
- `check-no-openai.sh` → clean.

## Deploy note
Connector `.py` changed → needs worker restart + `/mcp` reconnect after import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)