### PR TITLE
fix(world-cup): slim per-id /players payload (OOM fix)

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -71,7 +71,10 @@ workflow:
         id: "$.get('af_player_item', {}).get('id')"
         season: "$.get('season', '2026')"
       outputs:
-        af_players: "[{'response': $.get('response', [])}]"
+        # Keep only identity fields — the full /players body carries large
+        # per-competition statistics arrays that OOM the sync when held in
+        # state for every squad player.
+        af_players: "[{'response': [{'player': {'id': (p.get('player') or {}).get('id'), 'name': (p.get('player') or {}).get('name'), 'firstname': (p.get('player') or {}).get('firstname'), 'lastname': (p.get('player') or {}).get('lastname'), 'birth': {'date': ((p.get('player') or {}).get('birth') or {}).get('date')}, 'nationality': (p.get('player') or {}).get('nationality')}} for p in ($.get('response', []) or [])]}]"
 
     - type: connector
       name: fetch-espn-rosters


### PR DESCRIPTION
Holding the full /players body (large per-competition `statistics` arrays) for all ~1244 squad players OOM-killed the sync's client-api container (exit 137). Project the foreach output to only the identity fields build needs. No connector/spec change → import only, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)