### PR TITLE
feat(world-cup): carry forward entain/transfermarkt player ids

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -992,3 +992,21 @@ class TestBuildPlayerCrosswalk:
         assert d["_id"] == "urn:machina:sport:soccer:player:fernando-muslera:19860616:ury"
         assert d["name"] == "Fernando Muslera"
         assert d["birth_date"] == "1986-06-16"
+
+    def test_carry_forward_entain_transfermarkt_by_af_id(self):
+        teams = [{"_id": "urn:machina:sport:soccer:team:argentina:arg", "name": "Argentina", "country": "Argentina",
+                  "provider_ids": {"api_football": "26"}}]
+        af_squads = [{"response": [{"team": {"id": 26}, "players": [
+            {"id": "154", "name": "L. Messi", "position": "Attacker"}]}]}]
+        af_players = [{"response": [{"player": {
+            "id": 154, "firstname": "Lionel", "lastname": "Messi", "name": "Lionel Messi",
+            "birth": {"date": "1987-06-24"}, "nationality": "Argentina"}}]}]
+        # Legacy doc uses the *_player_id key style; ids must be inherited + renamed.
+        existing = [{"provider_ids": {"api_football_player_id": "154",
+                                      "entain_player_id": "223306",
+                                      "transfermarkt_player_id": "28003"}}]
+        r = build_player_crosswalk({"params": {"teams": teams, "af_squads": af_squads,
+                                               "af_players": af_players, "existing_players": existing}})["data"]
+        d = r["normalized_items"][0]
+        assert d["_id"] == "urn:machina:sport:soccer:player:lionel-messi:19870624:arg"
+        assert d["provider_ids"] == {"api_football": "154", "entain": "223306", "transfermarkt": "28003"}

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -36,6 +36,19 @@ workflow:
       outputs:
         teams: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
 
+    - type: document
+      name: load-existing-players
+      description: Load existing player docs (provider_ids only) so non-api-football ids (entain, transfermarkt) carry forward across re-syncs.
+      config:
+        action: search
+        search-limit: 5000
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: {"$regex": "^urn:machina:sport:soccer:player:"}
+      outputs:
+        existing_players: "[{'provider_ids': d.get('value', {}).get('provider_ids', {})} for d in ($.get('documents', []) or [])]"
+
     - type: connector
       name: fetch-af-squads
       description: api-football squad per team (one call per team via foreach).
@@ -133,6 +146,7 @@ workflow:
         af_players: "$.get('af_players', [])"
         opta_squads: "$.get('opta_squads', {})"
         espn_rosters: "$.get('espn_rosters', [])"
+        existing_players: "$.get('existing_players', [])"
       outputs:
         normalized_items: "$.get('normalized_items', [])"
         provider_summary: "$.get('provider_summary', {})"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1902,6 +1902,8 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
       - af_players: list of api-football /players responses (birth date + nationality, joined by id)
       - opta_squads: opta squads response (opta ids by team + lastname + first-initial)
       - espn_rosters: list of sports-skills get_team_profile responses (espn ids, same match)
+      - existing_players: existing crosswalk player docs; provider ids not produced here
+        (entain, transfermarkt) are carried forward by api-football id across re-syncs
     """
     params = _params(request_data)
     maps = _team_maps(_as_list(params.get("teams")))
@@ -1980,9 +1982,33 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
                 canon[key]["provider_ids"]["espn"] = _text(p.get("id"))
                 summary["espn"] += 1
 
+    # Carry forward provider ids this build does not itself produce (e.g. entain,
+    # transfermarkt) from existing crosswalk docs, joined by api-football id, so a
+    # force-update re-sync preserves them instead of dropping them.
+    produced = {"api_football", "opta", "espn"}
+    key_alias = {"api_football_player_id": "api_football",
+                 "entain_player_id": "entain",
+                 "transfermarkt_player_id": "transfermarkt"}
+    carry: dict[str, dict[str, str]] = {}
+    for doc in _flatten_foreach(params.get("existing_players")):
+        d = _unwrap(doc)
+        pids = d.get("provider_ids") if isinstance(d, dict) else None
+        if not isinstance(pids, dict):
+            continue
+        af = _text(pids.get("api_football") or pids.get("api_football_player_id"))
+        if not af:
+            continue
+        for k, v in pids.items():
+            nk = key_alias.get(k, k)
+            if nk not in produced and _text(v):
+                carry.setdefault(af, {})[nk] = _text(v)
+
     items: list[dict[str, Any]] = []
     for k in order:
         c = canon[k]
+        af_id = c["provider_ids"].get("api_football", "")
+        for nk, v in carry.get(af_id, {}).items():
+            c["provider_ids"].setdefault(nk, v)
         meta = dob_by_id.get(c["provider_ids"].get("api_football", ""), {})
         dob8 = _parse_birth_date(meta.get("dob"))
         if dob8 != "00000000":


### PR DESCRIPTION
## Why
The pod has 1246 pre-existing "multi-provider" player docs carrying `entain_player_id` + `transfermarkt_player_id`. The player sync saves with `force-update` (whole-doc replace), so a naive re-sync drops any provider id it doesn't itself produce. To **merge then delete** those docs durably (not a one-shot that the next sync wipes), the build must re-derive those ids each run.

## What
- `build_player_crosswalk` accepts `existing_players` (existing crosswalk docs, provider_ids only) and **carries forward** any provider id it doesn't produce (entain, transfermarkt), joined by **api-football id**, renaming legacy `*_player_id` keys to the clean team-crosswalk style (`entain`, `transfermarkt`).
- Workflow: new `load-existing-players` task (projects provider_ids only — light) feeds `existing_players` into build.

After this runs, the canonical 1244 docs hold `api_football + opta + espn + entain + transfermarkt`, and the old multi-provider set can be deleted. Subsequent syncs keep inheriting the ids from the prior generation, so they persist.

## Test
- `pytest …/tests -q` → 84 passed (adds `test_carry_forward_entain_transfermarkt_by_af_id`).
- `check-no-openai.sh` → clean.

## Deploy note
Connector `.py` changed → worker restart + `/mcp` reconnect after import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)