### PR TITLE
feat(world-cup): real DOB via /players/profiles, no placeholders

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -940,26 +940,37 @@ class TestBuildPlayerCrosswalk:
     def test_af_canonical_plus_opta_enrich(self):
         af = [{"response": [{"team": {"id": 9}, "players": [
             {"id": 386828, "name": "Lamine Yamal", "position": "Attacker"}]}]}]
+        afp = [{"response": [{"player": {"id": 386828, "name": "Lamine Yamal",
+                                          "birth": {"date": "2007-07-13"}}}]}]
         opta = {"squad": [{"contestantId": "o-esp", "person": [
             {"id": "o-yamal", "firstName": "Lamine", "lastName": "Yamal", "type": "player"}]}]}
-        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af, "opta_squads": opta}})["data"]
+        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af,
+                                               "af_players": afp, "opta_squads": opta}})["data"]
         d = r["normalized_items"][0]
         assert r["count"] == 1
-        assert d["_id"] == "urn:machina:sport:soccer:player:lamine-yamal:00000000:esp"
+        assert d["_id"] == "urn:machina:sport:soccer:player:lamine-yamal:20070713:esp"
         assert d["provider_ids"] == {"api_football": "386828", "opta": "o-yamal"}
         assert d["team"]["@id"] == "urn:machina:sport:soccer:team:spain:esp"
         assert "sport:Player" in d["@type"]
 
     def test_unmatched_opta_name_leaves_af_only(self):
         af = [{"response": [{"team": {"id": 9}, "players": [{"id": "44", "name": "Rodri"}]}]}]
+        afp = [{"response": [{"player": {"id": 44, "name": "Rodri", "birth": {"date": "1996-06-22"}}}]}]
         opta = {"squad": [{"contestantId": "o-esp", "person": [
             {"id": "o-r", "firstName": "Rodrigo", "lastName": "Hernandez", "type": "player"}]}]}
-        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af, "opta_squads": opta}})["data"]
+        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af,
+                                               "af_players": afp, "opta_squads": opta}})["data"]
         assert r["normalized_items"][0]["provider_ids"] == {"api_football": "44"}
 
     def test_empty_warns(self):
         r = build_player_crosswalk({"params": {}})["data"]
         assert r["count"] == 0 and r["warnings"]
+
+    def test_player_without_dob_is_excluded(self):
+        af = [{"response": [{"team": {"id": 9}, "players": [{"id": "44", "name": "Rodri"}]}]}]
+        r = build_player_crosswalk({"params": {"teams": self._teams(), "af_squads": af}})["data"]
+        assert r["count"] == 0
+        assert r["provider_summary"]["excluded_no_dob"] == 1
 
     def test_dob_from_af_players_plus_espn_id(self):
         teams = [{"_id": "urn:machina:sport:soccer:team:spain:esp", "name": "Spain", "country": "Spain",

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -69,20 +69,19 @@ workflow:
 
     - type: connector
       name: fetch-af-players
-      description: api-football /players by player id (full name + birth date + nationality) for every squad player. /players?team requires recorded season stats, which most national teams lack pre-tournament; per-id resolves DOB reliably.
+      description: api-football /players/profiles by player id (season-independent full name + birth date + nationality) for every squad player. /players?team requires recorded season stats which national teams lack pre-tournament; the profile endpoint resolves DOB for everyone.
       condition: "len($.get('af_squads', [])) > 0"
       continue_on_error: true
       connector:
         name: api-football
-        command: get-players
+        command: get-players/profiles
       foreach:
         concurrent: false
         name: af_player_item
         expr: $
         value: "[{'id': p.get('id')} for resp in $.get('af_squads', []) if isinstance(resp, dict) for entry in (resp.get('response', []) or []) for p in (entry.get('players', []) or []) if p.get('id')]"
       inputs:
-        id: "$.get('af_player_item', {}).get('id')"
-        season: "$.get('season', '2026')"
+        player: "$.get('af_player_item', {}).get('id')"
       outputs:
         # Keep only identity fields — the full /players body carries large
         # per-competition statistics arrays that OOM the sync when held in

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1910,7 +1910,7 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
     by_af, by_opta, by_espn = maps["api_football"], maps["opta"], maps["espn"]
     canon: dict[tuple, dict[str, Any]] = {}
     order: list[tuple] = []
-    summary = {"api_football": 0, "opta": 0, "espn": 0, "with_dob": 0}
+    summary = {"api_football": 0, "opta": 0, "espn": 0, "with_dob": 0, "excluded_no_dob": 0}
 
     # Canonical set + team link from api-football squads.
     for resp in _flatten_foreach(params.get("af_squads")):
@@ -2011,8 +2011,12 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             c["provider_ids"].setdefault(nk, v)
         meta = dob_by_id.get(c["provider_ids"].get("api_football", ""), {})
         dob8 = _parse_birth_date(meta.get("dob"))
-        if dob8 != "00000000":
-            summary["with_dob"] += 1
+        # A player URN's disambiguator is the birth date — without one the URN is
+        # ambiguous, so skip the player rather than mint a 00000000 placeholder.
+        if dob8 == "00000000":
+            summary["excluded_no_dob"] += 1
+            continue
+        summary["with_dob"] += 1
         # Prefer the /players full name over the (sometimes abbreviated) squad name.
         display_name = meta.get("name") or c["name"]
         urn = f"urn:machina:sport:soccer:player:{_slugify(display_name)}:{dob8}:{c['team']['iso3']}"

--- a/connectors/api-football/api-football.json
+++ b/connectors/api-football/api-football.json
@@ -2686,6 +2686,53 @@
     }
    }
   },
+  "/players/profiles": {
+   "get": {
+    "summary": "Get player profiles",
+    "description": "Season-independent player profile (incl. birth date + nationality + full name) by player id or search. Paginated.",
+    "operationId": "get-players/profiles",
+    "security": [
+     {
+      "x-apisports-key": []
+     }
+    ],
+    "parameters": [
+     {
+      "name": "player",
+      "in": "query",
+      "schema": {
+       "type": "integer"
+      }
+     },
+     {
+      "name": "search",
+      "in": "query",
+      "schema": {
+       "type": "string"
+      }
+     },
+     {
+      "name": "page",
+      "in": "query",
+      "schema": {
+       "type": "integer"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Successful response",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ApiResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
   "/teams": {
    "get": {
     "summary": "Get teams",


### PR DESCRIPTION
Player URNs use birth date as the disambiguator, so 00000000 placeholders are garbage. Switch DOB lookup to the season-independent `/players/profiles` endpoint (resolves DOB for players lacking current-season stats) and **exclude** any player still without a real DOB instead of placeholdering. Adds `/players/profiles` to the api-football spec. 85 tests pass; lint clean. Connector .py + spec changed → restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)