### PR TITLE
fix(world-cup): pick fullest player name

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1021,3 +1021,16 @@ class TestBuildPlayerCrosswalk:
         d = r["normalized_items"][0]
         assert d["_id"] == "urn:machina:sport:soccer:player:lionel-messi:19870624:arg"
         assert d["provider_ids"] == {"api_football": "154", "entain": "223306", "transfermarkt": "28003"}
+
+    def test_profiles_abbreviated_name_falls_back_to_firstlast(self):
+        teams = [{"_id": "urn:machina:sport:soccer:team:uruguay:ury", "name": "Uruguay", "country": "Uruguay",
+                  "provider_ids": {"api_football": "7"}}]
+        af = [{"response": [{"team": {"id": 7}, "players": [{"id": "5995", "name": "N. de la Cruz"}]}]}]
+        # /players/profiles abbreviates `name` but carries full firstname/lastname.
+        afp = [{"response": [{"player": {"id": 5995, "name": "N. de la Cruz",
+                                          "firstname": "Diego Nicolás", "lastname": "de la Cruz Arcosa",
+                                          "birth": {"date": "1997-06-01"}}}]}]
+        r = build_player_crosswalk({"params": {"teams": teams, "af_squads": af, "af_players": afp}})["data"]
+        d = r["normalized_items"][0]
+        assert d["name"] == "Diego Nicolás de la Cruz Arcosa"
+        assert d["_id"] == "urn:machina:sport:soccer:player:diego-nicolas-de-la-cruz-arcosa:19970601:ury"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1865,6 +1865,12 @@ def _name_tokens(name: Any) -> tuple[str, str]:
     return (toks[-1], toks[0][:1])
 
 
+def _is_full_name(name: Any) -> bool:
+    """True if name reads as a full name, not an initial form like 'N. de la Cruz'."""
+    parts = _text(name).split()
+    return len(parts) >= 2 and "." not in parts[0] and len(parts[0]) > 1
+
+
 def _team_maps(teams: list[Any]) -> dict[str, dict]:
     """provider key -> {provider_id: teaminfo} from team-crosswalk docs."""
     maps: dict[str, dict] = {"api_football": {}, "opta": {}, "espn": {}}
@@ -1948,7 +1954,8 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             dob_by_id[_text(player["id"])] = {
                 "dob": _text((player.get("birth") or {}).get("date")),
                 "nationality": _text(player.get("nationality")),
-                "name": _text(player.get("name")) or (first + " " + last).strip(),
+                "name": _text(player.get("name")),
+                "full": (first + " " + last).strip(),
             }
 
     # Opta ids by team + lastname + first-initial.
@@ -2017,8 +2024,12 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             summary["excluded_no_dob"] += 1
             continue
         summary["with_dob"] += 1
-        # Prefer the /players full name over the (sometimes abbreviated) squad name.
-        display_name = meta.get("name") or c["name"]
+        # Pick the fullest available name: a non-abbreviated squad/profile name,
+        # else firstname+lastname (profiles abbreviates the `name` field).
+        display_name = next(
+            (n for n in (c["name"], meta.get("name")) if _is_full_name(n)),
+            meta.get("full") or meta.get("name") or c["name"],
+        )
         urn = f"urn:machina:sport:soccer:player:{_slugify(display_name)}:{dob8}:{c['team']['iso3']}"
         items.append({
             "metadata": {"entity_urn": urn},


### PR DESCRIPTION
/players/profiles abbreviates the `name` field ('N. de la Cruz') but carries full firstname/lastname. Select the fullest available name (non-abbreviated squad/profile name, else firstname+lastname) for the slug + display. 86 tests pass. Connector .py changed → restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)