### PR TITLE
feat(world-cup): event identity crosswalk (sportradar + entain)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -68,6 +68,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-sync-player-crosswalk.yml
   - type: workflow
+    path: workflows/worldcup-sync-event-crosswalk.yml
+  - type: workflow
     path: workflows/worldcup-compare-market-sources.yml
   - type: workflow
     path: workflows/worldcup-find-market-edges.yml

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -23,6 +23,7 @@ normalize_identity_crosswalk = _module.normalize_identity_crosswalk
 mint_event_identity = _module.mint_event_identity
 merge_provider_entities = _module.merge_provider_entities
 build_player_crosswalk = _module.build_player_crosswalk
+build_event_crosswalk = _module.build_event_crosswalk
 
 
 def _kalshi_record(**overrides):
@@ -1034,3 +1035,46 @@ class TestBuildPlayerCrosswalk:
         d = r["normalized_items"][0]
         assert d["name"] == "Diego Nicolás de la Cruz Arcosa"
         assert d["_id"] == "urn:machina:sport:soccer:player:diego-nicolas-de-la-cruz-arcosa:19970601:ury"
+
+
+class TestBuildEventCrosswalk:
+    def _teams(self):
+        return [
+            {"_id": "urn:machina:sport:soccer:team:mexico:mex", "name": "Mexico",
+             "provider_ids": {"sportradar": "sr:competitor:4781", "entain": "234216"}},
+            {"_id": "urn:machina:sport:soccer:team:south-africa:zaf", "name": "South Africa",
+             "provider_ids": {"sportradar": "sr:competitor:4736", "entain": "201277"}},
+        ]
+
+    def _events(self):
+        return [{
+            "_id": "urn:machina:sport:soccer:event:mexico-vs-south-africa:20260611:wor",
+            "sport:competitors": [
+                {"@id": "urn:machina:sport:soccer:team:mexico:mex"},
+                {"@id": "urn:machina:sport:soccer:team:south-africa:zaf"},
+            ],
+            "provider_ids": {"api_football_fixture_id": "1489369"},
+        }]
+
+    def test_attaches_sportradar_and_entain_event_ids(self):
+        sr = {"schedules": [{"sport_event": {"id": "sr:sport_event:66456904", "competitors": [
+            {"id": "sr:competitor:4781"}, {"id": "sr:competitor:4736"}]}}]}
+        bwin = {"items": [{"id": {"entityId": 7722030, "full": "2:7722030"},
+                           "participants": [{"id": 201277}, {"id": 234216}]}]}
+        r = build_event_crosswalk({"params": {"teams": self._teams(), "events": self._events(),
+                                              "sportradar_schedule": sr, "entain_fixtures": bwin}})["data"]
+        ev = r["normalized_items"][0]
+        assert ev["provider_ids"]["api_football_fixture_id"] == "1489369"
+        assert ev["provider_ids"]["sportradar_event_id"] == "sr:sport_event:66456904"
+        assert ev["provider_ids"]["entain_event_id"] == "7722030"
+        assert ev["metadata"]["event_urn"] == "urn:machina:sport:soccer:event:mexico-vs-south-africa:20260611:wor"
+        assert r["provider_summary"] == {"events": 1, "sportradar": 1, "entain": 1}
+
+    def test_unmatched_pair_is_left_untouched(self):
+        # sportradar event for a different pair (one unknown competitor) → no attach.
+        sr = {"schedules": [{"sport_event": {"id": "sr:sport_event:999", "competitors": [
+            {"id": "sr:competitor:4781"}, {"id": "sr:competitor:0000"}]}}]}
+        r = build_event_crosswalk({"params": {"teams": self._teams(), "events": self._events(),
+                                              "sportradar_schedule": sr}})["data"]
+        assert "sportradar_event_id" not in r["normalized_items"][0]["provider_ids"]
+        assert r["provider_summary"]["sportradar"] == 0

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml
@@ -1,0 +1,111 @@
+workflow:
+  name: worldcup-sync-event-crosswalk
+  title: World Cup Intelligence - Sync Event Identity Crosswalk
+  description: |
+    Attach sportradar + entain (bwin) event ids to the canonical worldcup:event docs,
+    matched by team pair via the team crosswalk. api-football remains the event source;
+    sportradar/entain contribute provider_ids only (for cross-provider exposure).
+
+  context-variables:
+    debugger:
+      enabled: true
+    sportradar-soccer:
+      api_key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
+    bwin:
+      Bwin-AccessId: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID
+      Bwin-AccessIdToken: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID_TOKEN
+  inputs:
+    sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
+    bwin_country: "$.get('bwin_country', 'gb')"
+    bwin_competition_id: "$.get('bwin_competition_id', '102868')"
+  outputs:
+    saved_count: "len($.get('normalized_items', []))"
+    provider_summary: "$.get('provider_summary', {})"
+    workflow-status: "len($.get('normalized_items', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-teams
+      description: Load the team crosswalk for sportradar/entain provider-id maps.
+      config:
+        action: search
+        search-limit: 100
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: {"$regex": "^urn:machina:sport:soccer:team:"}
+      outputs:
+        teams: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: document
+      name: load-events
+      description: Load the canonical World Cup event docs to enrich with provider ids.
+      config:
+        action: search
+        search-limit: 500
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+      outputs:
+        events: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: fetch-sr-schedule
+      description: Sportradar full season schedule (sport_events for the World Cup season).
+      condition: "len($.get('events', [])) > 0"
+      continue_on_error: true
+      connector:
+        name: sportradar-soccer
+        command: get-seasons/{season_id}/schedules.json
+        command_attribute:
+          season_id: "$.get('sr_season_id', 'sr:season:101177')"
+      inputs:
+        api_key: "$.get('api_key')"
+      outputs:
+        sportradar_schedule: "{'schedules': $.get('schedules', [])}"
+
+    - type: connector
+      name: fetch-bwin-wc
+      description: Entain/bwin fixtures for the World Cup competition (event id + participants).
+      condition: "len($.get('events', [])) > 0"
+      continue_on_error: true
+      connector:
+        name: bwin
+        command: get-offer/api/{sportId}/{country}/fixtures
+        command_attribute:
+          sportId: "'4'"
+          country: "$.get('bwin_country', 'gb')"
+      inputs:
+        language: "'en'"
+        competitionIds: "$.get('bwin_competition_id', '102868')"
+        onlyMainMarkets: "'true'"
+      outputs:
+        entain_fixtures: "{'items': $.get('items', [])}"
+
+    - type: connector
+      name: build-event-crosswalk
+      description: Attach sportradar/entain event ids to events by team pair.
+      connector:
+        name: worldcup-market-intelligence
+        command: build_event_crosswalk
+      inputs:
+        teams: "$.get('teams', [])"
+        events: "$.get('events', [])"
+        sportradar_schedule: "$.get('sportradar_schedule', {})"
+        entain_fixtures: "$.get('entain_fixtures', {})"
+      outputs:
+        normalized_items: "$.get('normalized_items', [])"
+        provider_summary: "$.get('provider_summary', {})"
+
+    - type: document
+      name: save-events
+      description: Save the enriched event docs back to same-pod state.
+      condition: "len($.get('normalized_items', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:event'"
+      documents:
+        items: "$.get('normalized_items', [])"
+      inputs:
+        normalized_items: "$.get('normalized_items', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2059,3 +2059,75 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
         "data": {"normalized_items": items, "count": len(items),
                  "provider_summary": summary, "warnings": warnings},
     }
+
+
+def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Attach sportradar + entain event ids to canonical WC event docs (matched by team pair).
+
+    Params:
+      - events: canonical worldcup:event values (each has sport:competitors[].@id team URNs)
+      - teams: team-crosswalk docs (for sportradar/entain provider-id -> team URN maps)
+      - sportradar_schedule: sportradar /seasons/{id}/schedules.json response(s)
+      - entain_fixtures: bwin fixtures response(s)
+    """
+    params = _params(request_data)
+    by_sr: dict[str, str] = {}
+    by_entain: dict[str, str] = {}
+    for t in _as_list(params.get("teams")):
+        if not isinstance(t, dict):
+            continue
+        pids = t.get("provider_ids") or {}
+        urn = _text(_first(t, "_id", "@id", "id"))
+        if pids.get("sportradar"):
+            by_sr[_text(pids["sportradar"])] = urn
+        if pids.get("entain"):
+            by_entain[_text(pids["entain"])] = urn
+
+    by_pair: dict[frozenset, dict[str, Any]] = {}
+    out: list[dict[str, Any]] = []
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        ev.setdefault("metadata", {"event_urn": _text(_first(ev, "_id", "@id", "id"))})
+        out.append(ev)
+        urns = [_text(c.get("@id")) for c in (ev.get("sport:competitors") or [])
+                if isinstance(c, dict) and c.get("@id")]
+        if len(urns) == 2:
+            by_pair[frozenset(urns)] = ev
+
+    summary = {"events": len(out), "sportradar": 0, "entain": 0}
+
+    for resp in _flatten_foreach(params.get("sportradar_schedule")):
+        data = _unwrap(resp)
+        for item in (data.get("schedules", []) if isinstance(data, dict) else []):
+            se = item.get("sport_event", {}) if isinstance(item, dict) else {}
+            sid = _text(se.get("id"))
+            urns = [by_sr.get(_text(c.get("id"))) for c in (se.get("competitors") or [])]
+            urns = [u for u in urns if u]
+            if not sid or len(urns) != 2:
+                continue
+            ev = by_pair.get(frozenset(urns))
+            if ev is not None and "sportradar_event_id" not in (ev.get("provider_ids") or {}):
+                ev.setdefault("provider_ids", {})["sportradar_event_id"] = sid
+                summary["sportradar"] += 1
+
+    for resp in _flatten_foreach(params.get("entain_fixtures")):
+        data = _unwrap(resp)
+        for fx in (data.get("items", []) if isinstance(data, dict) else []):
+            if not isinstance(fx, dict):
+                continue
+            fid = fx.get("id")
+            eid = _text(fid.get("entityId") if isinstance(fid, dict) else fid)
+            urns = [by_entain.get(_text(p.get("id"))) for p in (fx.get("participants") or [])]
+            urns = [u for u in urns if u]
+            if not eid or len(urns) != 2:
+                continue
+            ev = by_pair.get(frozenset(urns))
+            if ev is not None and "entain_event_id" not in (ev.get("provider_ids") or {}):
+                ev.setdefault("provider_ids", {})["entain_event_id"] = eid
+                summary["entain"] += 1
+
+    return {
+        "status": True,
+        "data": {"normalized_items": out, "count": len(out), "provider_summary": summary},
+    }

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -40,3 +40,5 @@ connector:
       value: "merge_provider_entities"
     - name: "Build player crosswalk"
       value: "build_player_crosswalk"
+    - name: "Build event crosswalk"
+      value: "build_event_crosswalk"


### PR DESCRIPTION
Adds `build_event_crosswalk` + `worldcup-sync-event-crosswalk` — attaches **sportradar** (`sr:sport_event`) and **entain/bwin** (`id.entityId`) event ids to the 72 canonical `worldcup:event` docs, matched by team pair via the team crosswalk's sportradar/entain id maps. api-football stays the source; others add `provider_ids` only, so games become cross-provider like teams. 88 tests pass; lint clean. Connector .py + spec/workflow → restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)