### PR TITLE
refactor(world-cup): uniform provider_ids schema

### DIFF
--- a/agent-templates/world-cup-intelligence/docs/api-contracts.md
+++ b/agent-templates/world-cup-intelligence/docs/api-contracts.md
@@ -13,9 +13,9 @@ Events, teams, and competitions use **canonical machina URNs** minted determinis
 - competition: `urn:machina:sport:soccer:competition:{name-slug}:wor`
 - venue: `urn:machina:sport:soccer:venue:{name-slug}:{iso3}` (omitted when the provider gives no venue)
 
-Every event doc also carries `provider_ids` (`api_football_fixture_id|home_team_id|away_team_id|league_id|venue_id`, plus entain/sportradar/opta/espn ids when mapped). **API-Football is the data source; sports-skills (ESPN/Transfermarkt) is fallback/enrichment; entain/sportradar/opta supply ids only (never their match data).**
+Every doc (event, team, player, competition) carries a uniform `provider_ids` map: **one key per provider, whose value is that provider's id for THIS object** — e.g. an event has `{api_football: <fixture id>, sportradar: <sr:sport_event id>, entain: <fixture id>, opta: <match id>, espn: <event id>}`; a team has `{api_football, espn, opta, sportradar, entain}`; a player has `{api_football, espn, opta, ...}`. No secondary ids (team/league/venue) live in `provider_ids` — those are resolved relationally (event `sport:competitors[].@id` → team crosswalk → that team's `provider_ids.api_football`; league via the competition). **API-Football is the data source; sports-skills (ESPN/Transfermarkt) is fallback/enrichment; entain/sportradar/opta supply ids only (never their match data).**
 
-**Alternate key:** reads accept the canonical `event_urn` OR `provider_event_id` (the API-Football fixture id, e.g. `1489417`) — the latter is the stable, simple handle for clients. Markets are keyed by `{source}:{source_market_id}` (e.g. `polymarket:2415458`).
+**Alternate key:** reads accept the canonical `event_urn` OR `provider_event_id` (the API-Football fixture id, e.g. `1489417`, stored at `provider_ids.api_football`) — the latter is the stable, simple handle for clients. Markets are keyed by `{source}:{source_market_id}` (e.g. `polymarket:2415458`).
 
 Market-to-event entity linking (matching a Kalshi/Polymarket market to a specific fixture) is **planned, not implemented**. Markets are discovered by `query`/`team` text search, not by event id.
 

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -639,7 +639,7 @@ def _event_doc(urn, name, start, status="NS", home="A", away="B", venue="Stadium
             {"name": away, "sport:qualifier": "away", "schema:logo": f"af://{away}.png"},
         ],
         "venue": {"name": venue, "schema:addressLocality": "City"},
-        "provider_ids": {"api_football_fixture_id": fixture},
+        "provider_ids": {"api_football": fixture},
     }
 
 
@@ -696,7 +696,7 @@ class TestNormalizeSchedule:
                 {"name": "Uruguay", "sport:qualifier": "home", "schema:logo": "u.png"},
                 {"name": "Spain", "sport:qualifier": "away", "schema:logo": "s.png"},
             ],
-            "provider_ids": {"api_football_fixture_id": "1489417"},
+            "provider_ids": {"api_football": "1489417"},
         }
         r = normalize_schedule({"params": {"events": [iptc], "team": "spain"}})
         ev = r["data"]["events"][0]
@@ -791,11 +791,7 @@ class TestMintEventIdentity:
         comps = {c["sport:qualifier"]: c["@id"] for c in d["sport:competitors"]}
         assert comps["home"] == "urn:machina:sport:soccer:team:uruguay:ury"
         assert comps["away"] == "urn:machina:sport:soccer:team:spain:esp"
-        assert d["provider_ids"] == {
-            "api_football_fixture_id": "1489417", "api_football_league_id": "1",
-            "api_football_home_team_id": "7", "api_football_away_team_id": "9",
-            "api_football_venue_id": "1076",
-        }
+        assert d["provider_ids"] == {"api_football": "1489417"}
         assert d["sport:status"] == "NS"
 
     def test_full_iso_date_not_degraded_to_year(self):
@@ -809,7 +805,7 @@ class TestMintEventIdentity:
         d = mint_event_identity({"params": {"fixtures": [fx]}})["data"]["events"][0]
         assert "@id" not in d["sport:venue"]
         assert "None" not in d["_id"]
-        assert d["provider_ids"]["api_football_venue_id"] == ""
+        assert "api_football_venue_id" not in d["provider_ids"]
 
     def test_idempotent_urn_for_same_fixture(self):
         a = mint_event_identity({"params": {"fixtures": [_af_fixture()]}})["data"]["events"][0]
@@ -830,10 +826,10 @@ class TestMintEventIdentity:
                                       "entain_event_id": "7722030"}}]
         d = mint_event_identity({"params": {"fixtures": [_af_fixture()],
                                             "existing_events": existing}})["data"]["events"][0]
-        assert d["provider_ids"]["sportradar_event_id"] == "sr:sport_event:123"
-        assert d["provider_ids"]["entain_event_id"] == "7722030"
-        # Ingest-owned ids are still freshly minted, not from the carry map.
-        assert d["provider_ids"]["api_football_home_team_id"] == "7"
+        assert d["provider_ids"]["sportradar"] == "sr:sport_event:123"
+        assert d["provider_ids"]["entain"] == "7722030"
+        # Ingest still owns the api_football (fixture) id.
+        assert d["provider_ids"]["api_football"] == "1489417"
 
 
 # -- Provider entity merge (identity crosswalk producer) ---------------------
@@ -1065,7 +1061,7 @@ class TestBuildEventCrosswalk:
                 {"@id": "urn:machina:sport:soccer:team:mexico:mex"},
                 {"@id": "urn:machina:sport:soccer:team:south-africa:zaf"},
             ],
-            "provider_ids": {"api_football_fixture_id": "1489369"},
+            "provider_ids": {"api_football": "1489369"},
         }]
 
     def test_attaches_sportradar_and_entain_event_ids(self):
@@ -1076,9 +1072,9 @@ class TestBuildEventCrosswalk:
         r = build_event_crosswalk({"params": {"teams": self._teams(), "events": self._events(),
                                               "sportradar_schedule": sr, "entain_fixtures": bwin}})["data"]
         ev = r["normalized_items"][0]
-        assert ev["provider_ids"]["api_football_fixture_id"] == "1489369"
-        assert ev["provider_ids"]["sportradar_event_id"] == "sr:sport_event:66456904"
-        assert ev["provider_ids"]["entain_event_id"] == "7722030"
+        assert ev["provider_ids"]["api_football"] == "1489369"
+        assert ev["provider_ids"]["sportradar"] == "sr:sport_event:66456904"
+        assert ev["provider_ids"]["entain"] == "7722030"
         assert ev["metadata"]["event_urn"] == "urn:machina:sport:soccer:event:mexico-vs-south-africa:20260611:wor"
         assert r["provider_summary"] == {"events": 1, "sportradar": 1, "entain": 1}
 

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml
@@ -26,7 +26,7 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
       outputs:
         event_document: "($.get('documents', []) or [{}])[0].get('value', {})"
 

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml
@@ -28,14 +28,28 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
       outputs:
-        home_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_home_team_id')"
-        away_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_away_team_id')"
+        home_team_urn: "([t.get('@id') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
+        away_team_urn: "([t.get('@id') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
         home_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
         away_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
-        resolved_league: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_league_id')"
         resolved_year: "((($.get('documents', []) or [{}])[0].get('value', {}).get('schema:startDate') or '2026'))[:4]"
+
+    - type: document
+      name: lookup-teams
+      description: Resolve api-football team ids from the event's competitor team URNs via the team crosswalk.
+      condition: "($.get('home_team_urn') or '') != '' or ($.get('away_team_urn') or '') != ''"
+      config:
+        action: search
+        search-limit: 2
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: "{'$in': [u for u in [$.get('home_team_urn'), $.get('away_team_urn')] if u]}"
+      outputs:
+        home_team_id: "([d.get('value', {}).get('provider_ids', {}).get('api_football') for d in ($.get('documents', []) or []) if d.get('value', {}).get('_id') == $.get('home_team_urn')] or [None])[0]"
+        away_team_id: "([d.get('value', {}).get('provider_ids', {}).get('api_football') for d in ($.get('documents', []) or []) if d.get('value', {}).get('_id') == $.get('away_team_urn')] or [None])[0]"
 
     - type: connector
       name: fetch-injuries-af

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml
@@ -25,7 +25,7 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
       outputs:
         event_document: "($.get('documents', []) or [{}])[0].get('value', {})"
 

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml
@@ -29,10 +29,10 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('fixture_id') if $.get('fixture_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('fixture_id') if $.get('fixture_id') else {'$exists': True}"
       outputs:
         event_document: "($.get('documents', []) or [{}])[0].get('value', {})"
-        resolved_fixture_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_fixture_id') or $.get('fixture_id')"
+        resolved_fixture_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football') or $.get('fixture_id')"
 
     - type: connector
       name: fetch-player-stats-af

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml
@@ -28,12 +28,27 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
       outputs:
-        home_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_home_team_id')"
-        away_team_id: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_away_team_id')"
+        home_team_urn: "([t.get('@id') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
+        away_team_urn: "([t.get('@id') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
         home_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'home'] or [''])[0]"
         away_team_name: "([t.get('name') for t in (($.get('documents', []) or [{}])[0].get('value', {}).get('sport:competitors', []) or []) if t.get('sport:qualifier') == 'away'] or [''])[0]"
+
+    - type: document
+      name: lookup-teams
+      description: Resolve api-football team ids from the event's competitor team URNs via the team crosswalk.
+      condition: "($.get('home_team_urn') or '') != '' or ($.get('away_team_urn') or '') != ''"
+      config:
+        action: search
+        search-limit: 2
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: "{'$in': [u for u in [$.get('home_team_urn'), $.get('away_team_urn')] if u]}"
+      outputs:
+        home_team_id: "([d.get('value', {}).get('provider_ids', {}).get('api_football') for d in ($.get('documents', []) or []) if d.get('value', {}).get('_id') == $.get('home_team_urn')] or [None])[0]"
+        away_team_id: "([d.get('value', {}).get('provider_ids', {}).get('api_football') for d in ($.get('documents', []) or []) if d.get('value', {}).get('_id') == $.get('away_team_urn')] or [None])[0]"
 
     - type: connector
       name: fetch-home-squad-af

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml
@@ -28,9 +28,10 @@ workflow:
       filters:
         name: "'worldcup:event'"
         value._id: "$.get('event_urn') if $.get('event_urn') else {'$exists': True}"
-        value.provider_ids.api_football_fixture_id: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
+        value.provider_ids.api_football: "$.get('provider_event_id') if $.get('provider_event_id') else {'$exists': True}"
       outputs:
-        resolved_league: "(($.get('documents', []) or [{}])[0].get('value', {}).get('provider_ids', {}) or {}).get('api_football_league_id')"
+        # League is the World Cup competition (api-football league 1); the fetch
+        # below defaults to '1', so no per-event league id is needed here.
         resolved_year: "((($.get('documents', []) or [{}])[0].get('value', {}).get('schema:startDate') or '2026'))[:4]"
         resolved_season_slug: "(($.get('documents', []) or [{}])[0].get('value', {}) or {}).get('machina_competition_slug')"
 

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1206,7 +1206,7 @@ def normalize_schedule(request_data: dict[str, Any]) -> dict[str, Any]:
                 for t in competitors if isinstance(t, dict)
             ],
             "venue": _text(venue.get("name")) or None,
-            "fixture_id": (ev.get("provider_ids") or {}).get("api_football_fixture_id"),
+            "fixture_id": (ev.get("provider_ids") or {}).get("api_football"),
         })
 
     out.sort(key=lambda e: e.get("start_date") or "")
@@ -1731,21 +1731,26 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
     events: list[dict[str, Any]] = []
     warnings: list[str] = []
 
-    # Carry forward provider ids not produced by ingest (e.g. sportradar_event_id,
-    # entain_event_id added by the event crosswalk) from existing event docs, keyed
-    # by api-football fixture id, so a force-update re-ingest preserves them.
-    ingest_keys = {"api_football_fixture_id", "api_football_league_id",
-                   "api_football_home_team_id", "api_football_away_team_id", "api_football_venue_id"}
+    # Carry forward provider ids not produced by ingest (sportradar, opta, entain,
+    # espn — added by the event crosswalk) from existing event docs, keyed by the
+    # api-football fixture id, so a force-update re-ingest preserves them.
+    event_alias = {"sportradar_event_id": "sportradar", "entain_event_id": "entain",
+                   "opta_event_id": "opta", "espn_event_id": "espn"}
+    event_providers = {"sportradar", "opta", "entain", "espn"}
     carry: dict[str, dict[str, str]] = {}
     for ev in _as_list(params.get("existing_events")):
         d = _unwrap(ev)
         pids = d.get("provider_ids") if isinstance(d, dict) else None
         if not isinstance(pids, dict):
             continue
-        fid = _text(pids.get("api_football_fixture_id"))
+        fid = _text(pids.get("api_football") or pids.get("api_football_fixture_id"))
         if not fid:
             continue
-        keep = {k: _text(v) for k, v in pids.items() if k not in ingest_keys and _text(v)}
+        keep = {}
+        for k, v in pids.items():
+            nk = event_alias.get(k, k)
+            if nk in event_providers and _text(v):
+                keep[nk] = _text(v)
         if keep:
             carry[fid] = keep
 
@@ -1808,12 +1813,11 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
                 {"@type": "sport:Team", "@id": _machina_team_urn(away_name), "name": away_name,
                  "sport:qualifier": "away", "schema:logo": _text(away.get("logo")) or None},
             ],
+            # provider_ids holds ONLY each provider's id for THIS object (the event):
+            # api_football = the fixture id. Team/league/venue ids are resolved
+            # relationally (competitors -> team crosswalk, competition).
             "provider_ids": {
-                "api_football_fixture_id": fixture_id,
-                "api_football_league_id": _text(league.get("id")),
-                "api_football_home_team_id": _text(home.get("id")),
-                "api_football_away_team_id": _text(away.get("id")),
-                "api_football_venue_id": _text(venue.get("id")),
+                "api_football": fixture_id,
             },
             "machina_competition_slug": comp_slug,
             "raw_provider": "api-football",
@@ -2127,8 +2131,8 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             if not sid or len(urns) != 2:
                 continue
             ev = by_pair.get(frozenset(urns))
-            if ev is not None and "sportradar_event_id" not in (ev.get("provider_ids") or {}):
-                ev.setdefault("provider_ids", {})["sportradar_event_id"] = sid
+            if ev is not None and "sportradar" not in (ev.get("provider_ids") or {}):
+                ev.setdefault("provider_ids", {})["sportradar"] = sid
                 summary["sportradar"] += 1
 
     for resp in _flatten_foreach(params.get("entain_fixtures")):
@@ -2143,8 +2147,8 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             if not eid or len(urns) != 2:
                 continue
             ev = by_pair.get(frozenset(urns))
-            if ev is not None and "entain_event_id" not in (ev.get("provider_ids") or {}):
-                ev.setdefault("provider_ids", {})["entain_event_id"] = eid
+            if ev is not None and "entain" not in (ev.get("provider_ids") or {}):
+                ev.setdefault("provider_ids", {})["entain"] = eid
                 summary["entain"] += 1
 
     return {


### PR DESCRIPTION
`provider_ids` is now uniform across event/team/player: **one key per provider, value = that provider's id for the object**. Events drop the secondary `*_home_team_id/away_team_id/league_id/venue_id` and use `{api_football: <fixture id>, sportradar, entain}` (opta/espn to follow). Reads resolve team ids relationally (event competitors → team crosswalk) via a new `lookup-teams` task; league defaults to WC `1`. 89 tests, lint clean. Connector .py + reads changed → restart + re-ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)