### PR TITLE
feat(world-cup): event opta ids + player sportradar ids

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1076,7 +1076,7 @@ class TestBuildEventCrosswalk:
         assert ev["provider_ids"]["sportradar"] == "sr:sport_event:66456904"
         assert ev["provider_ids"]["entain"] == "7722030"
         assert ev["metadata"]["event_urn"] == "urn:machina:sport:soccer:event:mexico-vs-south-africa:20260611:wor"
-        assert r["provider_summary"] == {"events": 1, "sportradar": 1, "entain": 1}
+        assert r["provider_summary"] == {"events": 1, "sportradar": 1, "entain": 1, "opta": 0}
 
     def test_unmatched_pair_is_left_untouched(self):
         # sportradar event for a different pair (one unknown competitor) → no attach.
@@ -1086,3 +1086,33 @@ class TestBuildEventCrosswalk:
                                               "sportradar_schedule": sr}})["data"]
         assert "sportradar_event_id" not in r["normalized_items"][0]["provider_ids"]
         assert r["provider_summary"]["sportradar"] == 0
+
+
+def test_build_event_crosswalk_opta():
+    teams = [
+        {"_id": "urn:machina:sport:soccer:team:mexico:mex", "provider_ids": {"opta": "4vofb84dzb5fyc81n2ssws6ah"}},
+        {"_id": "urn:machina:sport:soccer:team:south-africa:zaf", "provider_ids": {"opta": "xmip8t9f2kefltjkraxzsxl9"}},
+    ]
+    events = [{"_id": "urn:machina:sport:soccer:event:mexico-vs-south-africa:20260611:wor",
+               "sport:competitors": [{"@id": "urn:machina:sport:soccer:team:mexico:mex"},
+                                     {"@id": "urn:machina:sport:soccer:team:south-africa:zaf"}],
+               "provider_ids": {"api_football": "1489369"}}]
+    opta = {"matchDate": [{"match": [{"id": "4tcpns1nwyc0jtpucgzj9dp90",
+            "homeContestantId": "4vofb84dzb5fyc81n2ssws6ah", "awayContestantId": "xmip8t9f2kefltjkraxzsxl9"}]}]}
+    r = build_event_crosswalk({"params": {"teams": teams, "events": events, "opta_schedule": opta}})["data"]
+    assert r["normalized_items"][0]["provider_ids"]["opta"] == "4tcpns1nwyc0jtpucgzj9dp90"
+    assert r["provider_summary"]["opta"] == 1
+
+
+def test_build_player_crosswalk_sportradar():
+    teams = [{"_id": "urn:machina:sport:soccer:team:belgium:bel", "name": "Belgium", "country": "Belgium",
+              "provider_ids": {"api_football": "1", "sportradar": "sr:competitor:4717"}}]
+    af_squads = [{"response": [{"team": {"id": 1}, "players": [{"id": "100", "name": "Axel Witsel"}]}]}]
+    af_players = [{"response": [{"player": {"id": 100, "name": "Axel Witsel", "firstname": "Axel",
+                  "lastname": "Witsel", "birth": {"date": "1989-01-12"}}}]}]
+    sr = [{"competitor": {"id": "sr:competitor:4717"}, "players": [{"id": "sr:player:35612", "name": "Witsel, Axel"}]}]
+    r = build_player_crosswalk({"params": {"teams": teams, "af_squads": af_squads,
+            "af_players": af_players, "sportradar_rosters": sr}})["data"]
+    d = r["normalized_items"][0]
+    assert d["provider_ids"]["sportradar"] == "sr:player:35612"
+    assert d["provider_ids"]["api_football"] == "100"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml
@@ -15,6 +15,9 @@ workflow:
     bwin:
       Bwin-AccessId: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID
       Bwin-AccessIdToken: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID_TOKEN
+    opta:
+      outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
+      secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
   inputs:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
@@ -22,6 +25,7 @@ workflow:
     sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
     bwin_country: "$.get('bwin_country', 'gb')"
     bwin_competition_id: "$.get('bwin_competition_id', '102868')"
+    opta_wc_tmcl: "$.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')"
   outputs:
     fixtures_count: "$.get('fixtures_count', 0)"
     saved_count: "len($.get('normalized_items', []) or $.get('iptc_events', []))"
@@ -115,8 +119,33 @@ workflow:
         entain_fixtures: "{'items': $.get('items', [])}"
 
     - type: connector
+      name: opta-auth
+      description: Get an Opta OAuth access token.
+      continue_on_error: true
+      connector:
+        name: opta
+        command: authorization
+      outputs:
+        opta_token: "$.get('access_token')"
+
+    - type: connector
+      name: fetch-opta-schedule
+      description: Opta tournament schedule (match ids + contestant ids) for the World Cup.
+      condition: "$.get('opta_token') is not None"
+      continue_on_error: true
+      connector:
+        name: opta
+        command: invoke_request
+      inputs:
+        access_token: "$.get('opta_token')"
+        endpoint: "'tournamentschedule'"
+        query_params: "{'tmcl': $.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')}"
+      outputs:
+        opta_schedule: "{'matchDate': $.get('matchDate', [])}"
+
+    - type: connector
       name: build-event-crosswalk
-      description: Attach sportradar/entain event ids to the minted events by team pair.
+      description: Attach sportradar/entain/opta event ids to the minted events by team pair.
       condition: "len($.get('iptc_events', [])) > 0"
       continue_on_error: true
       connector:
@@ -127,6 +156,7 @@ workflow:
         events: "$.get('iptc_events', [])"
         sportradar_schedule: "$.get('sportradar_schedule', {})"
         entain_fixtures: "$.get('entain_fixtures', {})"
+        opta_schedule: "$.get('opta_schedule', {})"
       outputs:
         normalized_items: "$.get('normalized_items', [])"
         provider_summary: "$.get('provider_summary', {})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml
@@ -14,10 +14,14 @@ workflow:
     bwin:
       Bwin-AccessId: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID
       Bwin-AccessIdToken: $TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID_TOKEN
+    opta:
+      outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
+      secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
   inputs:
     sr_season_id: "$.get('sr_season_id', 'sr:season:101177')"
     bwin_country: "$.get('bwin_country', 'gb')"
     bwin_competition_id: "$.get('bwin_competition_id', '102868')"
+    opta_wc_tmcl: "$.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')"
   outputs:
     saved_count: "len($.get('normalized_items', []))"
     provider_summary: "$.get('provider_summary', {})"
@@ -82,8 +86,33 @@ workflow:
         entain_fixtures: "{'items': $.get('items', [])}"
 
     - type: connector
+      name: opta-auth
+      description: Get an Opta OAuth access token.
+      continue_on_error: true
+      connector:
+        name: opta
+        command: authorization
+      outputs:
+        opta_token: "$.get('access_token')"
+
+    - type: connector
+      name: fetch-opta-schedule
+      description: Opta tournament schedule (match ids + contestant ids) for the World Cup.
+      condition: "$.get('opta_token') is not None"
+      continue_on_error: true
+      connector:
+        name: opta
+        command: invoke_request
+      inputs:
+        access_token: "$.get('opta_token')"
+        endpoint: "'tournamentschedule'"
+        query_params: "{'tmcl': $.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')}"
+      outputs:
+        opta_schedule: "{'matchDate': $.get('matchDate', [])}"
+
+    - type: connector
       name: build-event-crosswalk
-      description: Attach sportradar/entain event ids to events by team pair.
+      description: Attach sportradar/entain/opta event ids to events by team pair.
       connector:
         name: worldcup-market-intelligence
         command: build_event_crosswalk
@@ -92,6 +121,7 @@ workflow:
         events: "$.get('events', [])"
         sportradar_schedule: "$.get('sportradar_schedule', {})"
         entain_fixtures: "$.get('entain_fixtures', {})"
+        opta_schedule: "$.get('opta_schedule', {})"
       outputs:
         normalized_items: "$.get('normalized_items', [])"
         provider_summary: "$.get('provider_summary', {})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml
@@ -15,6 +15,8 @@ workflow:
     opta:
       outlet: $MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET
       secret: $MACHINA_CONTEXT_VARIABLE_OPTA_SECRET
+    sportradar-soccer:
+      api_key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
   inputs:
     season: "$.get('season', '2026')"
     opta_wc_tmcl: "$.get('opta_wc_tmcl', '873cbl9cd9butm4air0mugxzo')"
@@ -109,6 +111,26 @@ workflow:
         espn_rosters: "[$.get('data', {}) if $.get('status') else {}]"
 
     - type: connector
+      name: fetch-sr-rosters
+      description: Sportradar competitor squads (sr:player ids) per team via competitor profile.
+      condition: "len($.get('teams', [])) > 0"
+      continue_on_error: true
+      connector:
+        name: sportradar-soccer
+        command: get-competitors/{competitor_id}/profile.json
+        command_attribute:
+          competitor_id: "$.get('sr_team', {}).get('provider_ids', {}).get('sportradar')"
+      foreach:
+        concurrent: false
+        name: sr_team
+        expr: $
+        value: "[t for t in $.get('teams', []) if t.get('provider_ids', {}).get('sportradar')]"
+      inputs:
+        api_key: "$.get('api_key')"
+      outputs:
+        sportradar_rosters: "[{'competitor': $.get('competitor', {}), 'players': $.get('players', [])}]"
+
+    - type: connector
       name: opta-auth
       description: Get an Opta OAuth access token.
       continue_on_error: true
@@ -145,6 +167,7 @@ workflow:
         af_players: "$.get('af_players', [])"
         opta_squads: "$.get('opta_squads', {})"
         espn_rosters: "$.get('espn_rosters', [])"
+        sportradar_rosters: "$.get('sportradar_rosters', [])"
         existing_players: "$.get('existing_players', [])"
       outputs:
         normalized_items: "$.get('normalized_items', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1897,7 +1897,7 @@ def _is_full_name(name: Any) -> bool:
 
 def _team_maps(teams: list[Any]) -> dict[str, dict]:
     """provider key -> {provider_id: teaminfo} from team-crosswalk docs."""
-    maps: dict[str, dict] = {"api_football": {}, "opta": {}, "espn": {}}
+    maps: dict[str, dict] = {"api_football": {}, "opta": {}, "espn": {}, "sportradar": {}}
     for t in teams:
         if not isinstance(t, dict):
             continue
@@ -1938,9 +1938,11 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
     params = _params(request_data)
     maps = _team_maps(_as_list(params.get("teams")))
     by_af, by_opta, by_espn = maps["api_football"], maps["opta"], maps["espn"]
+    by_sr = maps["sportradar"]
     canon: dict[tuple, dict[str, Any]] = {}
     order: list[tuple] = []
-    summary = {"api_football": 0, "opta": 0, "espn": 0, "with_dob": 0, "excluded_no_dob": 0}
+    summary = {"api_football": 0, "opta": 0, "espn": 0, "sportradar": 0,
+               "with_dob": 0, "excluded_no_dob": 0}
 
     # Canonical set + team link from api-football squads.
     for resp in _flatten_foreach(params.get("af_squads")):
@@ -2013,10 +2015,30 @@ def build_player_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
                 canon[key]["provider_ids"]["espn"] = _text(p.get("id"))
                 summary["espn"] += 1
 
+    # Sportradar ids (competitor profile squads). Names are "Lastname, Firstname".
+    for resp in _flatten_foreach(params.get("sportradar_rosters")):
+        data = _unwrap(resp)
+        tinfo = by_sr.get(_text((data.get("competitor") or {}).get("id"))) if isinstance(data, dict) else None
+        if not tinfo:
+            continue
+        for p in data.get("players", []) or []:
+            if not isinstance(p, dict):
+                continue
+            nm = _text(p.get("name"))
+            if "," in nm:
+                last_raw, first_raw = nm.split(",", 1)
+                last, fi = _slugify(last_raw), _slugify(first_raw)[:1]
+            else:
+                last, fi = _name_tokens(nm)
+            key = (tinfo["iso3"], last, fi)
+            if key in canon and _text(p.get("id")):
+                canon[key]["provider_ids"]["sportradar"] = _text(p.get("id"))
+                summary["sportradar"] += 1
+
     # Carry forward provider ids this build does not itself produce (e.g. entain,
     # transfermarkt) from existing crosswalk docs, joined by api-football id, so a
     # force-update re-sync preserves them instead of dropping them.
-    produced = {"api_football", "opta", "espn"}
+    produced = {"api_football", "opta", "espn", "sportradar"}
     key_alias = {"api_football_player_id": "api_football",
                  "entain_player_id": "entain",
                  "transfermarkt_player_id": "transfermarkt"}
@@ -2090,13 +2112,15 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
 
     Params:
       - events: canonical worldcup:event values (each has sport:competitors[].@id team URNs)
-      - teams: team-crosswalk docs (for sportradar/entain provider-id -> team URN maps)
+      - teams: team-crosswalk docs (for sportradar/entain/opta provider-id -> team URN maps)
       - sportradar_schedule: sportradar /seasons/{id}/schedules.json response(s)
       - entain_fixtures: bwin fixtures response(s)
+      - opta_schedule: opta tournamentschedule response(s) (matchDate[].match[])
     """
     params = _params(request_data)
     by_sr: dict[str, str] = {}
     by_entain: dict[str, str] = {}
+    by_opta: dict[str, str] = {}
     for t in _as_list(params.get("teams")):
         if not isinstance(t, dict):
             continue
@@ -2106,6 +2130,8 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
             by_sr[_text(pids["sportradar"])] = urn
         if pids.get("entain"):
             by_entain[_text(pids["entain"])] = urn
+        if pids.get("opta"):
+            by_opta[_text(pids["opta"])] = urn
 
     by_pair: dict[frozenset, dict[str, Any]] = {}
     out: list[dict[str, Any]] = []
@@ -2119,7 +2145,24 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
         if len(urns) == 2:
             by_pair[frozenset(urns)] = ev
 
-    summary = {"events": len(out), "sportradar": 0, "entain": 0}
+    summary = {"events": len(out), "sportradar": 0, "entain": 0, "opta": 0}
+
+    for resp in _flatten_foreach(params.get("opta_schedule")):
+        data = _unwrap(resp)
+        for md in (data.get("matchDate", []) if isinstance(data, dict) else []):
+            for m in (md.get("match", []) if isinstance(md, dict) else []):
+                if not isinstance(m, dict):
+                    continue
+                mid = _text(m.get("id"))
+                urns = [by_opta.get(_text(m.get("homeContestantId"))),
+                        by_opta.get(_text(m.get("awayContestantId")))]
+                urns = [u for u in urns if u]
+                if not mid or len(urns) != 2:
+                    continue
+                ev = by_pair.get(frozenset(urns))
+                if ev is not None and "opta" not in (ev.get("provider_ids") or {}):
+                    ev.setdefault("provider_ids", {})["opta"] = mid
+                    summary["opta"] += 1
 
     for resp in _flatten_foreach(params.get("sportradar_schedule")):
         data = _unwrap(resp)


### PR DESCRIPTION
Completes the buildable provider coverage:
- **Events → opta**: opta tournamentschedule match id, joined by contestant ids. Events now carry api_football+sportradar+entain+opta.
- **Players → sportradar**: sr:player ids from competitor profile squads (name 'Lastname, Firstname'), matched by iso3+lastname+initial.

External caps (not pipeline gaps): ESPN event ids (sports-skills get_season_schedule empty for WC 2026 pre-tournament); entain player ids (no provider catalog). 91 tests, lint clean. Connector .py + workflows → restart + re-ingest + re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)