### PR TITLE
fix(world-cup): event competition URN alignment

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -787,7 +787,7 @@ class TestMintEventIdentity:
         d = mint_event_identity({"params": {"fixtures": [_af_fixture()]}})["data"]["events"][0]
         assert d["_id"] == d["@id"] == d["metadata"]["event_urn"]
         assert d["_id"] == "urn:machina:sport:soccer:event:uruguay-vs-spain:20260627:wor"
-        assert d["sport:competition"]["@id"] == "urn:machina:sport:soccer:competition:world-cup:wor"
+        assert d["sport:competition"]["@id"] == "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor"
         comps = {c["sport:qualifier"]: c["@id"] for c in d["sport:competitors"]}
         assert comps["home"] == "urn:machina:sport:soccer:team:uruguay:ury"
         assert comps["away"] == "urn:machina:sport:soccer:team:spain:esp"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1757,7 +1757,6 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(f, dict):
             continue
         fixture = f.get("fixture", {}) if isinstance(f.get("fixture"), dict) else {}
-        league = f.get("league", {}) if isinstance(f.get("league"), dict) else {}
         teams = f.get("teams", {}) if isinstance(f.get("teams"), dict) else {}
         home = teams.get("home", {}) if isinstance(teams.get("home"), dict) else {}
         away = teams.get("away", {}) if isinstance(teams.get("away"), dict) else {}
@@ -1775,8 +1774,11 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
             f"urn:machina:sport:soccer:event:"
             f"{_slugify(home_name)}-vs-{_slugify(away_name)}:{_event_date(date_iso)}:wor"
         )
-        comp_name = _text(league.get("name")) or "World Cup"
-        comp_urn = f"urn:machina:sport:soccer:competition:{_slugify(comp_name)}:wor"
+        # Canonical competition URN — must match the competition crosswalk doc and
+        # the market cache (api-football's league name "World Cup" would mint a
+        # different, dangling slug).
+        comp_name = "FIFA World Cup 2026"
+        comp_urn = "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor"
 
         venue_name = _text(venue.get("name"))
         venue_block: dict[str, Any] = {


### PR DESCRIPTION
Events minted competition:world-cup:wor (dangling, no doc) while the competition doc + markets use competition:fifa-world-cup-2026:wor. Emit the canonical URN from mint_event_identity so events/competition/markets join consistently. 91 tests, lint clean. Connector .py → restart + re-ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)