### PR TITLE
feat(world-cup): market entity linking

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -24,6 +24,7 @@ mint_event_identity = _module.mint_event_identity
 merge_provider_entities = _module.merge_provider_entities
 build_player_crosswalk = _module.build_player_crosswalk
 build_event_crosswalk = _module.build_event_crosswalk
+link_market_entities = _module.link_market_entities
 
 
 def _kalshi_record(**overrides):
@@ -1116,3 +1117,45 @@ def test_build_player_crosswalk_sportradar():
     d = r["normalized_items"][0]
     assert d["provider_ids"]["sportradar"] == "sr:player:35612"
     assert d["provider_ids"]["api_football"] == "100"
+
+
+class TestLinkMarketEntities:
+    def _teams(self):
+        return [
+            {"_id": "urn:machina:sport:soccer:team:brazil:bra", "name": "Brazil"},
+            {"_id": "urn:machina:sport:soccer:team:haiti:hti", "name": "Haiti"},
+            {"_id": "urn:machina:sport:soccer:team:czech-republic:cze", "name": "Czech Republic"},
+            {"_id": "urn:machina:sport:soccer:team:south-africa:zaf", "name": "South Africa"},
+        ]
+
+    def _events(self):
+        return [{"_id": "urn:machina:sport:soccer:event:brazil-vs-haiti:20260619:wor",
+                 "sport:competitors": [{"@id": "urn:machina:sport:soccer:team:brazil:bra"},
+                                       {"@id": "urn:machina:sport:soccer:team:haiti:hti"}]}]
+
+    def test_game_market_links_teams_and_event(self):
+        markets = [{"cache_id": "kalshi:x", "title": "Brazil vs Haiti Winner?",
+                    "slug": "KXWCGAME-26JUN19BRAHTI-BRA", "outcomes": [{"name": "Brazil"}, {"name": "No"}]}]
+        r = link_market_entities({"params": {"markets": markets, "teams": self._teams(), "events": self._events()}})["data"]
+        m = r["normalized_markets"][0]
+        assert m["competition_urn"] == "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor"
+        assert set(m["related_team_urns"]) == {"urn:machina:sport:soccer:team:brazil:bra", "urn:machina:sport:soccer:team:haiti:hti"}
+        assert m["event_urn"] == "urn:machina:sport:soccer:event:brazil-vs-haiti:20260619:wor"
+
+    def test_outright_market_single_team_no_event(self):
+        markets = [{"cache_id": "poly:y", "title": "Will Brazil win the 2026 FIFA World Cup?", "slug": "", "outcomes": []}]
+        r = link_market_entities({"params": {"markets": markets, "teams": self._teams(), "events": self._events()}})["data"]
+        m = r["normalized_markets"][0]
+        assert m["related_team_urns"] == ["urn:machina:sport:soccer:team:brazil:bra"]
+        assert m["event_urn"] is None
+
+    def test_alias_czechia_matches_czech_republic(self):
+        markets = [{"cache_id": "k:z", "title": "Will Czechia advance?", "slug": "", "outcomes": []}]
+        r = link_market_entities({"params": {"markets": markets, "teams": self._teams(), "events": self._events()}})["data"]
+        assert r["normalized_markets"][0]["related_team_urns"] == ["urn:machina:sport:soccer:team:czech-republic:cze"]
+
+    def test_no_team_market_empty(self):
+        markets = [{"cache_id": "k:w", "title": "2026 World Cup - Top Goalscorer", "slug": "", "outcomes": []}]
+        r = link_market_entities({"params": {"markets": markets, "teams": self._teams(), "events": self._events()}})["data"]
+        assert r["normalized_markets"][0]["related_team_urns"] == []
+        assert r["normalized_markets"][0]["event_urn"] is None

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
@@ -87,6 +87,45 @@ workflow:
         warnings: "$.get('warnings', [])"
 
     - type: document
+      name: load-teams
+      description: Load the team crosswalk for market team-name -> URN matching.
+      config:
+        action: search
+        search-limit: 100
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: {"$regex": "^urn:machina:sport:soccer:team:"}
+      outputs:
+        teams: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: document
+      name: load-events
+      description: Load event docs so per-game markets can link to a specific fixture by team pair.
+      config:
+        action: search
+        search-limit: 500
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+      outputs:
+        events: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: link-market-entities
+      description: Attach competition_urn + related_team_urns + event_urn to each market.
+      connector:
+        name: worldcup-market-intelligence
+        command: link_market_entities
+      inputs:
+        markets: "$.get('normalized_markets', [])"
+        teams: "$.get('teams', [])"
+        events: "$.get('events', [])"
+      outputs:
+        normalized_markets: "$.get('normalized_markets', [])"
+        provider_summary: "$.get('provider_summary', {})"
+
+    - type: document
       name: save-market-cache
       description: Save the normalized market cache in the same pod document store, upserted by record id.
       condition: "len($.get('normalized_markets', [])) > 0"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2197,3 +2197,90 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
         "status": True,
         "data": {"normalized_items": out, "count": len(out), "provider_summary": summary},
     }
+
+
+WC_COMPETITION_URN = "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor"
+
+# Market team-name variants -> canonical team name slug (as used in team URNs).
+_MARKET_TEAM_ALIASES = {
+    "czechia": "czech-republic",
+    "korea": "south-korea", "korea-republic": "south-korea",
+    "turkey": "turkiye",
+    "cote-d-ivoire": "ivory-coast", "cote-divoire": "ivory-coast",
+    "dr-congo": "congo-dr", "drc": "congo-dr", "democratic-republic-of-congo": "congo-dr",
+    "united-states": "usa", "united-states-of-america": "usa",
+    "bosnia": "bosnia-herzegovina", "bosnia-and-herzegovina": "bosnia-herzegovina",
+    "cape-verde": "cape-verde-islands",
+}
+
+
+def _market_team_index(teams: list[Any]) -> list[tuple]:
+    """(match_slug, team_urn) pairs, longest-first, including name aliases."""
+    canon_to_urn: dict[str, str] = {}
+    index: list[tuple] = []
+    for t in teams:
+        if not isinstance(t, dict):
+            continue
+        urn = _text(_first(t, "_id", "@id", "id"))
+        name_slug = _slugify(t.get("name"))
+        if not urn or not name_slug:
+            continue
+        canon_to_urn[name_slug] = urn
+        index.append((name_slug, urn))
+    for alias, canon in _MARKET_TEAM_ALIASES.items():
+        if canon in canon_to_urn:
+            index.append((alias, canon_to_urn[canon]))
+    index.sort(key=lambda x: len(x[0]), reverse=True)
+    return index
+
+
+def _match_team_urns(text_slug: str, index: list[tuple]) -> list[str]:
+    found: list[str] = []
+    for slug, urn in index:
+        if slug and urn not in found and re.search(r"(^|-)" + re.escape(slug) + r"($|-)", text_slug):
+            found.append(urn)
+    return found
+
+
+def link_market_entities(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Attach competition_urn + related_team_urns + event_urn to normalized markets.
+
+    Params:
+      - markets: normalized market records (from normalize_market_sources)
+      - teams: team-crosswalk docs (name -> URN, with aliases)
+      - events: worldcup:event docs (team-pair -> event_urn)
+    All markets here have already passed the World Cup relevance gate, so the
+    competition is always the canonical WC competition.
+    """
+    params = _params(request_data)
+    index = _market_team_index(_as_list(params.get("teams")))
+    by_pair: dict[frozenset, str] = {}
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        urns = [_text(c.get("@id")) for c in (ev.get("sport:competitors") or [])
+                if isinstance(c, dict) and c.get("@id")]
+        if len(urns) == 2:
+            by_pair[frozenset(urns)] = _text(_first(ev, "_id", "@id", "id"))
+
+    markets = _as_list(params.get("markets"))
+    summary = {"markets": len(markets), "with_team": 0, "with_event": 0}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        text = " ".join([
+            _text(m.get("title")), _text(m.get("slug")),
+            " ".join(_text(o.get("name")) for o in (m.get("outcomes") or []) if isinstance(o, dict)),
+        ])
+        related = _match_team_urns(_slugify(text), index)
+        m["competition_urn"] = WC_COMPETITION_URN
+        m["related_team_urns"] = related
+        m["event_urn"] = by_pair.get(frozenset(related)) if len(related) == 2 else None
+        if related:
+            summary["with_team"] += 1
+        if m["event_urn"]:
+            summary["with_event"] += 1
+    return {
+        "status": True,
+        "data": {"normalized_markets": markets, "count": len(markets), "provider_summary": summary},
+    }

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -42,3 +42,5 @@ connector:
       value: "build_player_crosswalk"
     - name: "Build event crosswalk"
       value: "build_event_crosswalk"
+    - name: "Link market entities"
+      value: "link_market_entities"


### PR DESCRIPTION
The market sync didn't produce `related_team_urns`/`competition_urn` (those were legacy Mach5 data a re-sync would wipe). Adds `link_market_entities` — attaches canonical competition URN, matches team names (with nation aliases) to team URNs, and links 2-team markets to a specific event by team pair. Wired into the market sync so both Kalshi + Polymarket refreshes self-link. 95 tests, lint clean. Connector .py → restart + re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)