### PR TITLE
feat(world-cup): price-history snapshots + market movers

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -48,6 +48,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-get-market-state.yml
   - type: workflow
+    path: workflows/worldcup-market-movers.yml
+  - type: workflow
     path: workflows/worldcup-get-iptc-event-context.yml
   - type: workflow
     path: workflows/worldcup-get-event-context.yml

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -25,6 +25,8 @@ merge_provider_entities = _module.merge_provider_entities
 build_player_crosswalk = _module.build_player_crosswalk
 build_event_crosswalk = _module.build_event_crosswalk
 link_market_entities = _module.link_market_entities
+build_market_snapshots = _module.build_market_snapshots
+compute_market_movers = _module.compute_market_movers
 
 
 def _kalshi_record(**overrides):
@@ -1159,3 +1161,38 @@ class TestLinkMarketEntities:
         r = link_market_entities({"params": {"markets": markets, "teams": self._teams(), "events": self._events()}})["data"]
         assert r["normalized_markets"][0]["related_team_urns"] == []
         assert r["normalized_markets"][0]["event_urn"] is None
+
+
+class TestMarketSnapshotsAndMovers:
+    def test_snapshot_id_is_hourly_and_slim(self):
+        markets = [{"cache_id": "kalshi:x", "source": "kalshi", "title": "Brazil vs Haiti Winner?",
+                    "fetched_at": "2026-06-06T15:17:27.989043Z",
+                    "outcomes": [{"name": "Brazil", "price": 0.9}, {"name": "No", "price": 0.1}],
+                    "volume": 100, "event_urn": "urn:e", "related_team_urns": ["urn:t"]}]
+        r = build_market_snapshots({"params": {"markets": markets}})["data"]
+        s = r["snapshots"][0]
+        assert s["metadata"]["snapshot_id"] == "kalshi:x:2026-06-06T15"
+        assert s["primary_name"] == "Brazil" and s["primary_price"] == 0.9
+        assert s["ts"] == "2026-06-06T15:17:27.989043Z"
+
+    def test_movers_rank_by_abs_delta(self):
+        markets = [
+            {"cache_id": "m1", "title": "A", "source": "kalshi", "outcomes": [{"name": "Yes", "price": 0.90}]},
+            {"cache_id": "m2", "title": "B", "source": "poly", "outcomes": [{"name": "Yes", "price": 0.50}]},
+        ]
+        snaps = [
+            {"cache_id": "m1", "ts": "2026-06-06T10:00:00Z", "primary_price": 0.88},
+            {"cache_id": "m1", "ts": "2026-06-06T08:00:00Z", "primary_price": 0.70},  # earliest = baseline
+            {"cache_id": "m2", "ts": "2026-06-06T09:00:00Z", "primary_price": 0.49},
+        ]
+        r = compute_market_movers({"params": {"markets": markets, "snapshots": snaps, "limit": 10}})["data"]
+        assert r["movers"][0]["cache_id"] == "m1"
+        assert r["movers"][0]["price_then"] == 0.70
+        assert r["movers"][0]["delta"] == 0.2
+        assert r["movers"][1]["cache_id"] == "m2"
+        assert r["movers"][1]["delta"] == 0.01
+
+    def test_movers_skips_markets_without_baseline(self):
+        markets = [{"cache_id": "new", "title": "N", "source": "kalshi", "outcomes": [{"name": "Yes", "price": 0.5}]}]
+        r = compute_market_movers({"params": {"markets": markets, "snapshots": [], "limit": 10}})["data"]
+        assert r["movers"] == []

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml
@@ -1,0 +1,56 @@
+workflow:
+  name: worldcup-market-movers
+  title: World Cup Intelligence - Market Movers
+  description: |
+    Biggest price moves across cached World Cup markets over a lookback window,
+    computed from the worldcup:market-snapshot price-history store. Each mover is
+    linked to its team/event/competition URNs. Read-only.
+
+  context-variables:
+    debugger:
+      enabled: true
+  inputs:
+    window_hours: "$.get('window_hours', 24)"
+    limit: "$.get('limit', 20)"
+  outputs:
+    movers: "$.get('movers', [])"
+    count: "len($.get('movers', []))"
+    workflow-status: "'executed'"
+  tasks:
+    - type: document
+      name: load-current-markets
+      description: Current market-cache records (latest prices).
+      config:
+        action: search
+        search-limit: 1000
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+      outputs:
+        markets: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: document
+      name: load-snapshots
+      description: Price snapshots within the lookback window (baseline for the delta).
+      config:
+        action: search
+        search-limit: 5000
+        search-vector: false
+      filters:
+        name: "'worldcup:market-snapshot'"
+        value.ts: "{'$gte': (datetime.utcnow() - timedelta(hours=int($.get('window_hours', 24)))).isoformat()}"
+      outputs:
+        snapshots: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: compute-movers
+      description: Rank markets by absolute price move vs the earliest snapshot in the window.
+      connector:
+        name: worldcup-market-intelligence
+        command: compute_market_movers
+      inputs:
+        markets: "$.get('markets', [])"
+        snapshots: "$.get('snapshots', [])"
+        limit: "$.get('limit', 20)"
+      outputs:
+        movers: "$.get('movers', [])"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
@@ -138,3 +138,29 @@ workflow:
         items: "$.get('normalized_markets', [])"
       inputs:
         normalized_markets: "$.get('normalized_markets', [])"
+
+    - type: connector
+      name: build-market-snapshots
+      description: Build hourly price snapshots (append-only time series) from the linked markets.
+      condition: "len($.get('normalized_markets', [])) > 0"
+      connector:
+        name: worldcup-market-intelligence
+        command: build_market_snapshots
+      inputs:
+        markets: "$.get('normalized_markets', [])"
+      outputs:
+        snapshots: "$.get('snapshots', [])"
+
+    - type: document
+      name: save-market-snapshots
+      description: Append hourly market snapshots (unique per market per hour) to the price-history store.
+      condition: "len($.get('snapshots', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:market-snapshot'"
+      documents:
+        items: "$.get('snapshots', [])"
+      inputs:
+        snapshots: "$.get('snapshots', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2360,3 +2360,103 @@ def link_market_entities(request_data: dict[str, Any]) -> dict[str, Any]:
         "status": True,
         "data": {"normalized_markets": markets, "count": len(markets), "provider_summary": summary},
     }
+
+
+def build_market_snapshots(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Build append-only price snapshots from linked markets (one per market per hour).
+
+    Snapshot id = "{cache_id}:{YYYY-MM-DDTHH}" so the 30-min market sync writes at
+    most one row per market per hour (last write in the hour wins) — a bounded
+    hourly price/volume time series for movement detection.
+    """
+    params = _params(request_data)
+    snapshots: list[dict[str, Any]] = []
+    for m in _as_list(params.get("markets")):
+        if not isinstance(m, dict):
+            continue
+        cid = _text(m.get("cache_id") or m.get("id"))
+        if not cid:
+            continue
+        ts = _text(m.get("fetched_at")) or _now_iso()
+        hour = ts[:13]  # "2026-06-06T15"
+        snap_id = f"{cid}:{hour}"
+        outs = [{"name": _text(o.get("name")), "price": o.get("price")}
+                for o in (m.get("outcomes") or []) if isinstance(o, dict)]
+        primary = outs[0] if outs else {}
+        snapshots.append({
+            "metadata": {"snapshot_id": snap_id},
+            "_id": snap_id, "id": snap_id,
+            "cache_id": cid,
+            "source": _text(m.get("source")),
+            "title": _text(m.get("title")),
+            "ts": ts,
+            "hour": hour,
+            "primary_name": primary.get("name"),
+            "primary_price": primary.get("price"),
+            "outcomes": outs,
+            "volume": m.get("volume"),
+            "liquidity": m.get("liquidity"),
+            "event_urn": m.get("event_urn"),
+            "competition_urn": m.get("competition_urn"),
+            "related_team_urns": m.get("related_team_urns") or [],
+        })
+    return {"status": True, "data": {"snapshots": snapshots, "count": len(snapshots)}}
+
+
+def compute_market_movers(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Rank markets by price movement vs the earliest snapshot in the window.
+
+    Params:
+      - markets: current market-cache records
+      - snapshots: market-snapshot rows already filtered to the lookback window
+      - limit: max movers to return
+    Baseline = oldest snapshot per cache_id in the supplied window; delta =
+    current primary-outcome price - baseline price.
+    """
+    params = _params(request_data)
+    try:
+        limit = int(params.get("limit") or 20)
+    except (TypeError, ValueError):
+        limit = 20
+
+    baseline: dict[str, dict[str, Any]] = {}
+    for s in _as_list(params.get("snapshots")):
+        if not isinstance(s, dict):
+            continue
+        cid = _text(s.get("cache_id"))
+        ts = _text(s.get("ts"))
+        if not cid or s.get("primary_price") is None:
+            continue
+        cur = baseline.get(cid)
+        if cur is None or (ts and ts < cur["ts"]):
+            baseline[cid] = {"ts": ts, "price": _to_float(s.get("primary_price"))}
+
+    movers: list[dict[str, Any]] = []
+    for m in _as_list(params.get("markets")):
+        if not isinstance(m, dict):
+            continue
+        cid = _text(m.get("cache_id") or m.get("id"))
+        outs = m.get("outcomes") or []
+        base = baseline.get(cid)
+        if not cid or not outs or not base:
+            continue
+        price_now = _to_float((outs[0] or {}).get("price"))
+        delta = round(price_now - base["price"], 4)
+        movers.append({
+            "cache_id": cid,
+            "title": _text(m.get("title")),
+            "source": _text(m.get("source")),
+            "outcome": _text((outs[0] or {}).get("name")),
+            "price_now": price_now,
+            "price_then": base["price"],
+            "delta": delta,
+            "abs_delta": abs(delta),
+            "since": base["ts"],
+            "volume": m.get("volume"),
+            "event_urn": m.get("event_urn"),
+            "related_team_urns": m.get("related_team_urns") or [],
+        })
+
+    movers.sort(key=lambda x: x["abs_delta"], reverse=True)
+    movers = movers[:limit]
+    return {"status": True, "data": {"movers": movers, "count": len(movers)}}

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -44,3 +44,7 @@ connector:
       value: "build_event_crosswalk"
     - name: "Link market entities"
       value: "link_market_entities"
+    - name: "Build market snapshots"
+      value: "build_market_snapshots"
+    - name: "Compute market movers"
+      value: "compute_market_movers"


### PR DESCRIPTION
Adds the two gaps for a market-intelligence layer:
- **Price-history store** — `build_market_snapshots` appends an hourly price/volume time series (`worldcup:market-snapshot`) on each 30-min market sync (one row per market per hour, bounded).
- **Market movers** — `compute_market_movers` + `worldcup-market-movers` rank markets by absolute price move vs the earliest snapshot in a window, each linked to team/event URNs.

98 tests, lint clean. Connector .py + workflows → restart. Populates over hours as snapshots accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)