### PR TITLE
perf(world-cup): fast model for grounded search calls

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-explain-market-move.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-explain-market-move.yml
@@ -82,7 +82,8 @@ workflow:
       connector:
         name: google-genai
         command: invoke_search
-        model: gemini-3.5-flash
+        # Fast tier: news grounding only; the move reasoning below stays smart.
+        model: gemini-3.1-flash-lite
         provider: vertex_ai
         location: global
       inputs:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml
@@ -56,7 +56,8 @@ workflow:
       connector:
         name: google-genai
         command: invoke_search
-        model: gemini-3.5-flash
+        # Fast tier: context grounding only; the brief synthesis below stays smart.
+        model: gemini-3.1-flash-lite
         provider: vertex_ai
         location: global
       inputs:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
@@ -41,7 +41,9 @@ workflow:
       connector:
         name: google-genai
         command: invoke_search
-        model: gemini-3.5-flash
+        # Fast tier: grounded search summarisation runs per-fixture in bulk;
+        # Google grounding carries factual quality, so use the lite model.
+        model: gemini-3.1-flash-lite
         provider: vertex_ai
         location: global
       foreach:


### PR DESCRIPTION
Routes the 3 grounded `invoke_search` steps to `gemini-3.1-flash-lite` (grounding carries quality; prematch enrichment runs per-fixture in bulk). Reasoning `invoke_prompt` steps stay on `gemini-3.5-flash`; grok stays `grok-4-fast`. Hardcoded. Workflow-only — import, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)