### PR TITLE
chore(world-cup): grok-4.3 for fan sentiment

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml
@@ -45,7 +45,7 @@ workflow:
       inputs:
         body: |
           {
-            "model": "grok-4-fast",
+            "model": "grok-4.3",
             "stream": False,
             "input": [
               {


### PR DESCRIPTION
Bump worldcup-fan-sentiment-context grok model grok-4-fast → grok-4.3. Workflow-only, import (no restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)