### PR TITLE
feat(world-cup): resolve endpoint + API contract refresh

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -44,6 +44,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-sync-market-sources.yml
   - type: workflow
+    path: workflows/worldcup-resolve.yml
+  - type: workflow
     path: workflows/worldcup-search-markets.yml
   - type: workflow
     path: workflows/worldcup-get-market-state.yml

--- a/agent-templates/world-cup-intelligence/docs/api-contracts.md
+++ b/agent-templates/world-cup-intelligence/docs/api-contracts.md
@@ -1,311 +1,212 @@
 # World Cup Intelligence API Contracts
 
-MCP/public gateway routes should call only allowlisted workflows from this template. Do not expose raw workflow or connector execution.
+Public gateway routes should call only allowlisted workflows from this template. Do not expose raw workflow or connector execution.
 
-All public routes are read-only market intelligence. Execution, betting placement, trading, and portfolio actions are out of scope.
+All public routes are **read-only** market & match intelligence. Execution, betting placement, trading, and portfolio actions are out of scope.
 
 ## Identifiers
 
-Events, teams, and competitions use **canonical machina URNs** minted deterministically from intrinsic attributes (so they are stable across providers):
+Every entity has a **canonical machina URN** minted deterministically from intrinsic attributes (stable across providers):
 
 - event: `urn:machina:sport:soccer:event:{home-slug}-vs-{away-slug}:{YYYYMMDD}:wor`
 - team: `urn:machina:sport:soccer:team:{name-slug}:{iso3}`
-- competition: `urn:machina:sport:soccer:competition:{name-slug}:wor`
+- player: `urn:machina:sport:soccer:player:{name-slug}:{YYYYMMDD-dob}:{iso3}`
+- competition: `urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor`
 - venue: `urn:machina:sport:soccer:venue:{name-slug}:{iso3}` (omitted when the provider gives no venue)
 
-Every doc (event, team, player, competition) carries a uniform `provider_ids` map: **one key per provider, whose value is that provider's id for THIS object** — e.g. an event has `{api_football: <fixture id>, sportradar: <sr:sport_event id>, entain: <fixture id>, opta: <match id>, espn: <event id>}`; a team has `{api_football, espn, opta, sportradar, entain}`; a player has `{api_football, espn, opta, ...}`. No secondary ids (team/league/venue) live in `provider_ids` — those are resolved relationally (event `sport:competitors[].@id` → team crosswalk → that team's `provider_ids.api_football`; league via the competition). **API-Football is the data source; sports-skills (ESPN/Transfermarkt) is fallback/enrichment; entain/sportradar/opta supply ids only (never their match data).**
+`iso3` is the ISO-3166 alpha-3 country code (lowercased); the UK home nations use their FIFA codes (`eng`, `sco`, `wal`) since they have no ISO alpha-3. Players are minted only when a verified birth date exists (no placeholder date).
+
+### Uniform `provider_ids`
+
+Every doc (event, team, player, competition) carries a uniform `provider_ids` map: **one key per provider whose value is that provider's id for THIS object**.
+
+- event: `{api_football: <fixture id>, sportradar: <sr:sport_event id>, opta: <match id>, entain: <fixture id>}`
+- team: `{api_football, espn, opta, sportradar, entain}`
+- player: `{api_football, espn, opta, sportradar}`
+- competition: `{api_football, espn, sportradar, entain}`
+
+No secondary ids (team/league/venue) live in `provider_ids` — those are resolved relationally (event `sport:competitors[].@id` → team crosswalk → that team's `provider_ids.api_football`; league via the competition). No internal `raw_provider` tag is exposed.
+
+**Provider roles:** API-Football is the match-data source; sports-skills (ESPN) is fallback/enrichment; entain/sportradar/opta supply **ids only** (never their match data).
+
+**Coverage note (provider-availability capped):** teams 100% on all 5 providers; events 100% on api_football/sportradar/opta/entain (ESPN event ids unavailable pre-tournament); players 100% api_football, ~92% espn, ~86% sportradar, ~27% opta (rises via the daily sync); no entain player ids exist.
 
 **Alternate key:** reads accept the canonical `event_urn` OR `provider_event_id` (the API-Football fixture id, e.g. `1489417`, stored at `provider_ids.api_football`) — the latter is the stable, simple handle for clients. Markets are keyed by `{source}:{source_market_id}` (e.g. `polymarket:2415458`).
 
-Market-to-event entity linking (matching a Kalshi/Polymarket market to a specific fixture) is **planned, not implemented**. Markets are discovered by `query`/`team` text search, not by event id.
+## Public (allowlisted) workflow set
+
+**Identity & fixtures**
+- `worldcup-resolve` — any provider id / URN → canonical entity + cross-provider ids
+- `worldcup-get-schedule` — fixtures, filter by date/team/status
+- `worldcup-get-event-context` — enriched match context (event + grounded prematch research + sports context)
+- `worldcup-get-iptc-event-context` — IPTC/semantic event shape
+- `worldcup-get-standings` — group tables
+- `worldcup-get-squads` — both teams' squads
+- `worldcup-get-injuries` — injuries/suspensions
+- `worldcup-get-player-performance-context` — player performance signals
+
+**Market intelligence**
+- `worldcup-search-markets` — market search (Kalshi + Polymarket, URN-linked)
+- `worldcup-get-market-state` — current price + order-book depth + price history + trades (live)
+- `worldcup-market-movers` — biggest price moves over a lookback window
+- `worldcup-compare-market-sources` — cross-venue price comparison
+- `worldcup-find-market-edges` — informational edge/arb candidates (AI)
+- `worldcup-explain-market-move` — why a price moved, grounded (AI)
+- `worldcup-generate-market-brief` — grounded market-intelligence brief (AI)
+- `worldcup-fan-sentiment-context` — social/news pulse (AI, grok)
+
+**Agents (conversational)** — `world-cup-intelligence-agent` (full read+market), `world-cup-market-analyst-agent` (market-focused). Activate before exposing.
+
+## Internal/admin workflow set (cron-driven, not exposed)
+
+- `worldcup-ingest-fixtures` — fetch fixtures + mint events + inline event crosswalk (cron `0 5 * * *`)
+- `worldcup-sync-market-sources` — refresh market cache + entity links + hourly snapshots (cron `*/30 * * * *`)
+- `worldcup-sync-player-crosswalk` — rebuild player crosswalk (cron `0 6 * * *`)
+- `worldcup-sync-team-crosswalk`, `worldcup-sync-event-crosswalk`, `worldcup-sync-identity-crosswalk` — identity sync
+- `worldcup-refresh-prematch-enrichment` — grounded prematch research onto event docs
+- `worldcup-health` — ops health check
+
+## Freshness tiers
+
+- **Identity / fixtures** — synced docs; teams/events stable, players refresh daily (06:00 UTC).
+- **Market cache** (`search-markets`) — refreshed every 30 min; responses carry a staleness warning past 15 min.
+- **`get-market-state`** — live from the source (current price, order book, history, trades).
+- **`market-movers`** — computed from the hourly `worldcup:market-snapshot` time series; needs ≥2 hourly buckets to show movement.
+
+## AI models
+
+- Grounded search steps (`invoke_search`: prematch enrichment, brief context, move news) → **`gemini-3.1-flash-lite`** (fast; Google grounding carries factual quality).
+- Reasoning/synthesis steps (`invoke_prompt`: brief synthesis, move explanation, edge analysis) → **`gemini-3.5-flash`**.
+- Fan sentiment / live social (`grok` `post-responses`) → **`grok-4.3`**.
 
 ## Connector and secret requirements
 
-- `worldcup-ingest-fixtures` needs the `api-football` connector and a vault secret named `API_FOOTBALL_API_KEY`.
-- `worldcup-fan-sentiment-context` needs the `grok` connector (this repo) and a vault secret named `MACHINA_CONTEXT_VARIABLE_GROK_API_KEY`.
-- `worldcup-generate-market-brief`, `worldcup-refresh-prematch-enrichment`, and `worldcup-find-market-edges` need the `google-genai` connector (this repo) and vault secrets `TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL` + `TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID`. Grounded prematch research uses `invoke_search` (Google Search grounding); all reasoning runs on `gemini-3.5-flash`.
+- `api-football` connector + vault secret `TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY` (fixtures, standings, squads, injuries, player stats).
+- `sports-skills` connector (Kalshi/Polymarket/ESPN orchestration).
+- `sportradar-soccer` + `TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY`, `opta` (stats-perform) + `MACHINA_CONTEXT_VARIABLE_OPTA_OUTLET`/`_SECRET`, `bwin` + `TEMP_CONTEXT_VARIABLE_BWIN_ACCESS_ID`/`_TOKEN` — provider-id crosswalks only.
+- `google-genai` + `TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL` + `_VERTEX_AI_PROJECT_ID` (Gemini).
+- `grok` + `MACHINA_CONTEXT_VARIABLE_GROK_API_KEY` (fan sentiment).
 
 Secret lookup uses the literal name after `$` in a workflow's context-variables.
 
-## Launch workflow set
+---
 
-- `worldcup-search-markets`
-- `worldcup-get-market-state`
-- `worldcup-get-event-context`
-- `worldcup-get-iptc-event-context`
-- `worldcup-get-player-performance-context`
-- `worldcup-compare-market-sources`
-- `worldcup-find-market-edges`
-- `worldcup-explain-market-move`
-- `worldcup-generate-market-brief`
-- `worldcup-fan-sentiment-context`
+## `worldcup-resolve`
 
-## Internal/admin workflow set
+Resolve any provider id (api_football, sportradar, opta, entain, espn, transfermarkt) **or** a canonical machina URN to the entity it identifies (team / player / event / competition), with all cross-provider ids attached.
 
-- `worldcup-sync-market-sources`
-- `worldcup-ingest-fixtures`
-- `worldcup-refresh-prematch-enrichment`
-- `worldcup-health`
+Request:
+
+```json
+{ "id": "sr:competitor:4748" }
+```
+
+Response:
+
+```json
+{
+  "entity": {
+    "_id": "urn:machina:sport:soccer:team:brazil:bra",
+    "@type": ["sport:IdentityCrosswalk", "sport:Team"],
+    "name": "Brazil",
+    "country": "Brazil",
+    "provider_ids": {"api_football": "6", "espn": "205", "opta": "ajab3...", "sportradar": "sr:competitor:4748", "entain": "234214"}
+  },
+  "entities": ["...all matches..."],
+  "count": 1
+}
+```
+
+Accepts: a machina URN (`urn:machina:…`), a fixture id (`1489389` → the event), any team/player provider id. Returns `entities: []` / `count: 0` when nothing matches. Searches both the identity-crosswalk (teams/players/competition) and the event store.
 
 ## Normalized WorldCupMarket shape
 
-`worldcup-sync-market-sources` and `worldcup-search-markets` normalize Kalshi/Polymarket/Sports Skills records into this cache/API shape before returning data or writing to `worldcup:market-cache`.
+`worldcup-sync-market-sources` and `worldcup-search-markets` normalize Kalshi/Polymarket/Sports Skills records into this shape, then `link_market_entities` adds `competition_urn` / `related_team_urns` / `event_urn`.
 
 ```json
 {
-  "metadata": {"cache_id": "polymarket:2415458"},
-  "id": "polymarket:2415458",
-  "cache_id": "polymarket:2415458",
-  "source": "polymarket",
-  "source_market_id": "2415458",
-  "source_event_id": "554734",
-  "title": "Will Belgium reach the Round of 16 at the 2026 FIFA World Cup?",
-  "description": "Provider resolution text when available",
-  "slug": "will-belgium-reach-the-round-of-16-at-the-2026-fifa-world-cup-...",
+  "metadata": {"cache_id": "kalshi:KXWCGAME-26JUN19BRAHTI-BRA"},
+  "id": "kalshi:KXWCGAME-26JUN19BRAHTI-BRA",
+  "cache_id": "kalshi:KXWCGAME-26JUN19BRAHTI-BRA",
+  "source": "kalshi",
+  "source_market_id": "KXWCGAME-26JUN19BRAHTI-BRA",
+  "source_event_id": "KXWCGAME-26JUN19BRAHTI",
+  "title": "Brazil vs Haiti Winner?",
   "status": "open",
-  "market_type": "group_stage_or_round_market",
-  "outcomes": [
-    {
-      "name": "Yes",
-      "price": 0.61,
-      "token_id": "7804...",
-      "source_outcome_id": "7804..."
-    }
-  ],
-  "volume": 998.49,
-  "liquidity": 1200.0,
-  "spread": 0.03,
-  "start_time": "2026-06-01T00:00:00Z",
-  "end_time": "2026-06-15T00:00:00Z",
-  "updated_at": "2026-06-03T22:04:11Z",
-  "fetched_at": "2026-06-03T22:10:00Z",
-  "resolution_risk_notes": [
-    "Read-only market intelligence. Verify provider resolution rules, fees, liquidity, and freshness before acting."
-  ],
-  "source_payload_keys": ["id", "question", "outcomes"]
+  "outcomes": [{"name": "Brazil", "price": 0.9, "source_outcome_id": "yes", "token_id": null}],
+  "volume": 10818.56,
+  "liquidity": null,
+  "spread": null,
+  "competition_urn": "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor",
+  "related_team_urns": ["urn:machina:sport:soccer:team:brazil:bra", "urn:machina:sport:soccer:team:haiti:hti"],
+  "event_urn": "urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor",
+  "fetched_at": "2026-06-06T15:17:27Z",
+  "resolution_risk_notes": ["Read-only market intelligence. Verify provider resolution rules, fees, liquidity, and freshness before acting."]
 }
 ```
+
+**Market entity linking is implemented**: every cached market carries `competition_urn` (always the canonical WC competition), `related_team_urns` (team-name match against the crosswalk, with nation aliases), and `event_urn` for two-team markets matched to a fixture by team pair. Outright markets (winner/top-scorer/group) have ≤1 team and no `event_urn`.
 
 ## `worldcup-search-markets`
 
-Search same-pod cached markets first, then optionally fall back to live Sports Skills, Polymarket, and Kalshi search.
+Search same-pod cached markets first, then optionally fall back to live provider search.
 
-Request:
+Request: `{ "query": "Brazil", "source": "all", "status": "open", "limit": 20, "force_live": false }`
 
-```json
-{
-  "query": "Brazil World Cup",
-  "team": "Brazil",
-  "source": "all",
-  "status": "open",
-  "limit": 20,
-  "force_live": false
-}
-```
+Response: `{ "markets": [WorldCupMarket], "count": 8, "sources": {...}, "warnings": [] }`
 
-Response:
-
-```json
-{
-  "markets": ["WorldCupMarket[]"],
-  "count": 12,
-  "sources": {
-    "polymarket_records_seen": 50,
-    "kalshi_records_seen": 0
-  },
-  "warnings": []
-}
-```
-
-Notes:
-
-- `source` accepts `all`, `polymarket`, or `kalshi`.
-- `force_live=true` bypasses cache preference and returns fresh normalized provider data.
-- Provider records are filtered for World Cup/FIFA/team/query relevance to avoid broad sports-market noise.
+- `source` ∈ `all|polymarket|kalshi`. `force_live=true` bypasses cache preference.
+- Records are filtered for World Cup/FIFA relevance.
 
 ## `worldcup-get-market-state`
 
-Resolve a `market_id` to current state, order-book depth, price history, and trades. Every read also refreshes the cached snapshot.
+Resolve a `market_id` to current state, order-book depth, price history, and trades (live).
 
-Request:
+Request: `{ "market_id": "kalshi:KXWCGAME-26JUN19BRAHTI-BRA", "include_book": true, "include_history": true, "history_hours": 24 }`
 
-```json
-{
-  "market_id": "kalshi:KXWCGAME-26JUN16FRASEN-FRA",
-  "include_book": true,
-  "include_history": true,
-  "include_trades": false,
-  "history_hours": 24,
-  "period_interval": 60
-}
-```
+Response: `{ market_id, source, market, book {outcomes[{name,bids[],asks[],best_bid,best_ask,spread}]}, history [{ts,price,volume}], trades [], warnings [] }`
 
-Response:
+- `market_id` namespace = `kalshi:<ticker>` | `polymarket:<id>`.
+- Kalshi asks implied from the opposite side's bids; depth needs `sports-skills >= 0.25.3`.
+- Best bid/ask computed by sorting levels (provider ordering not trusted).
 
-```json
-{
-  "market_id": "kalshi:KXWCGAME-26JUN16FRASEN-FRA",
-  "source": "kalshi",
-  "market": "WorldCupMarket (refreshed)",
-  "book": {
-    "outcomes": [
-      {
-        "name": "France",
-        "token_id": null,
-        "bids": [{"price": 0.69, "size": 568.15}],
-        "asks": [{"price": 0.71, "size": 300.0}],
-        "best_bid": 0.69,
-        "best_ask": 0.71,
-        "spread": 0.02
-      }
-    ]
-  },
-  "history": [{"ts": 1780545600, "price": 0.70, "volume": 140.72}],
-  "last_trade": null,
-  "trades": [],
-  "warnings": []
-}
-```
+## `worldcup-market-movers`
 
-Notes:
+Biggest price moves across cached markets over a lookback window, from the `worldcup:market-snapshot` hourly time series.
 
-- `market_id` uses the cache id namespace from search/sync (`kalshi:<ticker>` | `polymarket:<id>`).
-- Kalshi asks are implied from the opposite side's bids (ask_yes = 1 − bid_no); depth requires `sports-skills >= 0.25.3` and degrades with a warning below that.
-- Polymarket depth/history/trades are per outcome token; history covers the primary outcome.
-- Best bid/ask are computed by sorting levels — provider ordering is not trusted.
+Request: `{ "window_hours": 24, "limit": 20 }`
 
-## `worldcup-get-player-performance-context`
+Response: `{ "movers": [{cache_id, title, source, outcome, price_now, price_then, delta, abs_delta, since, volume, event_urn, related_team_urns}], "count": 20 }`
 
-Builds a player-level context package from API-Football fixture player stats and optional official FIFA Power Ranking data. Official FIFA/Aramco fields and Machina provisional signals are intentionally separate.
-
-Request:
-
-```json
-{
-  "event_urn": "urn:machina:sport:soccer:event:brazil-vs-serbia:20260615:wor",
-  "fixture_id": "123",
-  "player_id": "10",
-  "team_id": "7",
-  "official_fifa_power_ranking": {}
-}
-```
-
-Response:
-
-```json
-{
-  "player_performance_context": {
-    "event": {"_id": "urn:machina:sport:soccer:event:brazil-vs-serbia:20260615:wor"},
-    "player": {
-      "player_id": "10",
-      "name": "Alex Creator",
-      "team_id": "7",
-      "team_name": "Brazil",
-      "position": "M",
-      "is_goalkeeper": false,
-      "minutes_played": 87,
-      "eligible_for_power_ranking": true
-    },
-    "official_fifa_power_ranking": {
-      "status": "pending",
-      "expected_available_at": null,
-      "source": "fifa.com",
-      "scores": {
-        "attacking": null,
-        "creativity": null,
-        "defending": null,
-        "in_possession": null,
-        "defending_goal": null
-      },
-      "classification": {
-        "match_rank": null,
-        "tournament_rank": null,
-        "category_rankings": []
-      }
-    },
-    "machina_provisional_performance_signal": {
-      "status": "available",
-      "source_quality": "provider",
-      "confidence": 0.9,
-      "scores_0_10": {
-        "attacking": 7.0,
-        "creativity": 8.1,
-        "defending": 6.4,
-        "in_possession": null,
-        "defending_goal": null
-      },
-      "drivers": [],
-      "warnings": [],
-      "disclaimer": "Machina provisional signal only; not an official FIFA Power Ranking."
-    },
-    "context_and_evidence": {
-      "fallback_path": ["api-football"],
-      "citations": [],
-      "missing_info_flags": [],
-      "freshness": {"official_fifa_expected_lag_hours": 4}
-    }
-  }
-}
-```
-
-Notes:
-
-- Scale is 0-10.
-- FIFA public category taxonomy: outfield = attacking, creativity, defending; goalkeepers = in possession, defending goal.
-- Eligibility requires `minutes_played >= 20`.
-- The official ranking is usually pending for ~4 hours post-match; provisional scores are a faster context layer, not official FIFA data.
+Ranked by absolute price move vs the earliest snapshot in the window. Needs ≥2 hourly snapshots to surface movement.
 
 ## `worldcup-find-market-edges`
 
-Scans the cached markets and cross-venue match pairs for dislocations.
-
 Request: `{ "min_edge_bps": 100, "include_reasoning": true, "limit": 50 }`
 
-Returns `edge_candidates[]`, each either:
-- `within_venue_book_sum` — a Kalshi event whose outcome YES prices sum away from 1.0 (`book_sum`, `edge_bps`, `direction`, `legs[]`)
-- `cross_venue_draw` — Kalshi tie price vs Polymarket draw price for a matched game (`delta`, `edge_bps`, `cheaper_venue`)
-
-Plus `analysis` (gemini-3.5-flash explanation with fee/liquidity/resolution caveats). Informational only; never trade execution.
+Returns `edge_candidates[]` — `within_venue_book_sum` (Kalshi YES prices summing off 1.0) or `cross_venue_draw` (Kalshi tie vs Polymarket draw) — plus `analysis` (gemini-3.5-flash, with fee/liquidity/resolution caveats). Informational only.
 
 ## `worldcup-explain-market-move`
 
-Detects the largest price move for a `market_id` over a window and explains it.
+Request: `{ "market_id": "kalshi:…", "window_hours": 24, "min_move_bps": 200 }`
 
-Request: `{ "market_id": "kalshi:KXWCGAME-...-FRA", "window_hours": 24, "min_move_bps": 200 }`
+Returns `move` (`moved`, `net_move_bps`, `swing_bps`, `direction`, from/to price+ts) and, when moved, `explanation` (grounded, cited drivers classified confirmed/speculative/noise).
 
-Returns `move` (`moved`, `net_move_bps`, `swing_bps`, `direction`, from/to price + ts) and, when moved, `explanation` (grounded, cited drivers classified confirmed/speculative/noise). Uses `get_price_history` (normalized 0-1) + `invoke_search`.
+## `worldcup-generate-market-brief`
 
-## `worldcup-sync-market-sources`
+Request: `{ "event_urn": "urn:…event:brazil-vs-haiti:20260620:wor", "depth": "standard", "include_social_pulse": false }`
 
-Internal/admin workflow that refreshes `worldcup:market-cache`.
+Returns `brief` (headline, summary, key_factors, market_snapshot, risks_and_uncertainties, watch_items) — grounded search (lite) + synthesis (flash).
 
-Request:
+## `worldcup-fan-sentiment-context`
 
-```json
-{
-  "query": "FIFA World Cup 2026",
-  "source": "all",
-  "status": "open",
-  "limit": 100
-}
-```
+Request: `{ "query": "Brazil World Cup", "lookback_hours": 48, "force_live": true }`
 
-Response:
+Returns `fan_sentiment` (home/away narratives, breaking_news, buzz_level, narrative_threads, overall_sentiment) + `citations[]`, via grok-4.3 live X/web search.
 
-```json
-{
-  "markets_count": 100,
-  "sources": {
-    "polymarket_records_seen": 100,
-    "kalshi_records_seen": 0
-  },
-  "warnings": []
-}
-```
+## `worldcup-get-player-performance-context`
 
-Side effect:
-
-- bulk-upserts normalized records to same-pod document store under `worldcup:market-cache`.
+Player-level context from API-Football fixture player stats + optional official FIFA Power Ranking. Official FIFA fields and Machina provisional signals are kept separate. Scale 0–10; eligibility requires `minutes_played >= 20`; the official ranking is usually pending ~4h post-match.
 
 ## Guardrails
 

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml
@@ -1,0 +1,34 @@
+workflow:
+  name: worldcup-resolve
+  title: World Cup Intelligence - Resolve Entity
+  description: |
+    Resolve ANY provider id (api_football, sportradar, opta, entain, espn,
+    transfermarkt) OR a canonical machina URN to the entity it identifies —
+    team, player, event, or competition — with all cross-provider ids attached.
+    One key for your whole stack: feed in whatever id you have, get the
+    canonical urn:machina identity back. Read-only.
+
+  context-variables:
+    debugger:
+      enabled: true
+  inputs:
+    id: "$.get('id', '')"
+  outputs:
+    entity: "($.get('entities', [{}]) or [{}])[0]"
+    entities: "$.get('entities', [])"
+    count: "len($.get('entities', []))"
+    workflow-status: "len($.get('entities', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: resolve-entity
+      description: Match the id against the canonical _id or any provider_ids across the identity-crosswalk (teams/players/competition) + event stores.
+      condition: "$.get('id', '') != ''"
+      config:
+        action: search
+        search-limit: 10
+        search-vector: false
+      filters:
+        name: {"$in": ["worldcup:identity-crosswalk", "worldcup:event"]}
+        "$or": "[{'value._id': $.get('id')}, {'value.provider_ids.api_football': $.get('id')}, {'value.provider_ids.sportradar': $.get('id')}, {'value.provider_ids.opta': $.get('id')}, {'value.provider_ids.entain': $.get('id')}, {'value.provider_ids.espn': $.get('id')}, {'value.provider_ids.transfermarkt': $.get('id')}]"
+      outputs:
+        entities: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"


### PR DESCRIPTION
Adds `worldcup-resolve` (any provider id / URN → canonical entity + cross-provider ids across crosswalk+event stores) and rewrites `docs/api-contracts.md` to match the live system (player URN, uniform provider_ids, implemented market linking, full read set incl. resolve+movers, freshness tiers, current models, cron schedules). Workflow + doc only — import, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)