### PR TITLE
chore(world-cup): MongoDB indexes + snapshot TTL

### DIFF
--- a/agent-templates/world-cup-intelligence/infrastructure/mongodb/README.md
+++ b/agent-templates/world-cup-intelligence/infrastructure/mongodb/README.md
@@ -1,0 +1,35 @@
+# World Cup Intelligence — MongoDB indexes + TTL
+
+Version-controlled, idempotent index/TTL setup for the pod's `world-cup-2`
+database. Pattern adopted from `entain-templates/infrastructure/mongodb`
+(SportingBOT production).
+
+Run: `./apply.sh` (defaults: namespace `tenant-machina-drops`, db `world-cup-2`,
+shared mongo pod `tenant-machina-drops-databases`, container `mongodb`).
+
+## Why
+The `document` collection (~1,900 docs and growing) had only the default `_id_`
+index — every `search_documents` (resolve, reads, market-movers, market search)
+was a full collection scan. These indexes turn the hot paths into `IXSCAN`.
+
+## Indexes (on `document`, all `name`-prefixed)
+| Index | Serves |
+|-------|--------|
+| `idx_name_value_id` | reads/crosswalk by URN + `^`-anchored `_id` regex |
+| `idx_name_pid_{apifootball,sportradar,opta,entain,espn}` | `worldcup-resolve` (`$or` per provider) + reads |
+| `idx_name_competition_slug` | competition-slug filters |
+| `idx_name_ts` | `worldcup-market-movers` snapshot ts range |
+| `idx_name_related_team_urns` | market → team |
+| `idx_name_event_urn` | market → event |
+
+## TTL
+`ttl_market_snapshot_30d` — **partial** TTL on `created`, scoped to
+`name: "worldcup:market-snapshot"` (30-day retention for the price-history
+time series). Partial scoping is mandatory: the `document` collection is shared,
+so an unscoped TTL would expire identity/event/market docs too.
+
+## Not covered (string timestamps)
+Execution-log collections (`workflow_tasks` ~10k, `workflow_run`, `agent_run`)
+store `timestamp` as a **string**, not a BSON Date, so Mongo TTL cannot apply.
+Retain those via an app-level cleanup (a scheduled workflow that bulk-deletes by
+string timestamp `$lt`) — TODO, not in this script.

--- a/agent-templates/world-cup-intelligence/infrastructure/mongodb/apply.sh
+++ b/agent-templates/world-cup-intelligence/infrastructure/mongodb/apply.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Version-controlled MongoDB indexes + TTL for the World Cup Intelligence pod.
+# Idempotent: createIndex is a no-op when the index already exists.
+# Modeled on entain-templates/infrastructure/mongodb (SportingBOT production).
+#
+# Usage: ./apply.sh [namespace] [db-pod] [database]
+set -euo pipefail
+NS="${1:-tenant-machina-drops}"
+DB="${3:-world-cup-2}"
+POD="${2:-$(kubectl -n "$NS" get pods -o name | grep -m1 -- '-databases' | grep -v world-cup | sed 's#pod/##')}"
+# Default to the shared tenant mongo pod if not given:
+POD="${POD:-$(kubectl -n "$NS" get pods -o name | grep -m1 'tenant-machina-drops-databases' | sed 's#pod/##')}"
+
+echo "namespace=$NS pod=$POD db=$DB"
+
+kubectl -n "$NS" exec "$POD" -c mongodb -- mongosh "$DB" --quiet --eval '
+const r=[];
+function ci(keys,name,opts){ try{ db.document.createIndex(keys, Object.assign({name:name}, opts||{})); r.push("OK   "+name);}catch(e){ r.push("ERR  "+name+": "+e.codeName);} }
+// Performance indexes — every read filters by `name`, so all are name-prefixed.
+ci({name:1,"value._id":1},"idx_name_value_id");                                  // reads/crosswalk by URN (+ ^anchored regex)
+ci({name:1,"value.provider_ids.api_football":1},"idx_name_pid_apifootball");     // resolve + provider_event_id reads
+ci({name:1,"value.provider_ids.sportradar":1},"idx_name_pid_sportradar");        // resolve
+ci({name:1,"value.provider_ids.opta":1},"idx_name_pid_opta");                    // resolve
+ci({name:1,"value.provider_ids.entain":1},"idx_name_pid_entain");                // resolve
+ci({name:1,"value.provider_ids.espn":1},"idx_name_pid_espn");                    // resolve
+ci({name:1,"value.machina_competition_slug":1},"idx_name_competition_slug");     // competition filters
+ci({name:1,"value.ts":1},"idx_name_ts");                                         // market-snapshot movers (ts range)
+ci({name:1,"value.related_team_urns":1},"idx_name_related_team_urns");           // market -> team
+ci({name:1,"value.event_urn":1},"idx_name_event_urn");                           // market -> event
+// TTL (partial): expire ONLY market snapshots older than 30d. The `document`
+// collection is shared across entity types, so the TTL MUST be partial-scoped
+// by name or it would delete identity/event/market docs too. `created` is the
+// BSON Date field on document docs.
+ci({created:1},"ttl_market_snapshot_30d",{expireAfterSeconds:2592000, partialFilterExpression:{name:"worldcup:market-snapshot"}});
+r.forEach(x=>print(x));
+print("total document indexes: "+db.document.getIndexes().length);
+'


### PR DESCRIPTION
Brings over the SportingBOT `infrastructure/mongodb` pattern. The `document` collection had only `_id_` → every `search_documents` was a full scan. Adds 10 name-prefixed perf indexes (URN, the 5 resolve provider_ids, competition slug, snapshot ts, market team/event links) + a partial TTL (`ttl_market_snapshot_30d` on `created`, scoped to `worldcup:market-snapshot`, 30d). Idempotent `apply.sh`. Already applied to the live db; verified IXSCAN on hot paths. Ops scripts (not in _install) — no deploy.

Note: execution-log collections store string timestamps (no BSON Date), so Mongo TTL can't apply there — flagged for an app-level cleanup follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)