### PR TITLE
feat(world-cup): match-phase coverage cadence

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -64,6 +64,10 @@ datasets:
   - type: workflow
     path: workflows/worldcup-get-schedule.yml
   - type: workflow
+    path: workflows/worldcup-coverage-gateway.yml
+  - type: workflow
+    path: workflows/worldcup-refresh-live-status.yml
+  - type: workflow
     path: workflows/worldcup-get-player-performance-context.yml
   - type: workflow
     path: workflows/worldcup-sync-identity-crosswalk.yml

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -27,6 +27,8 @@ build_event_crosswalk = _module.build_event_crosswalk
 link_market_entities = _module.link_market_entities
 build_market_snapshots = _module.build_market_snapshots
 compute_market_movers = _module.compute_market_movers
+compute_coverage_signals = _module.compute_coverage_signals
+apply_live_status = _module.apply_live_status
 
 
 def _kalshi_record(**overrides):
@@ -1196,3 +1198,52 @@ class TestMarketSnapshotsAndMovers:
         markets = [{"cache_id": "new", "title": "N", "source": "kalshi", "outcomes": [{"name": "Yes", "price": 0.5}]}]
         r = compute_market_movers({"params": {"markets": markets, "snapshots": [], "limit": 10}})["data"]
         assert r["movers"] == []
+
+
+class TestCoverageCadence:
+    def _ev(self, urn, start, status="NS", fid=None):
+        d = {"_id": urn, "schema:startDate": start, "sport:status": status}
+        if fid:
+            d["provider_ids"] = {"api_football": fid}
+        return d
+
+    def test_coverage_signals_phases(self):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        iso = lambda dt: dt.isoformat()
+        events = [
+            self._ev("urn:live-window", iso(now - timedelta(minutes=30))),     # kicked off 30m ago → live
+            self._ev("urn:live-status", iso(now - timedelta(hours=5)), "2H"),  # status in-play → live
+            self._ev("urn:upcoming", iso(now + timedelta(hours=2))),           # upcoming 24h
+            self._ev("urn:done", iso(now - timedelta(hours=4))),               # finished window
+            self._ev("urn:far", iso(now + timedelta(days=3))),                 # neither
+        ]
+        r = compute_coverage_signals({"params": {"events": events}})["data"]
+        assert r["has_live"] is True
+        assert set(r["live_event_urns"]) == {"urn:live-window", "urn:live-status"}
+        assert r["live_count"] == 2
+        assert r["upcoming_24h"] == 1
+        assert r["recent_done"] == 1
+
+    def test_coverage_signals_none_live(self):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        events = [self._ev("urn:far", (now + timedelta(days=5)).isoformat())]
+        r = compute_coverage_signals({"params": {"events": events}})["data"]
+        assert r["has_live"] is False and r["live_event_urns"] == []
+
+    def test_apply_live_status_merges_score(self):
+        events = [
+            self._ev("urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor",
+                     "2026-06-20T00:30:00+00:00", "NS", fid="1489389"),
+            self._ev("urn:other", "2026-06-21T00:00:00+00:00", "NS", fid="999"),
+        ]
+        live = {"response": [{"fixture": {"id": 1489389, "status": {"short": "2H", "elapsed": 67}},
+                              "goals": {"home": 2, "away": 0}}]}
+        r = apply_live_status({"params": {"events": events, "live_fixtures": live}})["data"]
+        assert r["count"] == 1
+        d = r["normalized_items"][0]
+        assert d["_id"].endswith("brazil-vs-haiti:20260620:wor")
+        assert d["sport:status"] == "2H"
+        assert d["live_score"] == {"home": 2, "away": 0, "elapsed": 67}
+        assert d["metadata"]["event_urn"].endswith("brazil-vs-haiti:20260620:wor")

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml
@@ -1,0 +1,47 @@
+workflow:
+  name: worldcup-coverage-gateway
+  title: World Cup Intelligence - Coverage Gateway
+  description: |
+    Cheap, API-free phase detector for the match-phase coverage cadence. Reads
+    the event cache and emits signals (has_live, live_event_urns, upcoming_24h,
+    recent_done) so the hot/warm coverage agents only do expensive refreshes
+    when there is something to cover. Live = schedule window [kickoff, +150min]
+    or an in-play sport:status.
+
+  context-variables:
+    debugger:
+      enabled: true
+  outputs:
+    has_live: "$.get('has_live', False)"
+    live_event_urns: "$.get('live_event_urns', [])"
+    live_count: "$.get('live_count', 0)"
+    upcoming_24h: "$.get('upcoming_24h', 0)"
+    recent_done: "$.get('recent_done', 0)"
+    workflow-status: "'executed'"
+  tasks:
+    - type: document
+      name: load-events
+      description: Load event docs (schedule + status) for phase detection.
+      config:
+        action: search
+        search-limit: 500
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+      outputs:
+        events: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: compute-signals
+      description: Derive match-phase signals from the events (no API calls).
+      connector:
+        name: worldcup-market-intelligence
+        command: compute_coverage_signals
+      inputs:
+        events: "$.get('events', [])"
+      outputs:
+        has_live: "$.get('has_live', False)"
+        live_event_urns: "$.get('live_event_urns', [])"
+        live_count: "$.get('live_count', 0)"
+        upcoming_24h: "$.get('upcoming_24h', 0)"
+        recent_done: "$.get('recent_done', 0)"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml
@@ -1,0 +1,73 @@
+workflow:
+  name: worldcup-refresh-live-status
+  title: World Cup Intelligence - Refresh Live Status
+  description: |
+    Refresh in-play fixture status + score onto the cached event docs from
+    api-football live fixtures. Driven by the hot coverage agent during matches
+    so get-event-context / standings reflect live scores between daily ingests.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+  inputs:
+    league: "$.get('league', '1')"
+    season: "$.get('season', '2026')"
+  outputs:
+    updated_count: "len($.get('normalized_items', []))"
+    workflow-status: "len($.get('normalized_items', [])) > 0 and 'executed' or 'skipped'"
+  tasks:
+    - type: connector
+      name: fetch-live-fixtures
+      description: api-football live fixtures for the World Cup league.
+      continue_on_error: true
+      connector:
+        name: api-football
+        command: get-fixtures
+      inputs:
+        league: "$.get('league', '1')"
+        season: "$.get('season', '2026')"
+        live: "'all'"
+      outputs:
+        live_fixtures: "{'response': $.get('response', [])}"
+
+    - type: document
+      name: load-events
+      description: Load event docs to merge live status/score onto.
+      condition: "len(($.get('live_fixtures', {}) or {}).get('response', [])) > 0"
+      config:
+        action: search
+        search-limit: 500
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+      outputs:
+        events: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: apply-live-status
+      description: Merge live status + score onto matching event docs (by fixture id).
+      condition: "len($.get('events', [])) > 0"
+      connector:
+        name: worldcup-market-intelligence
+        command: apply_live_status
+      inputs:
+        events: "$.get('events', [])"
+        live_fixtures: "$.get('live_fixtures', {})"
+      outputs:
+        normalized_items: "$.get('normalized_items', [])"
+
+    - type: document
+      name: save-live-events
+      description: Persist the updated (live) event docs.
+      condition: "len($.get('normalized_items', [])) > 0"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:event'"
+      documents:
+        items: "$.get('normalized_items', [])"
+      inputs:
+        normalized_items: "$.get('normalized_items', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import re
 import unicodedata
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 
@@ -2460,3 +2460,94 @@ def compute_market_movers(request_data: dict[str, Any]) -> dict[str, Any]:
     movers.sort(key=lambda x: x["abs_delta"], reverse=True)
     movers = movers[:limit]
     return {"status": True, "data": {"movers": movers, "count": len(movers)}}
+
+
+# Live status set — fixtures considered in-play for coverage cadence.
+_LIVE_STATUS = {"1H", "HT", "2H", "ET", "BT", "P", "SUSP", "INT", "LIVE"}
+
+
+def compute_coverage_signals(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Match-phase signals from event docs (no API calls) for the coverage cadence.
+
+    Live is detected by the SCHEDULE window [kickoff, kickoff+150min] (robust even
+    when stored sport:status is stale) OR an explicit in-play sport:status.
+
+    Params: events (worldcup:event values)
+    """
+    params = _params(request_data)
+    now = datetime.now(timezone.utc)
+    live: list[str] = []
+    upcoming_24h = 0
+    recent_done = 0
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        urn = _text(_first(ev, "_id", "@id", "id"))
+        sd = _text(ev.get("schema:startDate"))
+        status = _text(ev.get("sport:status")).upper()
+        ko = None
+        if sd:
+            try:
+                ko = datetime.fromisoformat(sd.replace("Z", "+00:00"))
+            except ValueError:
+                ko = None
+            if ko is not None and ko.tzinfo is None:
+                ko = ko.replace(tzinfo=timezone.utc)
+        in_window = ko is not None and ko <= now <= ko + timedelta(minutes=150)
+        if status in _LIVE_STATUS or in_window:
+            live.append(urn)
+        elif ko is not None and now < ko <= now + timedelta(hours=24):
+            upcoming_24h += 1
+        elif ko is not None and ko + timedelta(minutes=150) < now <= ko + timedelta(hours=6):
+            recent_done += 1
+    return {
+        "status": True,
+        "data": {
+            "has_live": len(live) > 0,
+            "live_event_urns": live,
+            "live_count": len(live),
+            "upcoming_24h": upcoming_24h,
+            "recent_done": recent_done,
+        },
+    }
+
+
+def apply_live_status(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Merge live api-football fixture status + score onto matching event docs.
+
+    Params: events (worldcup:event values), live_fixtures (api-football get-fixtures
+    response(s), e.g. live=all). Returns only the events that have a live match,
+    as full docs (status + live_score updated) ready for bulk-update.
+    """
+    params = _params(request_data)
+    by_fid: dict[str, dict[str, Any]] = {}
+    for resp in _flatten_foreach(params.get("live_fixtures")):
+        data = _unwrap(resp)
+        for f in (data.get("response", []) if isinstance(data, dict) else []):
+            if not isinstance(f, dict):
+                continue
+            fixture = f.get("fixture") or {}
+            fid = _text(fixture.get("id"))
+            if not fid:
+                continue
+            goals = f.get("goals") or {}
+            by_fid[fid] = {
+                "status": _text((fixture.get("status") or {}).get("short")),
+                "elapsed": (fixture.get("status") or {}).get("elapsed"),
+                "home": goals.get("home"),
+                "away": goals.get("away"),
+            }
+    out: list[dict[str, Any]] = []
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        fid = _text((ev.get("provider_ids") or {}).get("api_football"))
+        info = by_fid.get(fid)
+        if not info:
+            continue
+        ev.setdefault("metadata", {"event_urn": _text(_first(ev, "_id", "@id", "id"))})
+        if info["status"]:
+            ev["sport:status"] = info["status"]
+        ev["live_score"] = {"home": info["home"], "away": info["away"], "elapsed": info["elapsed"]}
+        out.append(ev)
+    return {"status": True, "data": {"normalized_items": out, "count": len(out)}}

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -48,3 +48,7 @@ connector:
       value: "build_market_snapshots"
     - name: "Compute market movers"
       value: "compute_market_movers"
+    - name: "Compute coverage signals"
+      value: "compute_coverage_signals"
+    - name: "Apply live status"
+      value: "apply_live_status"


### PR DESCRIPTION
Brings over SportingBOT's gateway+hot cadence. `compute_coverage_signals` (API-free phase signals from event schedule) + `worldcup-coverage-gateway`; `apply_live_status` + `worldcup-refresh-live-status` (merge api-football live score/status onto events). A hot cron agent runs gateway → refreshes markets + live status **only when has_live** (fast in-play, cheap otherwise). 101 tests, lint clean. Connector .py → restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)