### PR TITLE
chore(world-cup): execution-log cleanup CronJob

### DIFF
--- a/agent-templates/world-cup-intelligence/infrastructure/mongodb/README.md
+++ b/agent-templates/world-cup-intelligence/infrastructure/mongodb/README.md
@@ -28,8 +28,11 @@ was a full collection scan. These indexes turn the hot paths into `IXSCAN`.
 time series). Partial scoping is mandatory: the `document` collection is shared,
 so an unscoped TTL would expire identity/event/market docs too.
 
-## Not covered (string timestamps)
-Execution-log collections (`workflow_tasks` ~10k, `workflow_run`, `agent_run`)
-store `timestamp` as a **string**, not a BSON Date, so Mongo TTL cannot apply.
-Retain those via an app-level cleanup (a scheduled workflow that bulk-deletes by
-string timestamp `$lt`) — TODO, not in this script.
+## Execution-log retention (CronJob)
+Execution-log collections (`workflow_tasks`, `workflow_run`, `agent_run`) store
+`timestamp` as a **string**, not a BSON Date, so Mongo TTL cannot apply. They are
+pruned by `execution-log-cleanup-cronjob.yaml` — a k8s CronJob (daily 04:30 UTC)
+that runs `mongosh` against the `world-cup-2` db and `deleteMany`s rows older than
+`RETENTION_DAYS` (default 14) via lexicographic ISO-string comparison. The
+doc-store API only reaches the `document` collection, so this is a CronJob rather
+than a workflow. Apply: `kubectl apply -f execution-log-cleanup-cronjob.yaml`.

--- a/agent-templates/world-cup-intelligence/infrastructure/mongodb/execution-log-cleanup-cronjob.yaml
+++ b/agent-templates/world-cup-intelligence/infrastructure/mongodb/execution-log-cleanup-cronjob.yaml
@@ -1,0 +1,55 @@
+# Execution-log retention for the World Cup pod's `world-cup-2` database.
+# The log collections (workflow_tasks / workflow_run / agent_run) store
+# `timestamp` as an ISO STRING (not a BSON Date), so MongoDB TTL cannot apply.
+# This CronJob prunes them by lexicographic ISO-string comparison instead.
+# Scoped to the world-cup-2 db only (the mongo service is shared across tenants).
+#
+# Apply: kubectl apply -f execution-log-cleanup-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: world-cup-2-execution-log-cleanup
+  namespace: tenant-machina-drops
+  labels:
+    app: world-cup-2
+    role: execution-log-cleanup
+spec:
+  schedule: "30 4 * * *"          # daily 04:30 UTC (before the 05:00 fixture ingest)
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: prune
+              image: mongo:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: RETENTION_DAYS
+                  value: "14"
+                - name: MONGO_URI
+                  value: "mongodb://tenant-machina-drops-mongodb:27017/world-cup-2"
+              command: ["mongosh"]
+              args:
+                - "$(MONGO_URI)"
+                - "--quiet"
+                - "--eval"
+                - |
+                  const days = parseInt(process.env.RETENTION_DAYS || '14');
+                  const cutoff = new Date(Date.now() - days*24*3600*1000).toISOString().replace('Z','');
+                  let total = 0;
+                  ['workflow_tasks','workflow_run','agent_run'].forEach(c => {
+                    const r = db[c].deleteMany({timestamp: {$lt: cutoff}});
+                    total += r.deletedCount;
+                    print(c + ': deleted ' + r.deletedCount + ' (timestamp < ' + cutoff + ')');
+                  });
+                  print('total deleted: ' + total);
+              resources:
+                requests: {memory: "64Mi", cpu: "50m"}
+                limits: {memory: "256Mi", cpu: "200m"}


### PR DESCRIPTION
Log collections store ISO-string timestamps (no BSON Date) so Mongo TTL can't apply, and the doc-store API can't reach them. Adds a k8s CronJob (daily 04:30 UTC, mongosh, scoped to world-cup-2) that prunes workflow_tasks/workflow_run/agent_run older than 14d by lexical ISO comparison. Applied + verified via a one-off job. Version-controlled in infrastructure/mongodb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)