### PR TITLE
feat(world-cup): composite Skill cards (Phase 2)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -15,6 +15,7 @@ setup:
     - xAI/Grok fan sentiment and live news pulse.
     - Market edge and arbitrage-candidate analysis for agent workflows.
     - Statistical match forecasts (Dixon-Coles) with model-vs-market gaps + Brier/calibration backtesting.
+    - Composite editorial Skills (match-preview, match-recap, player-spotlight, fan-pulse, market-watch) as TTL-cached cards.
     - Read-only workflows suitable for API/MCP productization.
   integrations:
     - api-football
@@ -27,7 +28,7 @@ setup:
     - pod-document-store
   status: available
   value: agent-templates/world-cup-intelligence
-  version: 0.2.0
+  version: 0.3.0
 
 datasets:
   - type: connector
@@ -99,6 +100,16 @@ datasets:
   - type: workflow
     path: workflows/worldcup-backtest-forecasts.yml
   - type: workflow
+    path: workflows/worldcup-match-preview.yml
+  - type: workflow
+    path: workflows/worldcup-match-recap.yml
+  - type: workflow
+    path: workflows/worldcup-player-spotlight.yml
+  - type: workflow
+    path: workflows/worldcup-fan-pulse.yml
+  - type: workflow
+    path: workflows/worldcup-market-watch.yml
+  - type: workflow
     path: _folders.yml
 
   - type: prompts
@@ -119,6 +130,14 @@ datasets:
     path: prompts/worldcup-fifa-ranking-extract.yml
   - type: prompts
     path: prompts/worldcup-match-forecast-explain.yml
+  - type: prompts
+    path: prompts/worldcup-match-preview.yml
+  - type: prompts
+    path: prompts/worldcup-match-recap.yml
+  - type: prompts
+    path: prompts/worldcup-player-spotlight.yml
+  - type: prompts
+    path: prompts/worldcup-market-watch.yml
 
   - type: mappings
     path: mappings/worldcup-iptc-event-to-api-response.yml

--- a/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/world-cup-intelligence-agent.yml
@@ -103,6 +103,35 @@ agent:
       outputs:
         brief: "$.get('brief', {})"
 
+    - name: worldcup-match-preview
+      description: Composite match-preview card for a fixture (cached, grounded)
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+
+    - name: worldcup-match-recap
+      description: Composite post-match recap card (final fixtures only, cached evergreen)
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+
+    - name: worldcup-player-spotlight
+      description: Composite player-spotlight card (cached, grounded)
+      inputs:
+        player_urn: "$.get('player_urn', '')"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+
+    - name: worldcup-fan-pulse
+      description: Composite fan-pulse card (social/news sentiment, cached)
+      inputs:
+        query: "$.get('query', 'FIFA World Cup')"
+        event_urn: "$.get('event_urn', '')"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+
   instructions: |
     Use match truth from API-Football, IPTC mappings, and provider event URNs before reasoning over markets.
     Use Google GenAI for grounded structured briefs and xAI/Grok for social/news pulse.

--- a/agent-templates/world-cup-intelligence/agents/world-cup-market-analyst-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/world-cup-market-analyst-agent.yml
@@ -40,6 +40,13 @@ agent:
         forecast: "$.get('forecast', {})"
         model_vs_market: "$.get('model_vs_market', {})"
 
+    - name: worldcup-market-watch
+      description: Composite market-watch card — movers + informational edges (cached, read-only)
+      inputs:
+        force_regen: "$.get('force_regen', False)"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+
   instructions: |
     Compare market data across Kalshi and Polymarket using normalized prices, liquidity, volume, and close times.
     Call out candidate price dislocations or arbitrage-style opportunities only as analysis for a human/agent to evaluate independently.

--- a/agent-templates/world-cup-intelligence/docs/api-contracts.md
+++ b/agent-templates/world-cup-intelligence/docs/api-contracts.md
@@ -59,6 +59,15 @@ No secondary ids (team/league/venue) live in `provider_ids` — those are resolv
 - `worldcup-get-match-forecast` — model-implied 1X2/O-U/scoreline probabilities (Dixon-Coles) for one event + the live model-vs-market gap. Informational only.
 - `worldcup-backtest-forecasts` — post-match Brier/calibration audit; publishes the `worldcup:forecast-audit:aggregate` track record (read the aggregate doc to surface accuracy).
 
+**Composite Skills (cached editorial cards)** — each serves a fresh cached candidate (idle cost = one doc search) or authors a new one on a cache miss / `force_regen`, then caches it with a TTL. Output is `skill_card` (the structured `body`) + `served_from` (`cache`|`generated`). All read-only/informational with the standard disclaimer; market-bearing cards keep resolution/liquidity/freshness caveats.
+- `worldcup-match-preview` (`event_urn`) — grounded preview; composes event + grounded news + optional model forecast + market snapshot. TTL 6h (FRESH).
+- `worldcup-match-recap` (`event_urn`) — grounded recap; authored ONLY once `sport:status` ∈ FT/AET/PEN, then cached EVERGREEN (once per match).
+- `worldcup-player-spotlight` (`player_urn`) — grounded player card. TTL 24h.
+- `worldcup-fan-pulse` (`query`/`event_urn`) — wraps `worldcup-fan-sentiment-context` (grok); caches the structured pulse. TTL 1h (HOT_SYNC).
+- `worldcup-market-watch` (global) — composes movers + informational edges into a summary card. TTL ~20min (HOT_SYNC).
+
+Candidate docs live in `worldcup:skill-<skill>` (upsert key `metadata{skill, subject_urn}`; `subject_urn` = event/player URN or `global`). The cron agent `worldcup-content-author` keeps the two global hot cards (market-watch, fan-pulse) warm when matches are live/upcoming; per-event/player cards are authored on first request and served from cache after.
+
 **Agents (conversational)** — `world-cup-intelligence-agent` (full read+market), `world-cup-market-analyst-agent` (market-focused). Activate before exposing.
 
 ## Internal/admin workflow set (cron-driven, not exposed)

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-market-watch.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-market-watch.yml
@@ -1,0 +1,45 @@
+prompts:
+  - type: prompt
+    name: worldcup-market-watch
+    title: World Cup Market Watch
+    description: Author a structured market-watch card summarizing movers and informational edges.
+    instruction: |
+      Write a concise market-watch card from `movers` (biggest recent price moves) and
+      `edge_candidates` (informational dislocations: within-venue book sums, cross-venue
+      draw gaps, and model-vs-market gaps). Summarize what is moving and where venues
+      disagree. Treat every edge strictly as an INFORMATIONAL candidate to investigate —
+      NOT a value bet or recommendation. Never use "guaranteed", "value bet", or "bet this"
+      language; always attach resolution/liquidity/freshness caveats. Use ONLY the supplied
+      data. Always include the disclaimer.
+    schema:
+      title: WorldCupMarketWatch
+      type: object
+      required: [headline, summary, resolution_caveats, disclaimer]
+      properties:
+        headline:
+          type: string
+        summary:
+          type: string
+        top_movers:
+          type: array
+          items:
+            type: object
+        cross_venue_notes:
+          type: array
+          items:
+            type: string
+        edge_hypotheses:
+          type: array
+          items:
+            type: object
+        price_vs_model:
+          type: array
+          items:
+            type: object
+          description: Optional. Model-vs-market gaps when forecasts exist.
+        resolution_caveats:
+          type: array
+          items:
+            type: string
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-match-preview.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-match-preview.yml
@@ -1,0 +1,52 @@
+prompts:
+  - type: prompt
+    name: worldcup-match-preview
+    title: World Cup Match Preview
+    description: Author a structured, grounded match-preview card for a World Cup fixture.
+    instruction: |
+      Write a concise, factual match-preview card for the fixture in `event` (IPTC event
+      doc with competitors, date, venue). Ground it in `research` (grounded web search:
+      team news, form, injuries) and, when present, `forecast` (a form-based statistical
+      model: probabilities + expected goals) and `markets` (current Kalshi/Polymarket
+      prices). Use ONLY facts present in the inputs — never invent stats, lineups, or
+      results. If `forecast` is empty, omit model-probability claims (do not fabricate
+      probabilities). If `markets` is empty, omit the market snapshot. Keep it neutral and
+      informational: this is match intelligence, NOT betting advice. Never use "guaranteed",
+      "value bet", or "bet this" language. Always include the disclaimer.
+    schema:
+      title: WorldCupMatchPreview
+      type: object
+      required: [headline, summary, watch_items, disclaimer]
+      properties:
+        headline:
+          type: string
+        summary:
+          type: string
+        team_form:
+          type: object
+          properties:
+            home:
+              type: string
+            away:
+              type: string
+        key_players:
+          type: array
+          items:
+            type: string
+        tactical_angle:
+          type: string
+        injuries_note:
+          type: string
+        model_forecast:
+          type: object
+          description: Optional. Model-implied probabilities when a forecast exists.
+        market_snapshot:
+          type: array
+          items:
+            type: object
+        watch_items:
+          type: array
+          items:
+            type: string
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-match-recap.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-match-recap.yml
@@ -1,0 +1,44 @@
+prompts:
+  - type: prompt
+    name: worldcup-match-recap
+    title: World Cup Match Recap
+    description: Author a structured, grounded post-match recap card for a finished World Cup fixture.
+    instruction: |
+      Write a factual post-match recap for the FINISHED fixture in `event` (IPTC event doc;
+      `live_score` / `sport:status` show the final result). Ground it in `research`
+      (grounded web search: match report, goals, key moments) and, when present,
+      `forecast` (the pre-match model probabilities, for a "how the model did" scorecard)
+      and `market_move` (how the market priced it). Use ONLY facts present in the inputs —
+      never invent goals, scorers, or events. State the final score from `event.live_score`.
+      If `forecast` is empty, omit the forecast scorecard. Neutral, informational tone —
+      NOT betting advice. Always include the disclaimer.
+    schema:
+      title: WorldCupMatchRecap
+      type: object
+      required: [headline, final_score, summary, disclaimer]
+      properties:
+        headline:
+          type: string
+        final_score:
+          type: string
+        summary:
+          type: string
+        turning_points:
+          type: array
+          items:
+            type: string
+        standout_players:
+          type: array
+          items:
+            type: string
+        what_it_means:
+          type: string
+        forecast_scorecard:
+          type: object
+          description: Optional. Compares the pre-match model probabilities to the result.
+        market_reaction:
+          type: array
+          items:
+            type: object
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/prompts/worldcup-player-spotlight.yml
+++ b/agent-templates/world-cup-intelligence/prompts/worldcup-player-spotlight.yml
@@ -1,0 +1,34 @@
+prompts:
+  - type: prompt
+    name: worldcup-player-spotlight
+    title: World Cup Player Spotlight
+    description: Author a structured, grounded spotlight card for a World Cup player.
+    instruction: |
+      Write a factual spotlight card for the player in `player` (identity-crosswalk doc:
+      name, country/team, provider ids). Ground it in `research` (grounded web search:
+      recent form, role, status) and, when present, `fixture` (their team's next/last
+      fixture context). Use ONLY facts present in the inputs — never invent stats,
+      transfers, or quotes. Neutral, informational tone. Always include the disclaimer.
+    schema:
+      title: WorldCupPlayerSpotlight
+      type: object
+      required: [headline, player_name, narrative, disclaimer]
+      properties:
+        headline:
+          type: string
+        player_name:
+          type: string
+        team:
+          type: string
+        position:
+          type: string
+        narrative:
+          type: string
+        recent_form:
+          type: string
+        performance_signals:
+          type: object
+        fixture_context:
+          type: string
+        disclaimer:
+          type: string

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml
@@ -1,0 +1,80 @@
+workflow:
+  name: worldcup-fan-pulse
+  title: World Cup Intelligence - Fan Pulse (Skill)
+  description: |
+    Composite Skill: a cached fan-pulse card (social/news sentiment). Serves a fresh
+    cached candidate (~1h); otherwise composes worldcup-fan-sentiment-context (grok-4.3
+    live X/web search) and caches the structured pulse. Read-only, informational. Subject
+    is the event_urn when supplied, else a tournament-wide 'global' pulse.
+
+  context-variables:
+    debugger:
+      enabled: true
+  inputs:
+    query: "$.get('query', 'FIFA World Cup')"
+    event_urn: "$.get('event_urn', '')"
+    force_regen: "$.get('force_regen', False)"
+    subject_urn: "$.get('event_urn', '') or 'global'"
+  outputs:
+    skill_card: "$.get('cached', {}).get('body', {}) if $.get('cached') else $.get('pulse_body', {})"
+    served_from: "'cache' if $.get('cached') else 'generated'"
+    workflow-status: "($.get('cached') or $.get('pulse_body', {})) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-cached
+      description: Serve a still-fresh cached fan-pulse card unless force_regen.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:skill-fan-pulse'"
+        value.subject_urn: "$.get('event_urn', '') or 'global'"
+        value.expires_at: "{'$gte': datetime.utcnow().isoformat() + 'Z'}"
+      outputs:
+        cached: "(($.get('documents', []) or [{}])[0].get('value', {})) if not $.get('force_regen', False) else {}"
+
+    - type: workflow
+      name: get-sentiment
+      description: Live social/news sentiment via the fan-sentiment-context workflow (grok).
+      condition: "not $.get('cached')"
+      workflow:
+        name: worldcup-fan-sentiment-context
+      inputs:
+        query: "$.get('query', 'FIFA World Cup')"
+        event_urn: "$.get('event_urn', '')"
+        force_live: true
+      outputs:
+        fan_sentiment: "$.get('fan_sentiment', {})"
+        citations: "$.get('citations', [])"
+
+    - type: document
+      name: save-candidate
+      description: Cache the fan-pulse card (~1h TTL).
+      condition: "not $.get('cached') and $.get('fan_sentiment', {}) != {}"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:skill-fan-pulse'"
+      documents:
+        items: |
+          [{
+            '_id': 'fan-pulse:' + ($.get('event_urn', '') or 'global'),
+            'metadata': {'skill': 'fan-pulse', 'subject_urn': $.get('event_urn', '') or 'global'},
+            'skill': 'fan-pulse',
+            'subject_urn': $.get('event_urn', '') or 'global',
+            'event_urn': $.get('event_urn', ''),
+            'freshness': 'HOT_SYNC',
+            'body': dict($.get('fan_sentiment', {}), citations=$.get('citations', [])),
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'expires_at': (datetime.utcnow() + timedelta(hours=1)).isoformat() + 'Z',
+            'version_control': {'processing': False, 'finished': True, 'source': 'worldcup-fan-pulse'},
+            'disclaimer': 'Informational sports market intelligence only. Not betting, trading, financial, or investment advice.'
+          }]
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+        fan_sentiment: "$.get('fan_sentiment', {})"
+        citations: "$.get('citations', [])"
+      outputs:
+        pulse_body: "dict($.get('fan_sentiment', {}), citations=$.get('citations', []))"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml
@@ -1,0 +1,103 @@
+workflow:
+  name: worldcup-market-watch
+  title: World Cup Intelligence - Market Watch (Skill)
+  description: |
+    Composite Skill: a tournament-wide market-watch card. Serves a cached candidate when
+    fresh (~20 min); otherwise composes the movers + informational edges workflows and
+    authors a summary (gemini-3.5-flash), then caches it. Read-only, informational — every
+    edge is a candidate to investigate, NOT a bet.
+
+  context-variables:
+    debugger:
+      enabled: true
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+  inputs:
+    force_regen: "$.get('force_regen', False)"
+  outputs:
+    skill_card: "$.get('cached', {}).get('body', {}) if $.get('cached') else $.get('market_watch', {})"
+    served_from: "'cache' if $.get('cached') else 'generated'"
+    workflow-status: "($.get('cached') or $.get('market_watch', {})) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-cached
+      description: Serve a still-fresh cached market-watch card unless force_regen.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:skill-market-watch'"
+        value.subject_urn: "'global'"
+        value.expires_at: "{'$gte': datetime.utcnow().isoformat() + 'Z'}"
+      outputs:
+        cached: "(($.get('documents', []) or [{}])[0].get('value', {})) if not $.get('force_regen', False) else {}"
+
+    - type: workflow
+      name: get-movers
+      description: Biggest recent price moves.
+      condition: "not $.get('cached')"
+      workflow:
+        name: worldcup-market-movers
+      inputs:
+        window_hours: 24
+        limit: 15
+      outputs:
+        movers: "$.get('movers', [])"
+
+    - type: workflow
+      name: get-edges
+      description: Informational edge candidates (book-sum, cross-venue, model-vs-market).
+      condition: "not $.get('cached')"
+      workflow:
+        name: worldcup-find-market-edges
+      inputs:
+        min_edge_bps: 150
+        include_reasoning: false
+        limit: 25
+      outputs:
+        edge_candidates: "$.get('edge_candidates', [])"
+
+    - type: prompt
+      name: worldcup-market-watch
+      description: Author the structured market-watch card.
+      condition: "not $.get('cached')"
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-3.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        movers: "$.get('movers', [])"
+        edge_candidates: "$.get('edge_candidates', [])"
+        timeout: 120
+      outputs:
+        market_watch: "$"
+
+    - type: document
+      name: save-candidate
+      description: Cache the market-watch card (~20 min TTL).
+      condition: "not $.get('cached') and $.get('market_watch', {}) != {}"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:skill-market-watch'"
+      documents:
+        items: |
+          [{
+            '_id': 'market-watch:global',
+            'metadata': {'skill': 'market-watch', 'subject_urn': 'global'},
+            'skill': 'market-watch',
+            'subject_urn': 'global',
+            'freshness': 'HOT_SYNC',
+            'body': $.get('market_watch', {}),
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'expires_at': (datetime.utcnow() + timedelta(minutes=20)).isoformat() + 'Z',
+            'version_control': {'processing': False, 'finished': True, 'source': 'worldcup-market-watch'},
+            'disclaimer': 'Informational sports market intelligence only. Not betting, trading, financial, or investment advice.'
+          }]
+      inputs:
+        market_watch: "$.get('market_watch', {})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml
@@ -1,0 +1,148 @@
+workflow:
+  name: worldcup-match-preview
+  title: World Cup Intelligence - Match Preview (Skill)
+  description: |
+    Composite Skill: a grounded, structured match-preview card for a fixture. Serves a
+    cached candidate when one is still fresh (idle cost = one doc search); authors a new
+    one (gemini-3.5-flash over event context + grounded research + optional model forecast
+    + market snapshot) on a cache miss or force_regen, and caches it with a TTL. Read-only,
+    informational — not betting advice.
+
+  context-variables:
+    debugger:
+      enabled: true
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+  inputs:
+    event_urn: "$.get('event_urn', '')"
+    force_regen: "$.get('force_regen', False)"
+  outputs:
+    skill_card: "$.get('cached', {}).get('body', {}) if $.get('cached') else $.get('preview', {})"
+    served_from: "'cache' if $.get('cached') else 'generated'"
+    workflow-status: "($.get('cached') or $.get('preview', {})) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-cached
+      description: Serve a still-fresh cached candidate (skips authoring) unless force_regen.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:skill-match-preview'"
+        value.subject_urn: "$.get('event_urn', '')"
+        value.expires_at: "{'$gte': datetime.utcnow().isoformat() + 'Z'}"
+      outputs:
+        cached: "(($.get('documents', []) or [{}])[0].get('value', {})) if not $.get('force_regen', False) else {}"
+
+    - type: document
+      name: load-event
+      description: Event doc (competitors, date, venue, live status).
+      condition: "not $.get('cached')"
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('event_urn', '')"
+      outputs:
+        event: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: document
+      name: load-forecast
+      description: Optional model forecast for the fixture.
+      condition: "not $.get('cached')"
+      continue_on_error: true
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:model-forecast'"
+        value._id: "$.get('event_urn', '')"
+      outputs:
+        forecast: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: document
+      name: load-markets
+      description: Cached markets linked to the fixture (snapshot for the card).
+      condition: "not $.get('cached')"
+      continue_on_error: true
+      config:
+        action: search
+        search-limit: 50
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+        value.event_urn: "$.get('event_urn', '')"
+      outputs:
+        markets: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: grounded-preview-research
+      description: Grounded team-news/form/injuries research for the fixture.
+      condition: "not $.get('cached') and $.get('event', {}) != {}"
+      continue_on_error: true
+      connector:
+        name: google-genai
+        command: invoke_search
+        model: gemini-3.1-flash-lite
+        location: global
+        provider: vertex_ai
+      inputs:
+        search_query: "$.get('event', {}).get('name', 'FIFA World Cup 2026') + ' match preview team news injuries form lineup'"
+        recency_days: 10
+        timeout: 120
+      outputs:
+        research: "$.get('answer', '')"
+
+    - type: prompt
+      name: worldcup-match-preview
+      description: Author the structured match-preview card.
+      condition: "not $.get('cached') and $.get('event', {}) != {}"
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-3.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        event: "$.get('event', {})"
+        forecast: "$.get('forecast', {})"
+        markets: "$.get('markets', [])"
+        research: "$.get('research', '')"
+        timeout: 120
+      outputs:
+        preview: "$"
+
+    - type: document
+      name: save-candidate
+      description: Cache the authored preview as a TTL candidate (upsert per fixture).
+      condition: "not $.get('cached') and $.get('preview', {}) != {}"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:skill-match-preview'"
+      documents:
+        items: |
+          [{
+            '_id': 'match-preview:' + $.get('event_urn', ''),
+            'metadata': {'skill': 'match-preview', 'subject_urn': $.get('event_urn', '')},
+            'skill': 'match-preview',
+            'subject_urn': $.get('event_urn', ''),
+            'event_urn': $.get('event_urn', ''),
+            'freshness': 'FRESH',
+            'body': $.get('preview', {}),
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'expires_at': (datetime.utcnow() + timedelta(hours=6)).isoformat() + 'Z',
+            'source_freshness': {'model_forecast_available': bool($.get('forecast', {}))},
+            'version_control': {'processing': False, 'finished': True, 'source': 'worldcup-match-preview'},
+            'disclaimer': 'Informational sports market intelligence only. Not betting, trading, financial, or investment advice.'
+          }]
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+        preview: "$.get('preview', {})"
+        forecast: "$.get('forecast', {})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml
@@ -1,0 +1,131 @@
+workflow:
+  name: worldcup-match-recap
+  title: World Cup Intelligence - Match Recap (Skill)
+  description: |
+    Composite Skill: a grounded post-match recap card. Only authors once the fixture is
+    FINAL (sport:status FT/AET/PEN); then caches it EVERGREEN (generated once per match).
+    Serves the cached candidate on subsequent calls. Read-only, informational.
+
+  context-variables:
+    debugger:
+      enabled: true
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+  inputs:
+    event_urn: "$.get('event_urn', '')"
+    force_regen: "$.get('force_regen', False)"
+  outputs:
+    skill_card: "$.get('cached', {}).get('body', {}) if $.get('cached') else $.get('recap', {})"
+    served_from: "'cache' if $.get('cached') else 'generated'"
+    workflow-status: "($.get('cached') or $.get('recap', {})) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-cached
+      description: Serve the cached (evergreen) recap if present, unless force_regen.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:skill-match-recap'"
+        value.subject_urn: "$.get('event_urn', '')"
+        value.expires_at: "{'$gte': datetime.utcnow().isoformat() + 'Z'}"
+      outputs:
+        cached: "(($.get('documents', []) or [{}])[0].get('value', {})) if not $.get('force_regen', False) else {}"
+
+    - type: document
+      name: load-event
+      description: Event doc (final status + score live merged).
+      condition: "not $.get('cached')"
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+        value._id: "$.get('event_urn', '')"
+      outputs:
+        event: "($.get('documents', []) or [{}])[0].get('value', {})"
+        is_final: "($.get('documents', []) or [{}])[0].get('value', {}).get('sport:status') in ('FT', 'AET', 'PEN')"
+
+    - type: document
+      name: load-forecast
+      description: Pre-match model forecast (for the scorecard).
+      condition: "not $.get('cached') and $.get('is_final') is True"
+      continue_on_error: true
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:model-forecast'"
+        value._id: "$.get('event_urn', '')"
+      outputs:
+        forecast: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: connector
+      name: grounded-recap-research
+      description: Grounded match-report research (only when final).
+      condition: "not $.get('cached') and $.get('is_final') is True"
+      continue_on_error: true
+      connector:
+        name: google-genai
+        command: invoke_search
+        model: gemini-3.1-flash-lite
+        location: global
+        provider: vertex_ai
+      inputs:
+        search_query: "$.get('event', {}).get('name', 'FIFA World Cup 2026') + ' result match report goals key moments'"
+        recency_days: 3
+        timeout: 120
+      outputs:
+        research: "$.get('answer', '')"
+
+    - type: prompt
+      name: worldcup-match-recap
+      description: Author the structured recap card (final fixtures only).
+      condition: "not $.get('cached') and $.get('is_final') is True"
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-3.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        event: "$.get('event', {})"
+        forecast: "$.get('forecast', {})"
+        research: "$.get('research', '')"
+        timeout: 120
+      outputs:
+        recap: "$"
+
+    - type: document
+      name: save-candidate
+      description: Cache the recap EVERGREEN (one per match).
+      condition: "not $.get('cached') and $.get('recap', {}) != {}"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:skill-match-recap'"
+      documents:
+        items: |
+          [{
+            '_id': 'match-recap:' + $.get('event_urn', ''),
+            'metadata': {'skill': 'match-recap', 'subject_urn': $.get('event_urn', '')},
+            'skill': 'match-recap',
+            'subject_urn': $.get('event_urn', ''),
+            'event_urn': $.get('event_urn', ''),
+            'freshness': 'EVERGREEN',
+            'body': $.get('recap', {}),
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'expires_at': (datetime.utcnow() + timedelta(days=365)).isoformat() + 'Z',
+            'source_freshness': {'model_forecast_available': bool($.get('forecast', {}))},
+            'version_control': {'processing': False, 'finished': True, 'source': 'worldcup-match-recap'},
+            'disclaimer': 'Informational sports market intelligence only. Not betting, trading, financial, or investment advice.'
+          }]
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+        recap: "$.get('recap', {})"
+        forecast: "$.get('forecast', {})"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml
@@ -1,0 +1,111 @@
+workflow:
+  name: worldcup-player-spotlight
+  title: World Cup Intelligence - Player Spotlight (Skill)
+  description: |
+    Composite Skill: a grounded spotlight card for a player. Serves a cached candidate
+    when fresh; otherwise authors one (gemini-3.5-flash over the player crosswalk doc +
+    grounded form research) and caches it (24h TTL). Read-only, informational.
+
+  context-variables:
+    debugger:
+      enabled: true
+    google-genai:
+      credential: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_CREDENTIAL
+      project_id: $TEMP_CONTEXT_VARIABLE_VERTEX_AI_PROJECT_ID
+  inputs:
+    player_urn: "$.get('player_urn', '')"
+    force_regen: "$.get('force_regen', False)"
+  outputs:
+    skill_card: "$.get('cached', {}).get('body', {}) if $.get('cached') else $.get('spotlight', {})"
+    served_from: "'cache' if $.get('cached') else 'generated'"
+    workflow-status: "($.get('cached') or $.get('spotlight', {})) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-cached
+      description: Serve a still-fresh cached spotlight unless force_regen.
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:skill-player-spotlight'"
+        value.subject_urn: "$.get('player_urn', '')"
+        value.expires_at: "{'$gte': datetime.utcnow().isoformat() + 'Z'}"
+      outputs:
+        cached: "(($.get('documents', []) or [{}])[0].get('value', {})) if not $.get('force_regen', False) else {}"
+
+    - type: document
+      name: load-player
+      description: Player identity-crosswalk doc.
+      condition: "not $.get('cached')"
+      config:
+        action: search
+        search-limit: 1
+        search-vector: false
+      filters:
+        name: "'worldcup:identity-crosswalk'"
+        value._id: "$.get('player_urn', '')"
+      outputs:
+        player: "($.get('documents', []) or [{}])[0].get('value', {})"
+
+    - type: connector
+      name: grounded-player-research
+      description: Grounded recent-form/role/status research for the player.
+      condition: "not $.get('cached') and $.get('player', {}) != {}"
+      continue_on_error: true
+      connector:
+        name: google-genai
+        command: invoke_search
+        model: gemini-3.1-flash-lite
+        location: global
+        provider: vertex_ai
+      inputs:
+        search_query: "$.get('player', {}).get('name', '') + ' ' + $.get('player', {}).get('country', '') + ' footballer recent form World Cup 2026 role status'"
+        recency_days: 21
+        timeout: 120
+      outputs:
+        research: "$.get('answer', '')"
+
+    - type: prompt
+      name: worldcup-player-spotlight
+      description: Author the structured player-spotlight card.
+      condition: "not $.get('cached') and $.get('player', {}) != {}"
+      connector:
+        name: google-genai
+        command: invoke_prompt
+        model: gemini-3.5-flash
+        location: global
+        provider: vertex_ai
+      inputs:
+        player: "$.get('player', {})"
+        research: "$.get('research', '')"
+        timeout: 120
+      outputs:
+        spotlight: "$"
+
+    - type: document
+      name: save-candidate
+      description: Cache the authored spotlight as a 24h TTL candidate.
+      condition: "not $.get('cached') and $.get('spotlight', {}) != {}"
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'worldcup:skill-player-spotlight'"
+      documents:
+        items: |
+          [{
+            '_id': 'player-spotlight:' + $.get('player_urn', ''),
+            'metadata': {'skill': 'player-spotlight', 'subject_urn': $.get('player_urn', '')},
+            'skill': 'player-spotlight',
+            'subject_urn': $.get('player_urn', ''),
+            'freshness': 'FRESH',
+            'body': $.get('spotlight', {}),
+            'generated_at': datetime.utcnow().isoformat() + 'Z',
+            'expires_at': (datetime.utcnow() + timedelta(hours=24)).isoformat() + 'Z',
+            'version_control': {'processing': False, 'finished': True, 'source': 'worldcup-player-spotlight'},
+            'disclaimer': 'Informational sports market intelligence only. Not betting, trading, financial, or investment advice.'
+          }]
+      inputs:
+        player_urn: "$.get('player_urn', '')"
+        spotlight: "$.get('spotlight', {})"


### PR DESCRIPTION
**Phase 2** of the reference-template enhancements (Theme B ← `machina-sports-tv`). Ports the plan→author + TTL-candidate pattern as 5 composite editorial **Skills**. Read-only / informational; Vertex-only.

## Design
Each Skill is a **self-contained get-or-author** workflow: it serves a still-fresh cached candidate (idle cost = one doc search) and only authors (`gemini-3.5-flash`) on a cache miss or `force_regen`, then caches a `worldcup:skill-<skill>` doc (upsert key `metadata{skill, subject_urn}`). No separate gateway needed; **pure YAML + prompts, no connector change** (deploy = import only, no reload).

Output: `skill_card` (the structured `body`) + `served_from` (`cache`|`generated`).

| Skill | Subject | Composes | TTL |
|---|---|---|---|
| `worldcup-match-preview` | event_urn | event + grounded news + optional forecast + market snapshot | 6h |
| `worldcup-match-recap` | event_urn | authored only once `sport:status` ∈ FT/AET/PEN → **EVERGREEN** (once/match) | 365d |
| `worldcup-player-spotlight` | player_urn | player crosswalk + grounded form research | 24h |
| `worldcup-fan-pulse` | query/event_urn | wraps `worldcup-fan-sentiment-context` (grok) | 1h |
| `worldcup-market-watch` | global | composes `worldcup-market-movers` + `worldcup-find-market-edges` | ~20min |

## Guardrails
All cards carry the standard disclaimer; market-bearing cards keep resolution/liquidity/freshness caveats; prompts forbid "guaranteed / value bet / bet this" language and fabricating stats (degrade gracefully when a read or the forecast is missing).

## Wiring
- Registered in `_install.yml` (v0.3.0).
- `world-cup-intelligence-agent` gets preview/recap/spotlight/fan-pulse; `world-cup-market-analyst-agent` gets market-watch.
- Cron agent `worldcup-content-author` (created on the pod) keeps the two global hot cards (market-watch, fan-pulse) warm when matches are live/upcoming; per-event/player cards author on first request and serve from cache after.
- `docs/api-contracts.md` updated with the Skills section.

## Verification
- All new YAML parses; 125 connector tests still pass; `check-no-openai` clean.
- Post-merge: import → spot-check `worldcup-match-preview` (generates+caches, 2nd call serves from cache) + `worldcup-market-watch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)