### PR TITLE
feat(world-cup): countdown-aware prematch staleness + fuzzy market match (Phase 3)

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -36,6 +36,8 @@ compute_model_vs_market_edge = _module.compute_model_vs_market_edge
 compute_forecast_audit = _module.compute_forecast_audit
 detect_market_edges = _module.detect_market_edges
 normalize_fifa_seed = _module.normalize_fifa_seed
+select_prematch_fixtures = _module.select_prematch_fixtures
+_match_team_urns = _module._match_team_urns
 
 
 def _kalshi_record(**overrides):
@@ -1481,6 +1483,73 @@ def test_normalize_fifa_seed_resolves_canonical_urn_from_teams():
                   {"team_name": "Japan", "team_urn": "urn:machina:sport:soccer:team:japan:jpn"}]}})["data"]
     urns = {s["team_name"]: s["team_urn"] for s in r["seed_ratings"]}
     assert urns["South Korea"] == "urn:machina:sport:soccer:team:korea-republic:kor"
+
+
+NOW = "2026-06-13T12:00:00Z"
+
+
+def _ev_pm(urn, start, status="NS", enriched=None):
+    d = {"_id": urn, "schema:startDate": start, "sport:status": status}
+    if enriched:
+        d["prematch_research_at"] = enriched
+    return d
+
+
+class TestSelectPrematchFixtures:
+    def test_finished_and_long_past_excluded(self):
+        events = [
+            _ev_pm("a", "2026-06-13T14:00:00Z"),                 # +2h upcoming
+            _ev_pm("b", "2026-06-12T12:00:00Z", status="FT"),   # finished
+            _ev_pm("c", "2026-06-13T00:00:00Z"),                 # kicked off 12h ago
+        ]
+        r = select_prematch_fixtures({"params": {"events": events, "now_iso": NOW}})["data"]
+        urns = [f["_id"] for f in r["fixtures"]]
+        assert urns == ["a"]
+
+    def test_nearest_kickoff_first(self):
+        events = [
+            _ev_pm("far", "2026-06-20T12:00:00Z"),
+            _ev_pm("near", "2026-06-13T15:00:00Z"),
+            _ev_pm("mid", "2026-06-15T12:00:00Z"),
+        ]
+        r = select_prematch_fixtures({"params": {"events": events, "now_iso": NOW}})["data"]
+        assert [f["_id"] for f in r["fixtures"]] == ["near", "mid", "far"]
+
+    def test_countdown_tier_staleness(self):
+        # Imminent (+2h, <24h tier -> 2h interval): enriched 1h ago = not due; 3h ago = due.
+        fresh = _ev_pm("fresh", "2026-06-13T14:00:00Z", enriched="2026-06-13T11:00:00Z")  # 1h ago
+        stale = _ev_pm("stale", "2026-06-13T14:00:00Z", enriched="2026-06-13T08:00:00Z")  # 4h ago
+        r = select_prematch_fixtures({"params": {"events": [fresh, stale], "now_iso": NOW}})["data"]
+        assert [f["_id"] for f in r["fixtures"]] == ["stale"]
+
+    def test_far_fixture_longer_interval(self):
+        # +8d (>168h tier -> 72h interval): enriched 2 days ago = NOT due.
+        ev = _ev_pm("x", "2026-06-21T12:00:00Z", enriched="2026-06-11T12:00:00Z")
+        r = select_prematch_fixtures({"params": {"events": [ev], "now_iso": NOW}})["data"]
+        assert r["count"] == 0
+
+    def test_force_and_limit(self):
+        events = [_ev_pm(str(i), "2026-06-1%dT12:00:00Z" % (4 + i), enriched=NOW) for i in range(5)]
+        # All enriched "now" -> none due normally; force overrides; limit caps.
+        r = select_prematch_fixtures({"params": {"events": events, "now_iso": NOW, "force": True, "limit": 2}})["data"]
+        assert r["count"] == 2
+
+
+class TestFuzzyTeamMatch:
+    INDEX = [("brazil", "u:bra"), ("morocco", "u:mar"), ("iran", "u:irn"),
+             ("iraq", "u:irq"), ("england", "u:eng"), ("croatia", "u:cro")]
+
+    def test_exact_pair_unchanged(self):
+        assert _match_team_urns("brazil-vs-morocco-winner", self.INDEX) == ["u:bra", "u:mar"]
+
+    def test_iran_does_not_match_iraq(self):
+        # Exact finds iran; fuzzy must NOT add iraq (ratio 0.75 < 0.88).
+        assert _match_team_urns("iran-winner", self.INDEX) == ["u:irn"]
+
+    def test_fuzzy_fills_typo(self):
+        # "ngland" misses exact; fuzzy fills england alongside exact croatia.
+        out = _match_team_urns("ngland-vs-croatia", self.INDEX)
+        assert set(out) == {"u:eng", "u:cro"}
 
 
 def test_build_event_forecasts_skips_unknown_team():

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml
@@ -18,18 +18,31 @@ workflow:
     workflow-status: "len($.get('search_results', [])) > 0 and 'executed' or 'skipped'"
   tasks:
     - type: document
-      name: find-fixtures-for-research
-      description: Find upcoming World Cup fixtures requiring fresh prematch research in same-pod state.
+      name: load-events
+      description: Load all World Cup event docs for countdown-aware staleness selection.
       config:
         action: search
-        search-limit: 10
+        search-limit: 500
         search-vector: false
       filters:
         name: "'worldcup:event'"
         value.machina_competition_slug: "$.get('competition_slug', 'world-cup-2026')"
       outputs:
-        fixtures: "[d.get('value', {}) for d in $.get('documents', [])][:int($.get('limit', 10))]"
-        has_fixtures: "len($.get('documents', [])) > 0"
+        all_events: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: select-fixtures
+      description: Pick fixtures due for enrichment — nearest kickoff first, refresh interval tightens as kickoff nears.
+      connector:
+        name: worldcup-market-intelligence
+        command: select_prematch_fixtures
+      inputs:
+        events: "$.get('all_events', [])"
+        limit: "$.get('limit', 10)"
+        force: "$.get('force', False)"
+      outputs:
+        fixtures: "$.get('fixtures', [])"
+        has_fixtures: "len($.get('fixtures', [])) > 0"
 
     # Grounded Google Search via google-genai invoke_search (sportingbot
     # coverage pattern) — one grounded answer + source links per fixture.
@@ -89,7 +102,8 @@ workflow:
               'prematch_research': next(
                 (r for r in $.get('search_results', []) if isinstance(r, dict) and r.get('research') and f.get('name') and r.get('query', '').startswith(f.get('name'))),
                 f.get('prematch_research', {}) or {}
-              )
+              ),
+              'prematch_research_at': datetime.utcnow().isoformat() + 'Z'
             })
             for f in $.get('fixtures', [])
             if isinstance(f, dict) and f.get('_id')

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -7,6 +7,7 @@ Kalshi/Polymarket market records into a stable shape for API/MCP/x402 exposure.
 
 from __future__ import annotations
 
+import difflib
 import hashlib
 import math
 import re
@@ -2324,11 +2325,43 @@ def _market_team_index(teams: list[Any]) -> list[tuple]:
     return index
 
 
+def _fuzzy_slug_in_text(slug: str, text_slug: str, threshold: float = 0.88) -> bool:
+    """True if `slug` closely matches an n-gram window of the dashed text.
+
+    Conservative (default 0.88) so near-but-distinct nations do NOT cross-match
+    (iran/iraq=0.75, niger/nigeria=0.83) while real typos do (england/ngland=0.92).
+    """
+    words = [w for w in slug.split("-") if w]
+    tokens = [t for t in text_slug.split("-") if t]
+    n = len(words)
+    if n == 0 or len(tokens) < n:
+        return False
+    best = 0.0
+    for i in range(len(tokens) - n + 1):
+        window = "-".join(tokens[i:i + n])
+        ratio = difflib.SequenceMatcher(None, slug, window).ratio()
+        if ratio > best:
+            best = ratio
+    return best >= threshold
+
+
 def _match_team_urns(text_slug: str, index: list[tuple]) -> list[str]:
     found: list[str] = []
+    # Primary: exact, word-boundary substring match (unchanged).
     for slug, urn in index:
         if slug and urn not in found and re.search(r"(^|-)" + re.escape(slug) + r"($|-)", text_slug):
             found.append(urn)
+    # Fallback: only to fill a likely 2-team market the exact pass missed (e.g. a
+    # minor spelling variant not in the alias map). Adds at most up to 2 total,
+    # never removes, so existing exact matches are untouched.
+    if len(found) < 2:
+        for slug, urn in index:
+            if urn in found:
+                continue
+            if _fuzzy_slug_in_text(slug, text_slug):
+                found.append(urn)
+                if len(found) >= 2:
+                    break
     return found
 
 
@@ -3274,3 +3307,72 @@ def compute_forecast_audit(request_data: dict[str, Any]) -> dict[str, Any]:
     if not forecast or hg is None or ag is None:
         return {"status": False, "data": {"error": "single mode needs forecast + actual_result {home_goals, away_goals}"}}
     return {"status": True, "data": {"audit_result": _single_audit(forecast, int(hg), int(ag)), "disclaimer": DISCLAIMER}}
+
+
+# -- Prematch enrichment scheduling ------------------------------------------
+# Countdown-aware refresh tiers: (countdown < N hours) -> refresh every M hours.
+# Closer to kickoff = fresher. Beyond the last tier -> 72h.
+_PREMATCH_TIERS = [(24.0, 2.0), (72.0, 6.0), (168.0, 48.0)]
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def select_prematch_fixtures(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Pick upcoming fixtures due for prematch enrichment, nearest kickoff first.
+
+    Replaces the flat "first N events" selection with a countdown-aware staleness
+    rule: a fixture is due when it has never been enriched OR its last enrichment
+    is older than the tier interval for its kickoff countdown (see _PREMATCH_TIERS).
+    Finished fixtures and those kicked off > 6h ago are skipped.
+
+    Params: events (worldcup:event docs), limit (default 10), force (ignore
+    staleness), now_iso (optional, for testing).
+    """
+    params = _params(request_data)
+    try:
+        limit = max(1, int(params.get("limit") or 10))
+    except (TypeError, ValueError):
+        limit = 10
+    force = bool(params.get("force", False))
+    now = _parse_iso(params.get("now_iso")) or datetime.now(timezone.utc)
+
+    selected: list[tuple[datetime, dict[str, Any]]] = []
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        if _text(ev.get("sport:status")).upper() in _FINAL_STATUS:
+            continue
+        ko = _parse_iso(ev.get("schema:startDate"))
+        if ko is None:
+            continue
+        countdown_h = (ko - now).total_seconds() / 3600.0
+        if countdown_h < -6:  # already kicked off long ago (and not flagged final) — skip
+            continue
+        cd = countdown_h if countdown_h > 0 else 0.0
+        interval_h = 72.0
+        for max_h, iv in _PREMATCH_TIERS:
+            if cd < max_h:
+                interval_h = iv
+                break
+        last = _parse_iso(ev.get("prematch_research_at"))
+        due = force or last is None or (now - last).total_seconds() / 3600.0 >= interval_h
+        if due:
+            selected.append((ko, ev))
+
+    selected.sort(key=lambda x: x[0])
+    fixtures = [ev for _, ev in selected[:limit]]
+    return {
+        "status": True,
+        "data": {"fixtures": fixtures, "count": len(fixtures), "considered": len(_as_list(params.get("events")))},
+    }

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.yml
@@ -64,3 +64,5 @@ connector:
       value: "compute_model_vs_market_edge"
     - name: "Compute forecast audit"
       value: "compute_forecast_audit"
+    - name: "Select prematch fixtures"
+      value: "select_prematch_fixtures"


### PR DESCRIPTION
**Phase 3** — efficiency/quality polish (Theme C ← `semantic-layer-templates`). Read-only; Vertex-only.

## 1. Countdown-aware prematch staleness
`worldcup-refresh-prematch-enrichment` previously loaded just the **first 10 events** every run (flat) — it never prioritized by kickoff, re-hit the same fixtures, and wasted grounded-search calls on far-future/finished games.

New connector `select_prematch_fixtures(events, limit, force, now_iso)`:
- Skips finished (FT/AET/PEN) and long-past (>6h after kickoff) fixtures.
- **Refresh interval tightens as kickoff nears**: `<24h → 2h`, `<72h → 6h`, `<7d → 48h`, else `72h` (vs `prematch_research_at`).
- Returns due fixtures **nearest-kickoff-first**, capped at `limit`.

The workflow now loads all events, selects via the connector, and stamps `prematch_research_at` on save so reruns honor the tiers.

## 2. Fuzzy market↔event match fallback
`_match_team_urns` keeps the exact/alias word-boundary match as primary, then adds a **conservative `difflib` fallback (≥0.88)** that only fills a likely 2-team market the exact pass missed (e.g. a spelling variant not in the alias map). It never removes exact matches and caps at 2 teams. Threshold tuned so near-but-distinct nations **don't** cross-match (iran/iraq=0.75, niger/nigeria=0.83) while real typos do (england/ngland=0.92).

## Verification
- **133 connector tests pass** (8 new: staleness tiers/ordering/finished-exclusion/force/limit; fuzzy iran≠iraq, exact-pair-unchanged, typo-fill).
- `check-no-openai` clean.
- Deferred (plan, low-priority): roster_summary denormalization.

Post-merge: import → reload-connector (`.py` changed) → spot-check `worldcup-refresh-prematch-enrichment` selects nearest fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)