### PR TITLE
fix(world-cup): market data-quality guards + standings third-place split

### DIFF
--- a/agent-templates/world-cup-intelligence/docs/api-contracts.md
+++ b/agent-templates/world-cup-intelligence/docs/api-contracts.md
@@ -155,6 +155,7 @@ Accepts: a machina URN (`urn:machina:…`), a fixture id (`1489389` → the even
   "volume": 10818.56,
   "liquidity": null,
   "spread": null,
+  "price_quality": "ok",
   "competition_urn": "urn:machina:sport:soccer:competition:fifa-world-cup-2026:wor",
   "related_team_urns": ["urn:machina:sport:soccer:team:brazil:bra", "urn:machina:sport:soccer:team:haiti:hti"],
   "event_urn": "urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor",
@@ -164,6 +165,8 @@ Accepts: a machina URN (`urn:machina:…`), a fixture id (`1489389` → the even
 ```
 
 **Market entity linking is implemented**: every cached market carries `competition_urn` (always the canonical WC competition), `related_team_urns` (team-name match against the crosswalk, with nation aliases), and `event_urn` for two-team markets matched to a fixture by team pair. Outright markets (winner/top-scorer/group) have ≤1 team and no `event_urn`.
+
+`price_quality` is `ok` or `unreliable` — a binary market whose two sides don't sum to ~1.0 (thin/stale book, e.g. some illiquid outright series) is flagged `unreliable`; such markets are excluded from `worldcup-market-movers` and `worldcup-find-market-edges` and carry a price caveat. `worldcup-get-standings` returns the 12 real groups in `groups` (`group_count: 12`) and the WC best-third-placed table separately in `third_place_ranking`.
 
 ## `worldcup-search-markets`
 

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1558,3 +1558,52 @@ def test_build_event_forecasts_skips_unknown_team():
         {"@id": "urn:unknown:b", "name": "B", "sport:qualifier": "away"}]}
     r = build_event_forecasts({"params": {"events": [event], "team_index": {}}})["data"]
     assert r["count"] == 0 and "urn:ev:z" in r["skipped"]
+
+
+class TestMarketDataQuality:
+    def test_degenerate_kalshi_outright_flagged(self):
+        # Sparse outright payload (yes_bid 100c / no_bid 98c) -> Yes 1.0 / No 0.98 (sum 1.98).
+        rec = {"ticker": "KXMENWORLDCUP-26-JP", "title": "Will the Japan win the 2026 Men's World Cup?",
+               "event_ticker": "KXMENWORLDCUP-26", "yes_bid": 100, "no_bid": 98, "volume": 123}
+        m = _module._normalize_record("kalshi", rec, "2026-06-06T00:00:00Z")
+        assert m["price_quality"] == "unreliable"
+        assert any("unreliable" in n.lower() for n in m["resolution_risk_notes"])
+
+    def test_normal_binary_ok_and_spread_computed(self):
+        rec = {"ticker": "KXWCGAME-X-ENG", "title": "England vs Croatia Winner?",
+               "yes_sub_title": "England", "yes_bid_dollars": "0.56",
+               "yes_ask_dollars": "0.57", "no_bid_dollars": "0.43"}
+        m = _module._normalize_record("kalshi", rec, "2026-06-06T00:00:00Z")
+        assert m["price_quality"] == "ok"
+        assert m["spread"] == 0.01
+
+    def test_movers_skips_unreliable(self):
+        markets = [
+            {"cache_id": "kalshi:JP", "source": "kalshi", "price_quality": "unreliable",
+             "outcomes": [{"name": "Yes", "price": 1.0}], "title": "Japan win WC"},
+            {"cache_id": "kalshi:G", "source": "kalshi", "price_quality": "ok",
+             "outcomes": [{"name": "Brazil", "price": 0.6}], "title": "Brazil vs X"},
+        ]
+        snaps = [{"cache_id": "kalshi:JP", "ts": "2026-06-06T10:00:00", "primary_price": 0.02},
+                 {"cache_id": "kalshi:G", "ts": "2026-06-06T10:00:00", "primary_price": 0.5}]
+        r = compute_market_movers({"params": {"markets": markets, "snapshots": snaps, "limit": 10}})["data"]
+        cids = [m["cache_id"] for m in r["movers"]]
+        assert "kalshi:JP" not in cids and "kalshi:G" in cids
+
+    def test_edges_exclude_unreliable(self):
+        cached = [{"cache_id": "kalshi:JP", "source": "kalshi", "source_event_id": "KXMENWORLDCUP-26",
+                   "price_quality": "unreliable", "title": "Japan win WC",
+                   "outcomes": [{"name": "Yes", "price": 1.0}]}]
+        r = detect_market_edges({"params": {"cached_markets": cached}})["data"]
+        assert r["count"] == 0
+
+
+def test_standings_separates_third_place_ranking():
+    af = {"response": [{"league": {"standings": [
+        [{"rank": 1, "group": "Group A", "team": {"id": 1, "name": "Mexico"}, "all": {}, "points": 0}],
+        [{"rank": 1, "group": "Ranking of third-placed teams", "team": {"id": 2, "name": "Foo"}, "all": {}, "points": 0}],
+    ]}}]}
+    r = normalize_standings({"params": {"af": af, "league_id": "1", "season": "2026"}})["data"]
+    assert r["group_count"] == 1
+    assert len(r["groups"]) == 1 and r["groups"][0]["group"] == "Group A"
+    assert len(r["third_place_ranking"]) == 1

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -185,6 +185,21 @@ def _polymarket_outcomes(record: dict[str, Any]) -> list[dict[str, Any]]:
     return normalized
 
 
+def _binary_price_quality(outcomes: list[dict[str, Any]]) -> str:
+    """Flag binary markets whose two sides don't sum to ~1.0 as 'unreliable'.
+
+    Thin/stale Kalshi outright series (e.g. KXMENWORLDCUP-26-*) return crossed or
+    placeholder quotes that normalize to e.g. Yes 1.0 / No 0.98 (sum 1.98) — an
+    impossible book. Real binaries sum within a small overround of 1.0.
+    """
+    priced = [o for o in outcomes if isinstance(o, dict) and o.get("price") is not None]
+    if len(priced) == 2:
+        total = _to_float(priced[0].get("price")) + _to_float(priced[1].get("price"))
+        if abs(total - 1.0) > 0.12:
+            return "unreliable"
+    return "ok"
+
+
 def _normalize_record(source: str, record: dict[str, Any], fetched_at: str) -> dict[str, Any] | None:
     if not isinstance(record, dict):
         return None
@@ -213,6 +228,25 @@ def _normalize_record(source: str, record: dict[str, Any], fetched_at: str) -> d
             cache_key = f"{cache_key}:{_text(source_event_id)}"
     cache_id = f"{source}:{cache_key}"
 
+    # Spread fallback: many Kalshi list payloads omit a `spread` field but carry
+    # yes_bid/yes_ask (cents or dollar strings) — derive it.
+    spread = _first(record, "spread", "bid_ask_spread")
+    if spread is None:
+        yes_ask = _normalize_probability(_first(record, "yes_ask", "yes_ask_dollars"))
+        yes_bid = _normalize_probability(_first(record, "yes_bid", "yes_bid_dollars"))
+        if yes_ask is not None and yes_bid is not None:
+            spread = round(abs(yes_ask - yes_bid), 6)
+
+    price_quality = _binary_price_quality(outcomes)
+    notes = [
+        "Read-only market intelligence. Verify provider resolution rules, fees, liquidity, and freshness before acting."
+    ]
+    if price_quality == "unreliable":
+        notes.append(
+            "Quoted prices look unreliable (the two sides don't sum to ~1.0) -- likely a thin or stale book. "
+            "Treat the price as indicative only."
+        )
+
     return {
         # `metadata` is the document-store bulk-update upsert key (the engine
         # filters on {metadata, name}), so re-syncs overwrite the same cache
@@ -229,16 +263,15 @@ def _normalize_record(source: str, record: dict[str, Any], fetched_at: str) -> d
         "status": status,
         "market_type": _text(_first(record, "sports_market_type", "type", "category", "market_type")) or None,
         "outcomes": outcomes,
+        "price_quality": price_quality,
         "volume": _first(record, "volume", "volume_24h", "dollar_volume", "volume_fp"),
         "liquidity": _first(record, "liquidity", "open_interest", "liquidity_dollars", "open_interest_fp"),
-        "spread": _first(record, "spread", "bid_ask_spread"),
+        "spread": spread,
         "start_time": _first(record, "start_date", "start_time", "open_time"),
         "end_time": _first(record, "end_date", "close_time", "expiration_time", "expected_expiration_time"),
         "updated_at": _first(record, "updated_at", "last_update_time", "last_updated") or fetched_at,
         "fetched_at": fetched_at,
-        "resolution_risk_notes": [
-            "Read-only market intelligence. Verify provider resolution rules, fees, liquidity, and freshness before acting."
-        ],
+        "resolution_risk_notes": notes,
         "source_payload_keys": sorted(record.keys()),
     }
 
@@ -598,6 +631,8 @@ def normalize_market_state(request_data: dict[str, Any]) -> dict[str, Any]:
 
     if not market:
         warnings.append("Market not found in cache and no live record returned.")
+    if isinstance(market, dict) and market.get("price_quality") == "unreliable":
+        warnings.append("Quoted prices look unreliable (the two sides don't sum to ~1.0) -- thin/stale book; treat as indicative only.")
     if not book:
         warnings.append("No order-book depth available for this market.")
     if not history:
@@ -669,7 +704,10 @@ def detect_market_edges(request_data):
       - limit: max candidates (default 50)
     """
     params = _params(request_data)
-    cached = [m for m in _as_list(params.get("cached_markets")) if isinstance(m, dict)]
+    # Drop markets with unreliable quotes (thin/stale books) so they can't throw
+    # fake within-venue/cross-venue/model edges.
+    cached = [m for m in _as_list(params.get("cached_markets"))
+              if isinstance(m, dict) and m.get("price_quality") != "unreliable"]
     try:
         min_edge_bps = int(params.get("min_edge_bps") or 50)
     except (TypeError, ValueError):
@@ -979,14 +1017,21 @@ def normalize_standings(request_data: dict[str, Any]) -> dict[str, Any]:
     for grp in groups:
         grp["table"].sort(key=lambda r: (r.get("rank") is None, r.get("rank") or 0))
 
+    # api-football returns the WC "Ranking of third-placed teams" as an extra
+    # standings table; it's not a 13th group. Split it out so group_count is the
+    # real number of groups (12) and the ranking is its own field.
+    real_groups = [g for g in groups if "third" not in _lower(g.get("group"))]
+    third_place = next((g for g in groups if "third" in _lower(g.get("group"))), None)
+
     return {
         "status": True,
         "data": {
             "source": source,
             "season": params.get("season"),
             "league_id": _text(params.get("league_id")) or None,
-            "group_count": len(groups),
-            "groups": groups,
+            "group_count": len(real_groups),
+            "groups": real_groups,
+            "third_place_ranking": (third_place or {}).get("table", []),
             "warnings": warnings,
         },
     }
@@ -2481,6 +2526,10 @@ def compute_market_movers(request_data: dict[str, Any]) -> dict[str, Any]:
     movers: list[dict[str, Any]] = []
     for m in _as_list(params.get("markets")):
         if not isinstance(m, dict):
+            continue
+        # Skip thin/stale books with unreliable quotes (e.g. degenerate outright
+        # series) so they don't surface as fake movers.
+        if m.get("price_quality") == "unreliable":
             continue
         cid = _text(m.get("cache_id") or m.get("id"))
         outs = m.get("outcomes") or []


### PR DESCRIPTION
Three data-quality nits the e2e eval surfaced. All **connector-only** in `worldcup-market-intelligence.py` — `sports-skills` faithfully relays the raw upstream quotes; sanity-guarding them is the intelligence layer's job, so nothing changes in the sports-skills repo.

### 1. Degenerate outright quotes (the real one)
Thin Kalshi tournament-winner markets (`KXMENWORLDCUP-26-*`) return a sparse payload (`yes_bid`/`no_bid` only) that normalized to **Yes 1.0 / No 0.98** (sum 1.98 — impossible), which then drove fake movers (*"Japan → 1.0 / USA → 0.02"*).
- New `_binary_price_quality` → `price_quality: "ok"|"unreliable"` in `_normalize_record` (a binary's two sides must sum within 0.12 of 1.0), with a price caveat appended.
- **Excluded** from `compute_market_movers` and `detect_market_edges`; flagged in `get-market-state` warnings.

### 2. Kalshi spread
Derive `spread` from `yes_bid`/`yes_ask` (cents or dollar strings) when the list payload omits a spread field (Polymarket already populated it).

### 3. Standings third-place table
api-football's *"Ranking of third-placed teams"* was counted as a 13th group. Now split into `third_place_ranking`; `group_count` reports the real **12**.

### Verification
- **138 connector tests pass** (5 new: degenerate flag, normal-binary + spread, movers/edges exclusion, standings split).
- `check-no-openai` clean.
- **Polymarket confirmed fully working** during the eval (102 cached WC markets, clean complementary prices, live CLOB order book + liquidity + last_trade) — no change needed.

Post-merge: import → reload-connector (`.py`) → re-sync market sources so cached docs get `price_quality` → confirm movers no longer show the bogus outright swings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)