### PR TITLE
fix(world-cup): don't snapshot unreliable markets (kills fake movers)

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1597,6 +1597,17 @@ class TestMarketDataQuality:
         r = detect_market_edges({"params": {"cached_markets": cached}})["data"]
         assert r["count"] == 0
 
+    def test_snapshots_skip_unreliable(self):
+        markets = [
+            {"cache_id": "kalshi:JP", "source": "kalshi", "price_quality": "unreliable",
+             "fetched_at": "2026-06-06T20:00:00Z", "outcomes": [{"name": "Yes", "price": 1.0}]},
+            {"cache_id": "kalshi:G", "source": "kalshi", "price_quality": "ok",
+             "fetched_at": "2026-06-06T20:00:00Z", "outcomes": [{"name": "Brazil", "price": 0.6}]},
+        ]
+        r = build_market_snapshots({"params": {"markets": markets}})["data"]
+        cids = [s["cache_id"] for s in r["snapshots"]]
+        assert cids == ["kalshi:G"]
+
 
 def test_standings_separates_third_place_ranking():
     af = {"response": [{"league": {"standings": [

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2466,6 +2466,10 @@ def build_market_snapshots(request_data: dict[str, Any]) -> dict[str, Any]:
     for m in _as_list(params.get("markets")):
         if not isinstance(m, dict):
             continue
+        # Never snapshot an unreliable quote — a degenerate baseline (e.g. a thin
+        # outright series stuck at 1.0) would otherwise produce a fake mover later.
+        if m.get("price_quality") == "unreliable":
+            continue
         cid = _text(m.get("cache_id") or m.get("id"))
         if not cid:
             continue


### PR DESCRIPTION
Follow-up to #263. The movers exclusion only fires when a market's **current** quote is degenerate. A market that was degenerate at an earlier snapshot (recorded at 1.0) but now sums to 1.0 (e.g. the USA outright, now 0.02/0.98) still produced a bogus 1.0→0.02 mover off the polluted baseline. `build_market_snapshots` now **skips unreliable markets**, so no degenerate baseline is ever recorded. Existing polluted snapshots are purged operationally after deploy. 139 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)