### PR TITLE
fix(world-cup): name Kalshi leg outcomes from subtitle/-TIE (unblocks signal + edges)

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1676,3 +1676,31 @@ class TestComputeSignal:
         r = compute_signal({"params": {"forecast": _sig_forecast(), "markets": [_ok("kalshi", "Brazil", 0.50)]}})["data"]
         leg = r["signal"]["legs"][0]
         assert leg["kelly_full"] == round((0.60 - 0.50) / (1 - 0.50), 4)
+
+    def test_signal_buckets_sparse_kalshi_legs(self):
+        # End-to-end: sparse Kalshi legs (team in subtitle, "-TIE" ticker) normalize so
+        # compute_signal buckets home/draw/away by the team-named YES outcome.
+        recs = [
+            {"ticker": "KXWCGAME-X-BRA", "title": "Brazil vs Morocco Winner?", "subtitle": "Brazil", "yes_bid": 50, "no_bid": 49},
+            {"ticker": "KXWCGAME-X-MAR", "title": "Brazil vs Morocco Winner?", "subtitle": "Morocco", "yes_bid": 22, "no_bid": 77},
+            {"ticker": "KXWCGAME-X-TIE", "title": "Brazil vs Morocco Winner?", "yes_bid": 28, "no_bid": 71},
+        ]
+        markets = [_module._normalize_record("kalshi", r, "2026-06-06T00:00:00Z") for r in recs]
+        r = compute_signal({"params": {"forecast": _sig_forecast(), "markets": markets}})["data"]
+        buckets = {l["outcome"]: l["best_price"] for l in r["signal"]["legs"]}
+        assert buckets == {"home_win": 0.50, "away_win": 0.22, "draw": 0.28}
+        assert r["top_pick"]["outcome"] == "home_win"
+
+
+def test_kalshi_sparse_payload_names_team_from_subtitle():
+    rec = {"ticker": "KXWCGAME-26JUN19SCOMAR-MAR", "title": "Scotland vs Morocco Winner?",
+           "subtitle": "Morocco", "yes_bid": 49, "no_bid": 50}
+    m = _module._normalize_record("kalshi", rec, "2026-06-06T00:00:00Z")
+    assert "Morocco" in [o["name"] for o in m["outcomes"]]
+
+
+def test_kalshi_tie_leg_named_tie():
+    rec = {"ticker": "KXWCGAME-26JUN19SCOMAR-TIE", "title": "Scotland vs Morocco Winner?",
+           "yes_bid": 28, "no_bid": 71}
+    m = _module._normalize_record("kalshi", rec, "2026-06-06T00:00:00Z")
+    assert m["outcomes"][0]["name"] == "Tie"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -159,10 +159,14 @@ def _kalshi_outcomes(record: dict[str, Any]) -> list[dict[str, Any]]:
     )
     if no_price is None and yes_price is not None:
         no_price = round(1 - yes_price, 6)
-    # Kalshi binary markets describe the strike via yes_sub_title (e.g.
-    # "Uzbekistan" for "Congo DR vs Uzbekistan Winner?"). no_sub_title repeats
-    # the strike, so the No side keeps its literal name.
-    yes_name = _text(record.get("yes_sub_title")) or "Yes"
+    # Kalshi binary markets name the YES strike via yes_sub_title (e.g.
+    # "Uzbekistan" for "Congo DR vs Uzbekistan Winner?"). The thinner search
+    # payload drops yes_sub_title but carries the same label in `subtitle`; the
+    # tie leg has no team label, so fall back to the ticker suffix (...-TIE).
+    yes_name = _text(record.get("yes_sub_title")) or _text(record.get("subtitle"))
+    if not yes_name:
+        ticker = _lower(_first(record, "ticker", "market_ticker", "market_id", "id"))
+        yes_name = "Tie" if ticker.endswith("-tie") else "Yes"
     results = []
     if yes_price is not None:
         results.append({"name": yes_name, "price": yes_price, "token_id": None, "source_outcome_id": "yes"})


### PR DESCRIPTION
Verification of #265 surfaced this: the current Kalshi game-leg search payload carries **no `outcomes` and no `yes_sub_title`** — only `yes_bid`/`no_bid`, the team in `subtitle` (e.g. "Morocco"), and a `-MAR`/`-SCO`/`-TIE` ticker. `_kalshi_outcomes` named the YES outcome "Yes", so the 1X2 bucket-mapping (which keys on outcome name) failed → `worldcup-get-signal` returned 0 legs and `find-market-edges` model-vs-market silently stopped matching. Fix names the YES outcome `yes_sub_title → subtitle → "Tie" (for -TIE tickers) → "Yes"`. 147 tests pass (incl. an end-to-end sparse-leg signal test). Needs a market re-sync post-deploy to repopulate outcome names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)