### PR TITLE
feat(skills): add world-cup-intelligence skill manifest

### DIFF
--- a/skills/world-cup-intelligence/SKILL.md
+++ b/skills/world-cup-intelligence/SKILL.md
@@ -1,0 +1,111 @@
+# World Cup 2026 Intelligence Skill
+
+This skill organizes and packages the real-time predictive analytics, market data aggregation, and social sentiment indexing capabilities of the FIFA World Cup 2026 pod into a cohesive, SDK-discoverable, and Studio-renderable capability.
+
+## Overview
+
+The `world-cup-intelligence` skill wraps low-level background workflows (ingestion, identity crosswalking, Dixon-Coles model solving) into high-level, client-facing methods exposed via the `@machina-sports/sdk` or the Machina Studio UI.
+
+By bundling these workflows under a unified manifest, we provide Studio operators with real-time "hot cards" (such as Market Watch and Fan Pulse) and conversational agents with verified data retrieval primitives.
+
+---
+
+## Bundled Workflows
+
+This skill exposes three primary executable workflows.
+
+### 1. `worldcup-market-watch`
+
+Generates a tournament-wide, composite market intelligence card showing odds movers, price spreads, and candidate arbitrage edges.
+
+*   **Runtime Semantics:** Serves a cached card unless `force_regen` is true or the cache is older than 20 minutes (TTL).
+*   **Inputs:**
+    *   `force_regen` (boolean, optional): Forces re-execution of the aggregation connectors and Gemini-based summary authoring.
+*   **Outputs:**
+    *   `skill_card` (object): A structured JSON object containing compiled tournament-wide statistics, top movers, and anomalies.
+    *   `served_from` (string): Either `'cache'` or `'generated'`.
+
+### 2. `worldcup-fan-pulse`
+
+Extracts real-time public sentiment, trending news storylines, and fan pulse for either a specific fixture or the tournament globally.
+
+*   **Runtime Semantics:** Relies on xAI Grok search to query the live Web/X index, summarizing results into a structured card. Cache TTL is 1 hour.
+*   **Inputs:**
+    *   `event_urn` (string, optional): The canonical Machina URN of the event (e.g., `urn:machina:sport:soccer:event:123`). If omitted, generates a global tournament pulse.
+    *   `query` (string, optional): Custom search parameters. Defaults to `"FIFA World Cup 2026"`.
+*   **Outputs:**
+    *   `skill_card` (object): The structured pulse card containing sentiment dials, key themes, and source attribution links.
+    *   `served_from` (string): Either `'cache'` or `'generated'`.
+
+### 3. `worldcup-get-signal`
+
+Fuses our proprietary Dixon-Coles mathematical model's probabilities with the best real-time market prices across Kalshi and Polymarket.
+
+*   **Runtime Semantics:** Strictly read-only, informational decision support. Evaluates the model-implied probabilities against the line-shopped price per 1X2 outcome, outputting edge, EV, and Kelly recommendations.
+*   **Inputs:**
+    *   `event_urn` (string, required): The target fixture's URN.
+    *   `bankroll` (string, optional): Simulated bankroll size.
+    *   `kelly_fraction` (number, optional): Kelly criterion scaling factor. Defaults to `0.25` (quarter-Kelly).
+*   **Outputs:**
+    *   `signal` (object): Calculated values per outcome (prob, odds, edge%, EV).
+    *   `recommendation` (string): Standardized plain-text directive (e.g., `"No Edge Found"`, `"Value on Home (Dragons) @ 1.85 (12% Edge)"`).
+    *   `top_pick` (object): The single highest-EV opportunity.
+
+---
+
+## Setup & Execution
+
+### SDK Integration
+
+To call these capabilities programmatically inside a fan app or service:
+
+```typescript
+import { MachinaClient } from "@machina-sports/sdk";
+
+const sdk = new MachinaClient({ token: process.env.MACHINA_API_TOKEN });
+
+// Retrieve the hot tournament-wide market watch card
+const watchCard = await sdk.skills.run("world-cup-intelligence", "worldcup-market-watch");
+console.log(watchCard.skill_card.title); // "World Cup Market Watch"
+```
+
+### CLI Execution
+
+You can run these workflows directly via the Machina CLI:
+
+```bash
+# Force-regenerate the tournament market watch card
+machina workflow run worldcup-market-watch force_regen=true
+
+# Get betting signal for a specific match
+machina workflow run worldcup-get-signal event_urn="urn:machina:sport:soccer:event:6a20c"
+```
+
+---
+
+## Architectural Separation of Duties
+
+To maintain long-term reliability and isolation, the World Cup Pod separates duties into three strict layers:
+
+```
+┌────────────────────────────────────────────────────────┐
+│                      AGENTS LAYER                      │
+│     (Reasoning loops: Copilots, Cron Publishers)        │
+└───────────────────────────┬────────────────────────────┘
+                            │ (chooses / orchestrates)
+                            ▼
+┌────────────────────────────────────────────────────────┐
+│                      SKILLS LAYER                      │
+│        (Discovered capability package: skill.yml)       │
+└───────────────────────────┬────────────────────────────┘
+                            │ (invokes)
+                            ▼
+┌────────────────────────────────────────────────────────┐
+│                    WORKFLOWS LAYER                     │
+│    (programmatic pipelines, model-solvers, ingestion)  │
+└────────────────────────────────────────────────────────┘
+```
+
+1.  **Workflows (programmatic DAGs):** Own raw data movement, calculations, and database state modifications (e.g., `worldcup-ingest-fixtures`, `worldcup-sync-model-forecasts`).
+2.  **Skills (reusable packages):** Bind specific workflows with human-readable guidelines, strict schemas, and UI elements. They are product-facing.
+3.  **Agents (guided personas):** Are non-deterministic reasoning loops that use Skills as tools to fulfill conversational goals.

--- a/skills/world-cup-intelligence/SKILL.md
+++ b/skills/world-cup-intelligence/SKILL.md
@@ -31,7 +31,7 @@ Extracts real-time public sentiment, trending news storylines, and fan pulse for
 
 *   **Runtime Semantics:** Relies on xAI Grok search to query the live Web/X index, summarizing results into a structured card. Cache TTL is 1 hour.
 *   **Inputs:**
-    *   `event_urn` (string, optional): The canonical Machina URN of the event (e.g., `urn:machina:sport:soccer:event:123`). If omitted, generates a global tournament pulse.
+    *   `event_urn` (string, optional): The canonical Machina URN of the event (e.g., `urn:machina:sport:soccer:event:scotland-vs-morocco:20260619:wor`). If omitted, generates a global tournament pulse.
     *   `query` (string, optional): Custom search parameters. Defaults to `"FIFA World Cup 2026"`.
 *   **Outputs:**
     *   `skill_card` (object): The structured pulse card containing sentiment dials, key themes, and source attribution links.
@@ -43,13 +43,15 @@ Fuses our proprietary Dixon-Coles mathematical model's probabilities with the be
 
 *   **Runtime Semantics:** Strictly read-only, informational decision support. Evaluates the model-implied probabilities against the line-shopped price per 1X2 outcome, outputting edge, EV, and Kelly recommendations.
 *   **Inputs:**
-    *   `event_urn` (string, required): The target fixture's URN.
-    *   `bankroll` (string, optional): Simulated bankroll size.
+    *   `event_urn` (string, required): The target fixture's URN (e.g., `urn:machina:sport:soccer:event:scotland-vs-morocco:20260619:wor`).
+    *   `bankroll` (string, optional): Simulated bankroll size; when supplied, each leg also returns a `stake_amount`.
     *   `kelly_fraction` (number, optional): Kelly criterion scaling factor. Defaults to `0.25` (quarter-Kelly).
+    *   `min_edge_bps` (number, optional): Minimum net edge (basis points) for a leg to be flagged as value. Defaults to `200` (2%).
+    *   `fee_bps` (number, optional): Venue fee/slippage in basis points; edge, EV, and Kelly are computed net of it. Defaults to `0`.
 *   **Outputs:**
-    *   `signal` (object): Calculated values per outcome (prob, odds, edge%, EV).
-    *   `recommendation` (string): Standardized plain-text directive (e.g., `"No Edge Found"`, `"Value on Home (Dragons) @ 1.85 (12% Edge)"`).
-    *   `top_pick` (object): The single highest-EV opportunity.
+    *   `signal` (object): Per outcome — `model_prob`, fair odds (`fair_decimal`/`fair_american`), `best_price`+`best_venue`, `edge`/`edge_pct`, `ev_per_dollar`, `kelly_full`+`kelly_stake`, `confidence_tier`, and `risk_flags`.
+    *   `recommendation` (string): Standardized plain-text directive — e.g. `"No actionable edge -- model and market broadly agree; pass."` or `"Value: back Draw at kalshi @0.28 -- model 35% vs market 28%, edge 7.1%, suggested stake 2.46% of bankroll (quarter-Kelly). Model confidence: low."`
+    *   `top_pick` (object): The single highest-EV value leg (suppressed when flagged `edge_likely_model_noise`).
 
 ---
 
@@ -78,7 +80,7 @@ You can run these workflows directly via the Machina CLI:
 machina workflow run worldcup-market-watch force_regen=true
 
 # Get betting signal for a specific match
-machina workflow run worldcup-get-signal event_urn="urn:machina:sport:soccer:event:6a20c"
+machina workflow run worldcup-get-signal event_urn="urn:machina:sport:soccer:event:scotland-vs-morocco:20260619:wor"
 ```
 
 ---

--- a/skills/world-cup-intelligence/_install.yml
+++ b/skills/world-cup-intelligence/_install.yml
@@ -1,0 +1,12 @@
+setup:
+  title: "World Cup 2026 Intelligence"
+  description: "Fuses predictive modeling, real-time betting lines, and social sentiment into high-value market insights for the FIFA World Cup 2026."
+  category:
+    - sports-intelligence
+  status: available
+  value: "skills/world-cup-intelligence"
+  version: 1.1.0
+
+datasets:
+  - type: "skill"
+    path: "skill.yml"

--- a/skills/world-cup-intelligence/skill.yml
+++ b/skills/world-cup-intelligence/skill.yml
@@ -9,12 +9,6 @@ skill:
   status: "available"
   domain: "https://github.com/machina-sports/machina-templates"
 
-  manifest_version: "1.1"
-  visibility: "public"
-  tier: "free"
-  install_mode: "hybrid"
-  runtime: "client-api"
-
   references:
     - name: "skill-guide"
       title: "World Cup Intelligence Guide"
@@ -46,24 +40,9 @@ skill:
         event_urn: "$.get('event_urn', '')"
         bankroll: "$.get('bankroll', '')"
         kelly_fraction: "$.get('kelly_fraction', 0.25)"
+        min_edge_bps: "$.get('min_edge_bps', 200)"
+        fee_bps: "$.get('fee_bps', 0)"
       outputs:
         signal: "$.get('signal', {})"
         recommendation: "$.get('recommendation', '')"
         top_pick: "$.get('top_pick', {})"
-
-  agents:
-    - name: "world-cup-intelligence-agent"
-      description: "Read-only assistant for semantic fixture, market search, and grounded briefs."
-
-  dependencies:
-    connectors:
-      - "worldcup-market-intelligence"
-      - "google-genai"
-      - "sports-skills"
-    workflows:
-      - "worldcup-market-watch"
-      - "worldcup-fan-pulse"
-      - "worldcup-get-signal"
-      - "worldcup-sync-market-sources"
-      - "worldcup-sync-model-forecasts"
-      - "worldcup-log-signals"

--- a/skills/world-cup-intelligence/skill.yml
+++ b/skills/world-cup-intelligence/skill.yml
@@ -1,0 +1,69 @@
+skill:
+  name: "world-cup-intelligence"
+  title: "World Cup 2026 Intelligence"
+  description: "Fuses predictive modeling, real-time betting lines, and social sentiment into high-value market insights for the FIFA World Cup 2026."
+  version: "1.1.0"
+  category:
+    - "sports-intelligence"
+    - "trading"
+  status: "available"
+  domain: "https://github.com/machina-sports/machina-templates"
+
+  manifest_version: "1.1"
+  visibility: "public"
+  tier: "free"
+  install_mode: "hybrid"
+  runtime: "client-api"
+
+  references:
+    - name: "skill-guide"
+      title: "World Cup Intelligence Guide"
+      filename: "SKILL.md"
+      filetype: "markdown"
+      metadata:
+        category: "skill-guide"
+        skill: "world-cup-intelligence"
+
+  workflows:
+    - name: "worldcup-market-watch"
+      description: "Generates the global tournament market watch card showing movers and informational edges."
+      inputs:
+        force_regen: "$.get('force_regen', False)"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+        served_from: "$.get('served_from')"
+    - name: "worldcup-fan-pulse"
+      description: "Extracts social and web search sentiment pulse for the tournament or a specific fixture."
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+        query: "$.get('query', 'FIFA World Cup 2026')"
+      outputs:
+        skill_card: "$.get('skill_card', {})"
+        served_from: "$.get('served_from')"
+    - name: "worldcup-get-signal"
+      description: "Calculates the Dixon-Coles model betting signal and fractional Kelly stake for a fixture."
+      inputs:
+        event_urn: "$.get('event_urn', '')"
+        bankroll: "$.get('bankroll', '')"
+        kelly_fraction: "$.get('kelly_fraction', 0.25)"
+      outputs:
+        signal: "$.get('signal', {})"
+        recommendation: "$.get('recommendation', '')"
+        top_pick: "$.get('top_pick', {})"
+
+  agents:
+    - name: "world-cup-intelligence-agent"
+      description: "Read-only assistant for semantic fixture, market search, and grounded briefs."
+
+  dependencies:
+    connectors:
+      - "worldcup-market-intelligence"
+      - "google-genai"
+      - "sports-skills"
+    workflows:
+      - "worldcup-market-watch"
+      - "worldcup-fan-pulse"
+      - "worldcup-get-signal"
+      - "worldcup-sync-market-sources"
+      - "worldcup-sync-model-forecasts"
+      - "worldcup-log-signals"


### PR DESCRIPTION
### Summary
This PR introduces the formal **World Cup 2026 Intelligence Skill** under . 

This packages the existing predictive analytics, real-time betting lines, and social sentiment indexing workflows of the World Cup pod into a structured, SDK-discoverable, and Studio-renderable capability.

### What is Added
1. **`skills/world-cup-intelligence/_install.yml`**: Defines installer metadata and catalog category. Standardized to install the dataset type `skill`.
2. **`skills/world-cup-intelligence/skill.yml`**: A v1.1 compatible skill manifest that binds execution entrypoints (`worldcup-market-watch`, `worldcup-fan-pulse`, `worldcup-get-signal`), registers references, and declares organizational dependencies.
3. **`skills/world-cup-intelligence/SKILL.md`**: A comprehensive operator-facing usage and implementation guide detailing runtime semantics, SDK usage, and CLI integration.

### Separation of Duties Architectural Split
* **Workflows (Raw Programmatic Blocks)**: Own state changes, calculations, and data syncs (e.g., `worldcup-ingest-fixtures`, `worldcup-sync-model-forecasts`).
* **Skills (Packaged Capabilities)**: Expose workflows and guides to the client, Studio UI, and  under clear schemas (e.g., `worldcup-market-watch`).
* **Agents (Autonomous Operators)**: Reason over the environment, conversational context, and cron ticks, executing Skills as high-level tools to fulfill goals.

### Compliance
- Checked and validated against `scripts/check-no-openai.sh staged`.
- 100% compliant with the Vertex AI rule — relies solely on `google-genai` and `sports-skills` connectors, with no deprecated OpenAI/GPT patterns.