### PR TITLE
fix(world-cup): finalize stale live fixtures

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -29,6 +29,7 @@ build_market_snapshots = _module.build_market_snapshots
 compute_market_movers = _module.compute_market_movers
 compute_coverage_signals = _module.compute_coverage_signals
 apply_live_status = _module.apply_live_status
+finalize_stale_live_events = getattr(_module, "finalize_stale_live_events", None)
 compute_power_ranking = _module.compute_power_ranking
 compute_match_probabilities = _module.compute_match_probabilities
 build_event_forecasts = _module.build_event_forecasts
@@ -1227,7 +1228,7 @@ class TestCoverageCadence:
         iso = lambda dt: dt.isoformat()
         events = [
             self._ev("urn:live-window", iso(now - timedelta(minutes=30))),     # kicked off 30m ago → live
-            self._ev("urn:live-status", iso(now - timedelta(hours=5)), "2H"),  # status in-play → live
+            self._ev("urn:live-status", iso(now - timedelta(minutes=160)), "ET"),  # explicit in-play → live
             self._ev("urn:upcoming", iso(now + timedelta(hours=2))),           # upcoming 24h
             self._ev("urn:done", iso(now - timedelta(hours=4))),               # finished window
             self._ev("urn:far", iso(now + timedelta(days=3))),                 # neither
@@ -1246,6 +1247,20 @@ class TestCoverageCadence:
         r = compute_coverage_signals({"params": {"events": events}})["data"]
         assert r["has_live"] is False and r["live_event_urns"] == []
 
+    def test_coverage_signals_demotes_stale_regular_time_status(self):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        events = [
+            {
+                **self._ev("urn:stale", (now - timedelta(hours=5)).isoformat(), "2H"),
+                "live_score": {"home": 1, "away": 1, "elapsed": 90},
+            }
+        ]
+        r = compute_coverage_signals({"params": {"events": events}})["data"]
+        assert r["has_live"] is False
+        assert r["live_event_urns"] == []
+        assert r["recent_done"] == 1
+
     def test_apply_live_status_merges_score(self):
         events = [
             self._ev("urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor",
@@ -1261,6 +1276,28 @@ class TestCoverageCadence:
         assert d["sport:status"] == "2H"
         assert d["live_score"] == {"home": 2, "away": 0, "elapsed": 67}
         assert d["metadata"]["event_urn"].endswith("brazil-vs-haiti:20260620:wor")
+
+    def test_finalize_stale_live_events_marks_regular_time_docs_ft(self):
+        assert callable(finalize_stale_live_events)
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        events = [
+            {
+                **self._ev("urn:stale", (now - timedelta(hours=5)).isoformat(), "2H", fid="1489389"),
+                "live_score": {"home": 1, "away": 1, "elapsed": 90},
+            },
+            {
+                **self._ev("urn:extra-time", (now - timedelta(minutes=160)).isoformat(), "ET", fid="1489390"),
+                "live_score": {"home": 1, "away": 1, "elapsed": 105},
+            },
+        ]
+        r = finalize_stale_live_events({"params": {"events": events}})["data"]
+        assert r["count"] == 1
+        d = r["normalized_items"][0]
+        assert d["_id"] == "urn:stale"
+        assert d["sport:status"] == "FT"
+        assert d["live_score"] == {"home": 1, "away": 1}
+        assert d["metadata"]["event_urn"] == "urn:stale"
 
 
 def _ranking(power, gpg=1.4, conf=0.8, source="results"):

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml
@@ -6,7 +6,8 @@ workflow:
     the event cache and emits signals (has_live, live_event_urns, upcoming_24h,
     recent_done) so the hot/warm coverage agents only do expensive refreshes
     when there is something to cover. Live = schedule window [kickoff, +150min]
-    or an in-play sport:status.
+    or an in-play sport:status that has not gone stale after the realistic
+    match window.
 
   context-variables:
     debugger:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml
@@ -3,8 +3,9 @@ workflow:
   title: World Cup Intelligence - Refresh Live Status
   description: |
     Refresh in-play fixture status + score onto the cached event docs from
-    api-football live fixtures. Driven by the hot coverage agent during matches
-    so get-event-context / standings reflect live scores between daily ingests.
+    api-football live fixtures, and finalize stale regular-time docs that got
+    stuck at 90'. Driven by the hot coverage agent during matches so
+    get-event-context / standings reflect live scores between daily ingests.
 
   context-variables:
     debugger:
@@ -15,8 +16,8 @@ workflow:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
   outputs:
-    updated_count: "len($.get('normalized_items', []))"
-    workflow-status: "len($.get('normalized_items', [])) > 0 and 'executed' or 'skipped'"
+    updated_count: "len(($.get('normalized_items', []) or []) + ($.get('stale_final_items', []) or []))"
+    workflow-status: "len(($.get('normalized_items', []) or []) + ($.get('stale_final_items', []) or [])) > 0 and 'executed' or 'skipped'"
   tasks:
     - type: connector
       name: fetch-live-fixtures
@@ -34,8 +35,7 @@ workflow:
 
     - type: document
       name: load-events
-      description: Load event docs to merge live status/score onto.
-      condition: "len(($.get('live_fixtures', {}) or {}).get('response', [])) > 0"
+      description: Load event docs to merge live status/score onto and finalize stale live docs.
       config:
         action: search
         search-limit: 500
@@ -48,7 +48,7 @@ workflow:
     - type: connector
       name: apply-live-status
       description: Merge live status + score onto matching event docs (by fixture id).
-      condition: "len($.get('events', [])) > 0"
+      condition: "len($.get('events', [])) > 0 and len(($.get('live_fixtures', {}) or {}).get('response', [])) > 0"
       connector:
         name: worldcup-market-intelligence
         command: apply_live_status
@@ -58,16 +58,28 @@ workflow:
       outputs:
         normalized_items: "$.get('normalized_items', [])"
 
+    - type: connector
+      name: finalize-stale-live-events
+      description: Mark stale regular-time live docs as full-time.
+      condition: "len($.get('events', [])) > 0"
+      connector:
+        name: worldcup-market-intelligence
+        command: finalize_stale_live_events
+      inputs:
+        events: "$.get('events', [])"
+      outputs:
+        stale_final_items: "$.get('normalized_items', [])"
+
     - type: document
       name: save-live-events
-      description: Persist the updated (live) event docs.
-      condition: "len($.get('normalized_items', [])) > 0"
+      description: Persist the updated live/final event docs.
+      condition: "len(($.get('normalized_items', []) or []) + ($.get('stale_final_items', []) or [])) > 0"
       config:
         action: bulk-update
         embed-vector: false
         force-update: true
       document_name: "'worldcup:event'"
       documents:
-        items: "$.get('normalized_items', [])"
+        items: "($.get('normalized_items', []) or []) + ($.get('stale_final_items', []) or [])"
       inputs:
-        normalized_items: "$.get('normalized_items', [])"
+        normalized_items: "($.get('normalized_items', []) or []) + ($.get('stale_final_items', []) or [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2568,13 +2568,16 @@ def compute_market_movers(request_data: dict[str, Any]) -> dict[str, Any]:
 
 # Live status set — fixtures considered in-play for coverage cadence.
 _LIVE_STATUS = {"1H", "HT", "2H", "ET", "BT", "P", "SUSP", "INT", "LIVE"}
+_FINAL_STATUS = {"FT", "AET", "PEN"}
+_REGULAR_TIME_STALE_STATUSES = {"2H", "LIVE"}
 
 
 def compute_coverage_signals(request_data: dict[str, Any]) -> dict[str, Any]:
     """Match-phase signals from event docs (no API calls) for the coverage cadence.
 
-    Live is detected by the SCHEDULE window [kickoff, kickoff+150min] (robust even
-    when stored sport:status is stale) OR an explicit in-play sport:status.
+    Live is detected by the SCHEDULE window [kickoff, kickoff+150min] plus
+    explicit in-play sport:status for overtime/interruptions. Frozen regular-time
+    provider docs stuck at "2H 90'" are demoted after the realistic live window.
 
     Params: events (worldcup:event values)
     """
@@ -2598,7 +2601,20 @@ def compute_coverage_signals(request_data: dict[str, Any]) -> dict[str, Any]:
             if ko is not None and ko.tzinfo is None:
                 ko = ko.replace(tzinfo=timezone.utc)
         in_window = ko is not None and ko <= now <= ko + timedelta(minutes=150)
-        if status in _LIVE_STATUS or in_window:
+        elapsed = _first(ev.get("live_score") or {}, "elapsed")
+        stale_regular_time = (
+            status in _REGULAR_TIME_STALE_STATUSES
+            and (elapsed is None or (isinstance(elapsed, (int, float)) and elapsed >= 90))
+            and ko is not None
+            and now > ko + timedelta(minutes=150)
+        )
+        explicit_live = (
+            status in _LIVE_STATUS
+            and not stale_regular_time
+            and ko is not None
+            and now <= ko + timedelta(hours=6)
+        )
+        if in_window or explicit_live:
             live.append(urn)
         elif ko is not None and now < ko <= now + timedelta(hours=24):
             upcoming_24h += 1
@@ -2657,6 +2673,46 @@ def apply_live_status(request_data: dict[str, Any]) -> dict[str, Any]:
     return {"status": True, "data": {"normalized_items": out, "count": len(out)}}
 
 
+def finalize_stale_live_events(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Mark stale regular-time live event docs as final.
+
+    Params: events (worldcup:event values). Returns full docs ready for bulk-update.
+    """
+    params = _params(request_data)
+    now = datetime.now(timezone.utc)
+    out: list[dict[str, Any]] = []
+    for ev in _as_list(params.get("events")):
+        if not isinstance(ev, dict):
+            continue
+        status = _text(ev.get("sport:status")).upper()
+        if status not in _REGULAR_TIME_STALE_STATUSES:
+            continue
+        ko = None
+        sd = _text(ev.get("schema:startDate"))
+        if sd:
+            try:
+                ko = datetime.fromisoformat(sd.replace("Z", "+00:00"))
+            except ValueError:
+                ko = None
+            if ko is not None and ko.tzinfo is None:
+                ko = ko.replace(tzinfo=timezone.utc)
+        elapsed = _first(ev.get("live_score") or {}, "elapsed")
+        is_stale = (
+            ko is not None
+            and now > ko + timedelta(minutes=150)
+            and (elapsed is None or (isinstance(elapsed, (int, float)) and elapsed >= 90))
+        )
+        if not is_stale:
+            continue
+        next_ev = dict(ev)
+        next_ev["sport:status"] = "FT"
+        score = next_ev.get("live_score") if isinstance(next_ev.get("live_score"), dict) else {}
+        next_ev["live_score"] = {k: score.get(k) for k in ("home", "away") if score.get(k) is not None}
+        next_ev.setdefault("metadata", {"event_urn": _text(_first(next_ev, "_id", "@id", "id"))})
+        out.append(next_ev)
+    return {"status": True, "data": {"normalized_items": out, "count": len(out)}}
+
+
 # -- Quantitative forecast layer ---------------------------------------------
 # Pure-stdlib, deterministic statistical models. Read-only and INFORMATIONAL:
 # probabilities are form-based estimates, gaps are not value/bet signals.
@@ -2673,7 +2729,6 @@ GAP_CAVEATS = [
     "Gap is informational only, not a value or bet signal.",
     "Fee-, liquidity-, and resolution-rule-blind. Verify settlement terms before acting.",
 ]
-_FINAL_STATUS = {"FT", "AET", "PEN"}
 _DEFAULT_RANK_WEIGHTS = {
     "outcome": 0.40, "attack": 0.32, "defense": 0.28,
     "win_rate": 0.60, "points_per_game": 0.40,


### PR DESCRIPTION
## Summary
- Stop stale regular-time World Cup event docs from keeping coverage in `has_live` after the realistic live window.
- Add a refresh finalizer that persists frozen `2H`/`LIVE` 90' docs as `FT` while preserving final score.
- Cover stale coverage and finalization behavior with connector regressions.

## Test plan
- `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py`
- YAML parse check for `worldcup-coverage-gateway.yml` and `worldcup-refresh-live-status.yml`


Made with [Cursor](https://cursor.com)