### PR TITLE
fix(worldcup): register hot market refresh agents

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -29,7 +29,7 @@ setup:
     - pod-document-store
   status: available
   value: agent-templates/world-cup-intelligence
-  version: 0.5.0
+  version: 0.5.1
 
 datasets:
   - type: connector
@@ -41,6 +41,10 @@ datasets:
     path: agents/world-cup-market-analyst-agent.yml
   - type: agent
     path: agents/worldcup-market-sync-agent.yml
+  - type: agent
+    path: agents/worldcup-coverage-hot-agent.yml
+  - type: agent
+    path: agents/worldcup-content-author-agent.yml
 
   - type: workflow
     path: workflows/worldcup-health.yml

--- a/agent-templates/world-cup-intelligence/agents/worldcup-content-author-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/worldcup-content-author-agent.yml
@@ -1,0 +1,54 @@
+agent:
+  name: worldcup-content-author
+  title: World Cup · Content Author · Hot
+  description: >
+    Every 15 minutes: run the coverage gateway, refresh the market cache when no
+    match is live, and refresh global hot Skill cards when matches are live,
+    within 24h, or recently finished. Cheap (gateway only) otherwise.
+  status: active
+
+  jobs:
+    - name: tick
+      type: agent
+      target: worldcup-content-author
+      cron: "*/15 * * * *"
+      enabled: true
+
+  context: {}
+  context-variables: {}
+
+  workflows:
+    - name: worldcup-coverage-gateway
+      inputs: {}
+      outputs:
+        has_live: "$.get('has_live')"
+        recent_done: "$.get('recent_done')"
+        upcoming_24h: "$.get('upcoming_24h')"
+
+    - name: worldcup-sync-market-sources
+      condition: "$.get('has_live') is not True"
+      inputs:
+        # LITERALS on purpose: workflow inputs are expression-evaluated.
+        # Bare strings like "FIFA World Cup" / "open" are invalid expressions
+        # and make the market-cache warm path fail or skip stale.
+        query: "'FIFA World Cup'"
+        status: "'open'"
+        limit: 400
+      outputs:
+        markets_count: "$.get('markets_count')"
+        warnings: "$.get('warnings')"
+
+    - name: worldcup-market-watch
+      condition: "$.get('has_live') is True or $.get('upcoming_24h', 0) > 0 or $.get('recent_done', 0) > 0"
+      inputs:
+        force_regen: true
+      outputs:
+        served_from: "$.get('served_from')"
+
+    - name: worldcup-fan-pulse
+      condition: "$.get('has_live') is True or $.get('upcoming_24h', 0) > 0 or $.get('recent_done', 0) > 0"
+      inputs:
+        force_regen: true
+        query: "''"
+      outputs:
+        served_from: "$.get('served_from')"

--- a/agent-templates/world-cup-intelligence/agents/worldcup-coverage-hot-agent.yml
+++ b/agent-templates/world-cup-intelligence/agents/worldcup-coverage-hot-agent.yml
@@ -1,0 +1,45 @@
+agent:
+  name: worldcup-coverage-hot
+  title: World Cup · Coverage · Hot (Live)
+  description: >
+    Every 2 minutes: run the coverage gateway, then refresh markets and live
+    status only when matches are in-play. Cheap (gateway only) when nothing is
+    live.
+  status: active
+
+  jobs:
+    - name: tick
+      type: agent
+      target: worldcup-coverage-hot
+      cron: "*/2 * * * *"
+      enabled: true
+
+  context: {}
+  context-variables: {}
+
+  workflows:
+    - name: worldcup-coverage-gateway
+      inputs: {}
+      outputs:
+        has_live: "$.get('has_live')"
+        live_count: "$.get('live_count')"
+
+    - name: worldcup-sync-market-sources
+      condition: "$.get('has_live') is True"
+      inputs:
+        # LITERALS on purpose: workflow inputs are expression-evaluated.
+        # Bare strings like "FIFA World Cup" / "open" are invalid expressions
+        # and break the live market-refresh path during in-play windows.
+        query: "'FIFA World Cup'"
+        status: "'open'"
+        limit: 250
+      outputs:
+        markets_count: "$.get('markets_count')"
+
+    - name: worldcup-refresh-live-status
+      condition: "$.get('has_live') is True"
+      inputs:
+        league: "1"
+        season: "2026"
+      outputs:
+        updated_count: "$.get('updated_count')"


### PR DESCRIPTION
## Summary
- Add template-managed hot coverage and content author agents for World Cup market refreshes
- Use expression-safe string literals for market-source query/status inputs
- Register the agents in the World Cup Intelligence install manifest and bump the template version

## Test Plan
- python3 YAML parse check for World Cup template files
- ./scripts/check-no-openai.sh staged
- python3 -m py_compile agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
- git diff --cached --check

Note: python3 -m pytest agent-templates/world-cup-intelligence/tests -q could not run locally because pytest is not installed in the system Python.