### PR TITLE
fix(betting-copilot): Kalshi market reads are keyless

### DIFF
--- a/agent-templates/betting-copilot/agent.yml
+++ b/agent-templates/betting-copilot/agent.yml
@@ -6,7 +6,10 @@ agent:
   entry-point: "betting-copilot-workflow"
   context-variables:
     kalshi:
-      bearerAuth: "$TEMP_CONTEXT_VARIABLE_KALSHI_API_KEY"
+      # Public Kalshi market data (events/markets) is keyless — no token
+      # needed for reads. A key is only required for trading/portfolio,
+      # which this agent never does.
+      bearerAuth: ""
     polymarket:
       # No API key needed for public endpoints
       bearerAuth: ""

--- a/agent-templates/betting-copilot/connectors/kalshi.yml
+++ b/agent-templates/betting-copilot/connectors/kalshi.yml
@@ -9,13 +9,8 @@ connector:
       version: "v2"
     servers:
       - url: "https://trading-api.kalshi.com/v2"
-    security:
-      - bearerAuth: []
-    components:
-      securitySchemes:
-        bearerAuth:
-          type: http
-          scheme: Bearer
+    # Public market data (events/markets) is keyless — no security scheme.
+    # Trading/portfolio endpoints would need a key, but this agent only reads.
     paths:
       /events:
         get:


### PR DESCRIPTION
## What

Deploying the **betting-copilot** agent-template demanded a `KALSHI_API_KEY` that doesn't exist for its use case.

Kalshi **public market data** (`/events`, `/markets`) is **keyless** — a key is only needed for trading/portfolio, which this agent never does. But the template declared `security: [bearerAuth]` on the Kalshi connector and wired `kalshi.bearerAuth: $TEMP_CONTEXT_VARIABLE_KALSHI_API_KEY` in `agent.yml`, so the Factory credential pre-flight asked the customer for a nonexistent key.

## Fix

Mirror Polymarket (already `bearerAuth: ""`):
- `agent.yml` → `kalshi.bearerAuth: ""`
- `connectors/kalshi.yml` → drop the `security: [bearerAuth]` requirement

## Paired change

A Factory-agent fix makes the secrets pre-flight robust in general (keyless connectors are never flagged; `check_secrets` "not found" = absent, not a failure; trust pod/claw-provisioned secrets): machina-sports/machina-factory-customer#163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
