### PR TITLE
fix(worldcup): ingest captures fixture score (live_score) for played matches

### DIFF
--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2061,6 +2061,21 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
             },
             "machina_competition_slug": comp_slug,
         }
+        # Capture the SCORE from the fixture goals. api-football's get-fixtures
+        # returns goals for in-play AND finished fixtures; without this the daily
+        # ingest wrote sport:status=FT but NO live_score, so finished matches
+        # looked score-less downstream (only the live=all refresh ever set a
+        # score, so a match never seen in-play stayed scoreless — and its
+        # scoreless ingest doc competed with the live-captured one). Only set
+        # when both goals are present (unplayed NS fixtures have null goals).
+        goals = f.get("goals") if isinstance(f.get("goals"), dict) else {}
+        gh, ga = goals.get("home"), goals.get("away")
+        if gh is not None and ga is not None:
+            doc["live_score"] = {
+                "home": gh,
+                "away": ga,
+                "elapsed": (fixture.get("status") or {}).get("elapsed"),
+            }
         for k, v in carry.get(fixture_id, {}).items():
             doc["provider_ids"].setdefault(k, v)
         events.append(doc)


### PR DESCRIPTION
## Why

The world-cup-mcp `worldcup:event` feed was missing scores: **29 of 31 FT fixtures had no `live_score`**, and there was a duplicate `canada-vs-qatar` doc (one scored 6-0 from the live refresh, one scoreless from the daily ingest).

`mint_event_identity` (the daily ingest, `worldcup-ingest-fixtures`) set `sport:status` — including `FT` — but **discarded the fixture's `goals`**. The only writer that ever set `live_score` was `apply_live_status`, which fetches `live=all` (in-play only). So any match not captured *during* play finished score-less, and its scoreless ingest doc competed with the live-captured one.

This starved the downstream SportsClaw TV truth guard, which then flagged a **correct** broadcast (Canada 6-0 Qatar, David hat trick) as a fabricated scoreline.

## What

In `mint_event_identity`, capture `goals → live_score` when both goals are present (api-football returns `goals` for in-play and finished fixtures; unplayed `NS` fixtures have null goals and are left unset). The ingest doc now carries the real final score, so:
- finished matches are no longer score-less, and
- the ingest stops writing a competing scoreless doc for live-captured fixtures.

Additive + low-risk: only adds a `live_score` field when goals exist.

## Deploy / verify
- Merge + re-import the template to the world-cup-mcp pod, then run `worldcup-ingest-fixtures` once to backfill final scores across all played fixtures.
- Verify: `worldcup:event` FT docs carry `live_score`, and no duplicate URNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)