### PR TITLE
fix(worldcup): sync-model-forecasts honors min_games=8 (completes #277)

### DIFF
--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml
@@ -16,7 +16,7 @@ workflow:
   inputs:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
-    min_games_full_confidence: "$.get('min_games_full_confidence', 5)"
+    min_games_full_confidence: "$.get('min_games_full_confidence', 8)"
   outputs:
     forecasts_count: "len($.get('forecasts', []))"
     field_size: "$.get('field_size', 0)"
@@ -56,7 +56,7 @@ workflow:
       inputs:
         finished_fixtures: "$.get('finished_fixtures', [])"
         seed_ratings: "$.get('seed_ratings', [])"
-        min_games_full_confidence: "$.get('min_games_full_confidence', 5)"
+        min_games_full_confidence: "$.get('min_games_full_confidence', 8)"
       outputs:
         team_index: "$.get('team_index', {})"
         field_size: "$.get('field_size', 0)"


### PR DESCRIPTION
## Why

PR #277 raised `compute_power_ranking`'s default `min_games_full_confidence` **5 → 8** so a proven-elite side stays anchored to its FIFA seed through the group stage (a 48-team WC side plays ~3 games; 2-3 noisy early results shouldn't override a strong prior).

But `worldcup-sync-model-forecasts.yml` **hardcodes `5`** and passes it explicitly to the connector, overriding the new function default. So the daily forecast cadence kept running at 5 — **#277's `min_games` bump never reached production** (only its attack/defense seed-blend did).

## What

Align the workflow's two `min_games_full_confidence` defaults (`inputs` + the `compute-power-ranking` task) from 5 → 8 to match the function default and the rest of #277.

## Verified

Regenerated all upcoming-match forecasts at `min_games=8` and compared to the pre-#277 docs:

| Match | Before | After |
|---|---|---|
| Brazil v Haiti | Brazil 49% (0-0) | Brazil **73%** (1-0) |
| Morocco v Haiti | Morocco 48% | Morocco 72% |
| Croatia v Ghana | Croatia 40% | Croatia 60% |
| Germany v Ivory Coast | Germany 91% | Germany 90% (already correct, unchanged) |

The blend also correctly regresses small-sample over-performers down (e.g. Sweden 76% → 53% vs Japan). Average favourite win% across 45 fixtures moved 52.6% → 54.3% — squeezing out small-sample distortions, not inflating everything.

At the old default of 5 the same corrections are milder (Brazil ~65% vs 73%); 8 is what #277 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)