### PR TITLE
fix(worldcup): event-doc upsert idempotency (overwrite metadata, not setdefault)

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1425,6 +1425,28 @@ class TestCoverageCadence:
         assert d["live_score"] == {"home": 1, "away": 1}
         assert d["metadata"]["event_urn"] == "urn:stale"
 
+    def test_live_writers_overwrite_stray_metadata(self):
+        # Regression: a loaded value carrying a stray/empty `metadata` must be
+        # overwritten with the canonical {event_urn}, else the (metadata, name)
+        # upsert forks a duplicate event doc (observed: Colombia vs Portugal).
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        live_ev = self._ev("urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor",
+                            "2026-06-20T00:30:00+00:00", "NS", fid="1489389")
+        live_ev["metadata"] = {}
+        live = {"response": [{"fixture": {"id": 1489389, "status": {"short": "2H", "elapsed": 67}},
+                              "goals": {"home": 2, "away": 0}}]}
+        d = apply_live_status({"params": {"events": [live_ev], "live_fixtures": live}})["data"]["normalized_items"][0]
+        assert d["metadata"] == {"event_urn": "urn:machina:sport:soccer:event:brazil-vs-haiti:20260620:wor"}
+
+        stale_ev = {
+            **self._ev("urn:stale", (now - timedelta(hours=5)).isoformat(), "2H", fid="1489389"),
+            "live_score": {"home": 1, "away": 1, "elapsed": 90},
+            "metadata": {},
+        }
+        d = finalize_stale_live_events({"params": {"events": [stale_ev]}})["data"]["normalized_items"][0]
+        assert d["metadata"] == {"event_urn": "urn:stale"}
+
 
 def _ranking(power, gpg=1.4, conf=0.8, source="results"):
     return {"power_score": power, "breakdown": {"attack_score": power, "defense_score": power},

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2391,7 +2391,10 @@ def build_event_crosswalk(request_data: dict[str, Any]) -> dict[str, Any]:
     for ev in _as_list(params.get("events")):
         if not isinstance(ev, dict):
             continue
-        ev.setdefault("metadata", {"event_urn": _text(_first(ev, "_id", "@id", "id"))})
+        # Overwrite (not setdefault): the doc-store upsert keys on (metadata, name),
+        # so every writer MUST emit the SAME metadata or a stray/empty metadata on
+        # the loaded value forks a duplicate event doc under a different key.
+        ev["metadata"] = {"event_urn": _text(_first(ev, "_id", "@id", "id"))}
         out.append(ev)
         urns = [_text(c.get("@id")) for c in (ev.get("sport:competitors") or [])
                 if isinstance(c, dict) and c.get("@id")]
@@ -2779,7 +2782,10 @@ def apply_live_status(request_data: dict[str, Any]) -> dict[str, Any]:
         info = by_fid.get(fid)
         if not info:
             continue
-        ev.setdefault("metadata", {"event_urn": _text(_first(ev, "_id", "@id", "id"))})
+        # Overwrite (not setdefault): the doc-store upsert keys on (metadata, name),
+        # so every writer MUST emit the SAME metadata or a stray/empty metadata on
+        # the loaded value forks a duplicate event doc under a different key.
+        ev["metadata"] = {"event_urn": _text(_first(ev, "_id", "@id", "id"))}
         if info["status"]:
             ev["sport:status"] = info["status"]
         ev["live_score"] = {"home": info["home"], "away": info["away"], "elapsed": info["elapsed"]}
@@ -2822,7 +2828,9 @@ def finalize_stale_live_events(request_data: dict[str, Any]) -> dict[str, Any]:
         next_ev["sport:status"] = "FT"
         score = next_ev.get("live_score") if isinstance(next_ev.get("live_score"), dict) else {}
         next_ev["live_score"] = {k: score.get(k) for k in ("home", "away") if score.get(k) is not None}
-        next_ev.setdefault("metadata", {"event_urn": _text(_first(next_ev, "_id", "@id", "id"))})
+        # Overwrite (not setdefault): see apply_live_status — consistent metadata
+        # keeps the bulk-update upsert idempotent instead of forking a duplicate.
+        next_ev["metadata"] = {"event_urn": _text(_first(next_ev, "_id", "@id", "id"))}
         out.append(next_ev)
     return {"status": True, "data": {"normalized_items": out, "count": len(out)}}
 


### PR DESCRIPTION
## Problem

The `world-cup-intelligence` pod had a **duplicate event document** on the live store: `Colombia vs Portugal` existed twice with the same `_id`/fixture id but two different store records.

Root cause: the doc-store `bulk-update` upserts on `(metadata, name)`. Three event writers used `setdefault("metadata", ...)`:
- `apply_live_status`
- `finalize_stale_live_events`
- `build_event_crosswalk`

When a loaded event value carried a **stray/empty `metadata`**, `setdefault` was a no-op, so that write keyed on `metadata={}` instead of `{event_urn}` and **forked a second document**. The duplicate observed live came from the finalize-stale path (`metadata={}`, no `elapsed`, score-filtered).

## Fix

Overwrite `metadata` with the canonical `{event_urn: _id}` in all three writers (matching `refresh-prematch-enrichment`, which already overwrites). Every write now keys identically, so the upsert is idempotent.

Adds a regression test asserting both live writers overwrite a stray `metadata`.

## Context

This is the same *family* as entain-templates' WC sync fixes (#738/#750 — "update one canonical doc, don't duplicate"), surfaced while reviewing those against this pod. The other entain themes (SportRadar bracket placeholders, cached-standings freshness, EU season-year, version_control forecast reset) **do not apply here**: our canonical source is API-Football (resolves knockout team names), standings are fetched on-demand, and forecasts rebuild daily.

## Test
`pytest tests/test_worldcup_market_intelligence.py` → 168 passed.