### PR TITLE
fix(worldcup): forecast min_games=3 so a completed group stage washes out the FIFA seed

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -1529,6 +1529,22 @@ class TestComputePowerRanking:
         assert dland["data_source"] == "seed"
         assert dland["power_score"] == 0.7
 
+    def test_default_min_games_full_confidence_after_group_stage(self):
+        # Default min_games is 3: a COMPLETED group stage (3 games) yields full
+        # results confidence so the pre-tournament FIFA seed washes out
+        # (data_source "results", blend_w = 1.0) for the knockout phase.
+        fix = self.FIX + [
+            {"fixture": {"id": "4", "status": {"short": "FT"}},
+             "teams": {"home": {"name": "Aland"}, "away": {"name": "Dland"}}, "goals": {"home": 1, "away": 1}},
+        ]  # Aland now has 3 games (fixtures 1, 2, 4) — a full group stage.
+        seed = [{"team_urn": _module._machina_team_urn("Aland"), "team_name": "Aland", "seed_rating": 0.9}]
+        rk = compute_power_ranking({"params": {"finished_fixtures": fix, "seed_ratings": seed}})["data"]
+        assert rk["min_games_full_confidence"] == 3
+        aland = [r for r in rk["rankings"] if r["team_name"] == "Aland"][0]
+        assert aland["games"] == 3
+        assert aland["data_source"] == "results"
+        assert aland["confidence"] == 1.0
+
 
 class TestForecastAudit:
     PERFECT = {"probabilities": {"home_win": 1, "draw": 0, "away_win": 0, "over_2_5": 1, "under_2_5": 0},

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml
@@ -16,7 +16,7 @@ workflow:
   inputs:
     league: "$.get('league', '1')"
     season: "$.get('season', '2026')"
-    min_games_full_confidence: "$.get('min_games_full_confidence', 8)"
+    min_games_full_confidence: "$.get('min_games_full_confidence', 3)"
   outputs:
     forecasts_count: "len($.get('forecasts', []))"
     field_size: "$.get('field_size', 0)"
@@ -56,7 +56,7 @@ workflow:
       inputs:
         finished_fixtures: "$.get('finished_fixtures', [])"
         seed_ratings: "$.get('seed_ratings', [])"
-        min_games_full_confidence: "$.get('min_games_full_confidence', 8)"
+        min_games_full_confidence: "$.get('min_games_full_confidence', 3)"
       outputs:
         team_index: "$.get('team_index', {})"
         field_size: "$.get('field_size', 0)"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2914,18 +2914,19 @@ def compute_power_ranking(request_data: dict[str, Any]) -> dict[str, Any]:
       - finished_fixtures: api-football fixture objects (status FT/AET/PEN)
       - seed_ratings: [{team_urn, team_name, seed_rating(0-1)}] FIFA/qualifier prior
       - weights: optional override of _DEFAULT_RANK_WEIGHTS
-      - min_games_full_confidence: games for full results confidence (default 8)
+      - min_games_full_confidence: games for full results confidence (default 3)
     Bootstrap blend: power = w*results + (1-w)*seed, w = games/min_games. With 0
-    games a team is 100% seed (data_source "seed", low confidence). Default is 8
-    (not 5): in a 48-team World Cup a side plays ~3 group games, and 2-3 noisy
-    early results should not override a proven FIFA prior (a draw vs minnows is
-    not evidence Brazil is average) — only a full group + knockout run should.
+    games a team is 100% seed (data_source "seed", low confidence). Default is 3:
+    a 48-team World Cup side plays 3 group games, so a COMPLETED group stage gives
+    full results confidence and the pre-tournament FIFA prior washes out for the
+    knockouts — by then the seed's pre-tournament view is increasingly stale and
+    the model should reflect actual tournament form, not where teams started.
     """
     params = _params(request_data)
     w = dict(_DEFAULT_RANK_WEIGHTS)
     w.update(params.get("weights") or {})
     try:
-        min_games = max(1, int(params.get("min_games_full_confidence") or 8))
+        min_games = max(1, int(params.get("min_games_full_confidence") or 3))
     except (TypeError, ValueError):
         min_games = 8
 


### PR DESCRIPTION
## Problem

The Dixon-Coles forecast blends a results-based power ranking with a frozen pre-tournament FIFA seed: `power = (games/min_games)·results + (1 − games/min_games)·seed`.

With `min_games` set to **5** on the daily cron (and a code default of **8**), a knockout-stage team — which plays only **3 group games** before the bracket — capped at `blend_w = 0.6`. So the static pre-tournament seed kept a permanent **40% weight all through the knockouts**, and every live forecast stayed flagged `bootstrap_seeded` / `low_sample_size` with confidence ≤ 0.6 — the confidence tier never moved.

## Fix

Set `min_games = 3` so a **completed group stage = full results confidence** (`blend_w = 1.0`): the seed washes out for the knockout phase and the model reflects actual tournament form.

Changed in three layers:
- `compute_power_ranking` connector default (8 → 3) + rationale comment
- `worldcup-sync-model-forecasts` workflow default (8 → 3)
- the pod-only `worldcup-forecasts-daily` cron agent (5 → 3, applied via API — it isn't in the git template)

The seed itself stays a **frozen pre-tournament prior** — re-grounding it mid-tournament would double-count in-tournament results (once in FIFA's updated numbers, once in our own power score).

## Test
Adds a regression: 3 games + no explicit `min_games` → `data_source: results`, `confidence: 1.0`. Full suite: 169 passed.