### PR TITLE
feat(world-cup-intelligence): perfect-bracket simulator (wcbracket-*)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -17,6 +17,7 @@ setup:
     - Statistical match forecasts (Dixon-Coles) with model-vs-market gaps + Brier/calibration backtesting.
     - Composite editorial Skills (match-preview, match-recap, player-spotlight, fan-pulse, market-watch) as TTL-cached cards.
     - Structured betting signal (recommendation + edge% + EV + Kelly stake + risk flags), line-shopped + de-vigged.
+    - Perfect-bracket simulator (wcbracket-*) -- Monte Carlo of the knockout tree (R32 -> Final) with per-team advancement + champion odds, market-anchored where priced.
     - Read-only workflows suitable for API/MCP productization.
   integrations:
     - api-football
@@ -29,11 +30,13 @@ setup:
     - pod-document-store
   status: available
   value: agent-templates/world-cup-intelligence
-  version: 0.5.1
+  version: 0.6.0
 
 datasets:
   - type: connector
     path: worldcup-market-intelligence.yml
+  - type: connector
+    path: wcbracket-engine.yml
 
   - type: agent
     path: agents/world-cup-intelligence-agent.yml
@@ -45,6 +48,8 @@ datasets:
     path: agents/worldcup-coverage-hot-agent.yml
   - type: agent
     path: agents/worldcup-content-author-agent.yml
+  - type: agent
+    path: agents/wcbracket-simulator.yml
 
   - type: workflow
     path: workflows/worldcup-health.yml
@@ -120,6 +125,10 @@ datasets:
     path: workflows/worldcup-fan-pulse.yml
   - type: workflow
     path: workflows/worldcup-market-watch.yml
+  - type: workflow
+    path: workflows/wcbracket-simulate.yml
+  - type: workflow
+    path: workflows/wcbracket-get-bracket.yml
   - type: workflow
     path: _folders.yml
 

--- a/agent-templates/world-cup-intelligence/agents/wcbracket-simulator.yml
+++ b/agent-templates/world-cup-intelligence/agents/wcbracket-simulator.yml
@@ -1,0 +1,30 @@
+agent:
+  name: wcbracket-simulator
+  title: World Cup Bracket Sim - Simulator
+  description: >
+    Additive/exploration agent. On demand, forward-simulates the World Cup
+    knockout bracket from a cutoff date (default today's first knockout game)
+    through the Final and stores a worldcup:bracket-simulation document with
+    champion odds, the per-team advancement matrix, and the single most-likely
+    "perfect" bracket. Ships INACTIVE (status below) so it never auto-schedules
+    or disrupts existing pod agents -- run it with execute_agent, or set status
+    "active" + add config-frequency to refresh after each match day. Read-only
+    on source data; informational, not betting advice.
+  status: "inactive"
+  context:
+    status: "inactive"
+  context-agent:
+    from_date: "$.get('from_date', '2026-06-28')"
+    n_sims: "$.get('n_sims', 20000)"
+    market_weight: "$.get('market_weight', 0.65)"
+  workflows:
+    - name: wcbracket-simulate
+      description: Build the knockout tree and Monte Carlo simulate the perfect bracket.
+      inputs:
+        from_date: "$.get('from_date', '2026-06-28')"
+        n_sims: "$.get('n_sims', 20000)"
+        market_weight: "$.get('market_weight', 0.65)"
+      outputs:
+        champion: "$.get('champion', {})"
+        field_size: "$.get('field_size', 0)"
+        bracket_simulation_id: "$.get('bracket_simulation_id')"

--- a/agent-templates/world-cup-intelligence/docs/worldcup-bracket-sim-design.md
+++ b/agent-templates/world-cup-intelligence/docs/worldcup-bracket-sim-design.md
@@ -1,0 +1,94 @@
+# World Cup Perfect-Bracket Simulator — Design
+
+**Date:** 2026-06-28
+**Pod:** `world-cup-mcp` (all WC data already lives here)
+**Status:** additive / exploration. Touches no existing component.
+
+## Goal
+
+From the current tournament state forward (Round of 32 → Final), produce the
+single most-likely complete bracket plus every team's per-round advancement and
+championship probabilities — as accurately as possible by anchoring on
+prediction-market prices (Kalshi / Polymarket) where they exist and carrying the
+unpriced deep rounds with a Dixon-Coles team-strength model.
+
+This is an exploration project to demonstrate AI-driven tournament simulation.
+
+## Current state (verified 2026-06-28)
+
+- Real **FIFA World Cup 2026**, 48 teams, cached in `worldcup:event` docs.
+- Group stage complete: 76 matches `ft`. We are at the **Round of 32**.
+- The next match to kick off is **South Africa vs Canada** (2026-06-28 19:00 UTC) —
+  the "Canada vs South Africa" opener in the request.
+- 16 knockout fixtures cached (June 28 – July 4); 2 already `ft`, 14 `ns`.
+- Deeper rounds (R16 → Final) are NOT seeded — they depend on results, so the
+  simulator constructs them forward.
+- Markets are **per-match** (Kalshi `KXWCGAME-*` moneyline, spreads, totals;
+  Polymarket). No separate outright-champion market is cached.
+
+## What already exists (reused, not rebuilt)
+
+`worldcup-market-intelligence` connector provides:
+- `compute_power_ranking(finished_fixtures, seed_ratings)` → `team_index`
+  ({team_urn: {power_score, breakdown.attack_score/defense_score, confidence}}).
+- `normalize_fifa_seed` and `worldcup:fifa-ranking` seed docs.
+- `_match_probabilities` — analytic Dixon-Coles 1X2 from two rankings.
+
+`worldcup-sync-model-forecasts` workflow shows the canonical path to obtain
+`team_index`: api-football `get-fixtures` → finished → `compute_power_ranking`.
+
+## What is missing (this project builds)
+
+Tournament-level chaining: nobody forward-simulates the knockout tree to a full
+bracket. That is the additive piece.
+
+## Components (naming prefix `wcbracket-`, zero collision)
+
+1. **Connector `wcbracket-engine`** (pyscript), two commands:
+   - `build_bracket` — from knockout `worldcup:event` docs (+ finished fixture
+     results) construct: the R32 field, resolved winners for completed knockout
+     matches, and the forward single-elimination tree (R32→R16→QF→SF→Final).
+     R32 matches ordered by kickoff and paired adjacently (standard schedule
+     order); the constructed tree is emitted for inspection. Validates/dedups
+     (each team once in R32) and warns on data anomalies.
+   - `simulate_bracket` — inputs: bracket, `team_index`, per-match market 1X2
+     map, config. Precomputes analytic Dixon-Coles **pairwise knockout advance
+     probability** P(A beats B) for every possible matchup (regulation 1X2 with
+     draw resolved via ET/penalties). For R32 matches with a market moneyline,
+     blends model 1X2 with market 1X2 (default 65% market). Runs N≈20k Monte
+     Carlo tournaments, tallies per-team per-round reach + champion counts, and
+     derives the most-likely bracket (modal occupant per slot, higher-advance
+     team per match). Embedded DC math (no cross-connector import).
+
+2. **Workflow `wcbracket-simulate`** — loads finished fixtures, FIFA seed,
+   knockout events, and per-match markets; calls `compute_power_ranking` then the
+   engine; stores one `worldcup:bracket-simulation` document.
+
+3. **Workflow `wcbracket-get-bracket`** — read-only; serves the latest stored
+   simulation for the chat agent / inspection.
+
+4. **Agent `wcbracket-simulator`** — runs `wcbracket-simulate` on demand (can be
+   scheduled to refresh after each match day) and answers questions from the
+   stored document.
+
+## Market-anchored blend
+
+- **R32 (priced):** blend model 1X2 with Kalshi/Polymarket moneyline (market-weighted).
+- **R16+ (unpriced):** model pairwise advance from market-/results-calibrated
+  power ranking (the ranking already blends FIFA seed + actual group results).
+- **Completed knockout matches:** actual result, fixed.
+
+## Output document `worldcup:bracket-simulation`
+
+`value`: advancement matrix (team → P(reach R16/QF/SF/Final/win)), champion
+leaderboard, the most-likely bracket round-by-round, per-R32-match win
+probabilities with model-vs-market provenance, the constructed tree, run config
+and timestamp, plus `disclaimer` (informational, not betting advice).
+
+## Assumptions / caveats
+
+- R32→R16 tree pairing uses kickoff order (no authoritative bracket map in data);
+  the tree is emitted so it can be corrected via an explicit override input.
+- No outright-champion market exists to anchor on; per-match markets anchor R32,
+  the model carries the rest.
+- Informational simulation, not betting advice (mirrors existing WC disclaimers).

--- a/agent-templates/world-cup-intelligence/wcbracket-engine.py
+++ b/agent-templates/world-cup-intelligence/wcbracket-engine.py
@@ -1,0 +1,625 @@
+"""
+World Cup bracket-simulation engine (additive / exploration).
+
+Two commands:
+  build_bracket    -- construct the knockout tree (R32 -> Final) from cached
+                      knockout events, resolving completed matches.
+  simulate_bracket -- Monte Carlo the tree forward using analytic Dixon-Coles
+                      pairwise advance probabilities, anchored to per-match
+                      Kalshi/Polymarket moneyline where available. Emits per-team
+                      advancement probabilities, a champion leaderboard, and the
+                      single most-likely ("perfect") bracket.
+
+Pure stdlib (numpy optional). Standard pyscript envelope: {status, data, message}.
+Informational only -- not betting advice.
+"""
+
+import json
+import math
+import random
+import re
+
+DISCLAIMER = ("Informational tournament simulation built from public model + "
+              "market data. Probabilities are estimates, not betting advice.")
+
+ROUND_NAMES = ["R32", "R16", "QF", "SF", "F"]
+# What a winner in round i has *reached* (the next round / title).
+REACHED_BY_WINNING = {"R32": "R16", "R16": "QF", "QF": "SF", "SF": "F", "F": "champion"}
+
+_DEFAULT_XG = {
+    "base": 1.45,          # league-average goals per team
+    "attack_pivot": 0.5,   # attack_score that maps to a 1.0 multiplier
+    "def_factor": 0.5,     # opponent-defense suppression strength
+    "xg_min": 0.25,
+    "xg_max": 3.2,
+    "home_adv": 0.0,       # neutral venues in the knockout stage
+}
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _params(request_data):
+    if isinstance(request_data, str):
+        try:
+            request_data = json.loads(request_data)
+        except Exception:
+            request_data = {}
+    if not isinstance(request_data, dict):
+        return {}
+    p = request_data.get("params", request_data)
+    return p if isinstance(p, dict) else {}
+
+
+def _num(v, default=0.0):
+    try:
+        if v is None:
+            return default
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _slug(name):
+    s = re.sub(r"[^a-z0-9]+", "-", str(name or "").strip().lower())
+    return s.strip("-")
+
+
+def _poisson_pmf(k, lam):
+    return (lam ** k) * math.exp(-lam) / math.factorial(k)
+
+
+def _dc_tau(h, a, lam_h, lam_a, rho):
+    if rho == 0:
+        return 1.0
+    if h == 0 and a == 0:
+        return 1.0 - lam_h * lam_a * rho
+    if h == 0 and a == 1:
+        return 1.0 + lam_h * rho
+    if h == 1 and a == 0:
+        return 1.0 + lam_a * rho
+    if h == 1 and a == 1:
+        return 1.0 - rho
+    return 1.0
+
+
+def _ranking_fields(rank):
+    """Pull (power, attack, defense) from a compute_power_ranking entry."""
+    if not isinstance(rank, dict):
+        return 0.5, 0.5, 0.5
+    power = _num(rank.get("power_score"), 0.5)
+    bd = rank.get("breakdown") or {}
+    attack = _num(bd.get("attack_score"), power)
+    defense = _num(bd.get("defense_score"), power)
+    return power, attack, defense
+
+
+def _expected_goals(home_rank, away_rank, xg):
+    hp, h_att, h_def = _ranking_fields(home_rank)
+    ap, a_att, a_def = _ranking_fields(away_rank)
+    base, pivot, deff = xg["base"], xg["attack_pivot"], xg["def_factor"]
+    home_xg = base * (max(h_att, 0.15) / pivot) * (1 - a_def * deff) + xg["home_adv"]
+    away_xg = base * (max(a_att, 0.15) / pivot) * (1 - h_def * deff)
+    home_xg = max(xg["xg_min"], min(xg["xg_max"], home_xg))
+    away_xg = max(xg["xg_min"], min(xg["xg_max"], away_xg))
+    return home_xg, away_xg
+
+
+def _regulation_1x2(home_rank, away_rank, xg, rho=-0.12, max_goals=10):
+    """Analytic Dixon-Coles regulation 1X2."""
+    lam_h, lam_a = _expected_goals(home_rank, away_rank, xg)
+    hp = [_poisson_pmf(k, lam_h) for k in range(max_goals + 1)]
+    ap = [_poisson_pmf(k, lam_a) for k in range(max_goals + 1)]
+    hw = dw = aw = 0.0
+    total = 0.0
+    for h in range(max_goals + 1):
+        for a in range(max_goals + 1):
+            p = hp[h] * ap[a] * _dc_tau(h, a, lam_h, lam_a, rho)
+            total += p
+            if h > a:
+                hw += p
+            elif h == a:
+                dw += p
+            else:
+                aw += p
+    if total > 0:
+        hw, dw, aw = hw / total, dw / total, aw / total
+    return {"home_win": hw, "draw": dw, "away_win": aw,
+            "home_xg": round(lam_h, 3), "away_xg": round(lam_a, 3)}
+
+
+def _advance_prob(home_rank, away_rank, xg, rho, tie_scale):
+    """P(home advances) in a knockout: regulation win + tied games resolved by a
+    power-weighted coin (ET + penalties), clamped near 50/50."""
+    reg = _regulation_1x2(home_rank, away_rank, xg, rho)
+    hp = _num(home_rank.get("power_score") if isinstance(home_rank, dict) else None, 0.5)
+    ap = _num(away_rank.get("power_score") if isinstance(away_rank, dict) else None, 0.5)
+    edge = max(-0.15, min(0.15, (hp - ap) * tie_scale))
+    tie_break_home = 0.5 + edge
+    p_home = reg["home_win"] + reg["draw"] * tie_break_home
+    p_home = max(0.02, min(0.98, p_home))
+    return p_home, reg
+
+
+def _blend_market(reg, market_1x2, market_weight):
+    """Blend model regulation 1X2 with a market 1X2 (normalized)."""
+    if not market_1x2:
+        return reg, False
+    mw = max(0.0, min(1.0, market_weight))
+    keys = ("home_win", "draw", "away_win")
+    msum = sum(_num(market_1x2.get(k)) for k in keys)
+    if msum <= 0:
+        return reg, False
+    blended = {}
+    for k in keys:
+        m = _num(market_1x2.get(k)) / msum
+        blended[k] = mw * m + (1 - mw) * reg[k]
+    bsum = sum(blended.values()) or 1.0
+    for k in keys:
+        blended[k] /= bsum
+    blended["home_xg"] = reg.get("home_xg")
+    blended["away_xg"] = reg.get("away_xg")
+    return blended, True
+
+
+# --------------------------------------------------------------------------- #
+# build_bracket
+# --------------------------------------------------------------------------- #
+def _team_pair(ev):
+    home = away = None
+    for t in ev.get("teams") or []:
+        q = str(t.get("qualifier") or "").lower()
+        if q == "home":
+            home = t.get("name")
+        elif q == "away":
+            away = t.get("name")
+    if home is None or away is None:  # fall back to listed order
+        names = [t.get("name") for t in (ev.get("teams") or []) if t.get("name")]
+        if len(names) == 2:
+            home, away = names[0], names[1]
+    return home, away
+
+
+_FINAL_STATUS = {"FT", "AET", "PEN"}
+
+
+def _winner_by_pair_from_fixtures(finished_fixtures):
+    """Map frozenset({home_slug, away_slug}) -> winner_slug from api-football
+    finished fixtures (uses final goals; penalty shootout breaks ties)."""
+    out = {}
+    for f in finished_fixtures or []:
+        if not isinstance(f, dict):
+            continue
+        status = str(((f.get("fixture") or {}).get("status") or {}).get("short") or "").upper()
+        if status not in _FINAL_STATUS:
+            continue
+        teams = f.get("teams") or {}
+        hn = ((teams.get("home") or {}).get("name"))
+        an = ((teams.get("away") or {}).get("name"))
+        if not hn or not an:
+            continue
+        goals = f.get("goals") or {}
+        hg, ag = goals.get("home"), goals.get("away")
+        if hg is None or ag is None:
+            continue
+        hs, as_ = _slug(hn), _slug(an)
+        win = None
+        if hg > ag:
+            win = hs
+        elif ag > hg:
+            win = as_
+        else:  # tie in regulation/ET -> penalty shootout
+            pen = (f.get("score") or {}).get("penalty") or {}
+            ph, pa = pen.get("home"), pen.get("away")
+            if ph is not None and pa is not None and ph != pa:
+                win = hs if ph > pa else as_
+        if win:
+            out[frozenset((hs, as_))] = win
+    return out
+
+
+def _knockout_fixture_ids(fixtures):
+    """api-football fixture ids whose round is a knockout (NOT a group stage).
+
+    The schedule mixes the final group-stage games (often kicking off the same
+    calendar day the knockouts begin) with the real Round-of-32 fixtures, so a
+    date cutoff alone leaks group games into the bracket. api-football tags every
+    fixture with league.round ("Group Stage - 3" vs "Round of 32"/"8th Finals"/
+    "Quarter-finals"/...); anything that isn't a group round is a knockout."""
+    out = set()
+    for f in fixtures or []:
+        if not isinstance(f, dict):
+            continue
+        fid = str(((f.get("fixture") or {}).get("id")) or "")
+        rnd = str(((f.get("league") or {}).get("round")) or "").lower()
+        if fid and rnd and "group" not in rnd:
+            out.add(fid)
+    return out
+
+
+def build_bracket(request_data):
+    try:
+        p = _params(request_data)
+        events = p.get("knockout_events") or []
+        results = {}  # event_urn -> winner_slug (explicit override)
+        for r in p.get("finished_results") or []:
+            eu = r.get("event_urn")
+            wn = r.get("winner_name")
+            if eu and wn:
+                results[eu] = _slug(wn)
+        # Auto-resolve completed knockout matches from finished fixtures.
+        pair_winner = _winner_by_pair_from_fixtures(p.get("finished_fixtures"))
+
+        warnings = []
+        # Filter to knockout cutoff here (NOT in the workflow): the engine eval
+        # exposes `$` as a local, so a `$.get('from_date')` reference inside a
+        # workflow list-comprehension's if-clause runs in a scope that can't see
+        # it and silently yields zero events. Doing it in Python is robust.
+        from_date = str(p.get("from_date") or "")
+        evs = [e for e in events if isinstance(e, dict)]
+        # Prefer the authoritative knockout-round filter (drops leaked group
+        # games regardless of date); fall back to the date cutoff if the
+        # fixtures/round data isn't available or doesn't resolve enough matches.
+        ko_ids = _knockout_fixture_ids(p.get("fixtures"))
+        if ko_ids:
+            by_round = [e for e in evs if str(e.get("af_id") or "") in ko_ids]
+            if len(by_round) >= 2:
+                evs = by_round
+            else:
+                warnings.append(
+                    f"knockout-round filter matched {len(by_round)} events; using date cutoff instead")
+                if from_date:
+                    evs = [e for e in evs if str(e.get("start_date") or "") >= from_date]
+        elif from_date:
+            evs = [e for e in evs if str(e.get("start_date") or "") >= from_date]
+        # Order R32 matches by kickoff; allow explicit override.
+        order = p.get("bracket_order")
+        if order:
+            by_urn = {e.get("event_urn"): e for e in evs}
+            evs = [by_urn[u] for u in order if u in by_urn]
+        else:
+            evs = sorted(evs, key=lambda e: str(e.get("start_date") or ""))
+
+        # Dedup: each team appears once in R32.
+        seen_teams = set()
+        r32 = []
+        for ev in evs:
+            home, away = _team_pair(ev)
+            if not home or not away:
+                warnings.append(f"event {ev.get('event_urn')} missing a team; skipped")
+                continue
+            hs, as_ = _slug(home), _slug(away)
+            if hs in seen_teams or as_ in seen_teams:
+                warnings.append(f"duplicate team in {ev.get('event_urn')} ({home}/{away}); skipped")
+                continue
+            seen_teams.update((hs, as_))
+            eu = ev.get("event_urn")
+            status = str(ev.get("status") or "ns").lower()
+            # Prefer explicit result, then auto-resolved from finished fixtures.
+            winner = results.get(eu) or pair_winner.get(frozenset((hs, as_)))
+            if status in ("ft", "aet", "pen") and not winner:
+                warnings.append(f"completed match {eu} has no result available; will be simulated")
+                status = "ns"
+            r32.append({
+                "match_idx": len(r32), "event_urn": eu,
+                "home_name": home, "away_name": away,
+                "home_slug": hs, "away_slug": as_,
+                "status": "ft" if winner else "ns",
+                "winner_slug": winner,
+                "kickoff": ev.get("start_date"),
+            })
+
+        n = len(r32)
+        if n < 2:
+            return {"status": False, "data": {"bracket": {}},
+                    "message": f"Not enough knockout matches to build a bracket ({n})."}
+        # Pad to a power of two if needed (byes carry the home slot forward).
+        pow2 = 1 << (n - 1).bit_length()
+        if n != pow2:
+            warnings.append(f"{n} R32 matches is not a power of two; padding to {pow2} with byes")
+
+        rounds = [{"name": ROUND_NAMES[0] if pow2 >= 16 else "K1", "matches": r32}]
+        # Build forward feeder tree.
+        prev_count = pow2
+        ri = 1
+        cur = pow2 // 2
+        while cur >= 1:
+            matches = []
+            for j in range(cur):
+                matches.append({"match_idx": j, "feeders": [2 * j, 2 * j + 1]})
+            name = ROUND_NAMES[ri] if ri < len(ROUND_NAMES) else f"R{cur}"
+            rounds.append({"name": name, "matches": matches})
+            ri += 1
+            cur //= 2
+
+        bracket = {
+            "field_size": n, "padded_size": pow2,
+            "field_slugs": sorted(seen_teams),
+            "name_by_slug": {m["home_slug"]: m["home_name"] for m in r32}
+            | {m["away_slug"]: m["away_name"] for m in r32},
+            "rounds": rounds,
+            "warnings": warnings,
+            "disclaimer": DISCLAIMER,
+        }
+        return {"status": True, "data": {"bracket": bracket},
+                "message": f"Bracket built: {n} R32 matches, {len(rounds)} rounds."}
+    except Exception as e:
+        return {"status": False, "data": {"bracket": {}}, "message": f"build_bracket error: {e}"}
+
+
+# --------------------------------------------------------------------------- #
+# simulate_bracket
+# --------------------------------------------------------------------------- #
+# Kalshi/FIFA/IOC 3-letter team codes (used in the KXWCGAME market id suffix)
+# differ from the ISO-3166 alpha-3 codes our team URNs carry. Without this map a
+# fixture like South Africa (urn ...:zaf) vs a Kalshi "-RSA" market never anchors.
+_FIFA_TO_ISO3 = {
+    "ger": "deu", "ned": "nld", "por": "prt", "sui": "che", "cro": "hrv",
+    "rsa": "zaf", "alg": "dza", "den": "dnk", "uru": "ury", "par": "pry",
+    "ksa": "sau", "iri": "irn", "uae": "are", "chi": "chl", "tah": "pyf",
+    "bah": "bhr", "eng": "eng", "wal": "wal", "sco": "sco",
+}
+
+
+def _iso3_to_slug(related_team_urns):
+    """team-URN list -> {iso3: name_slug}. URN: urn:...:team:{slug}:{iso3}."""
+    out = {}
+    for u in related_team_urns or []:
+        parts = str(u).split(":")
+        if len(parts) >= 2 and parts[-1] and parts[-2]:
+            out[parts[-1].lower()] = parts[-2].lower()
+    return out
+
+
+def _affirmative_outcome(outcomes, home_slug, away_slug):
+    """The 'this side happens' price + which side it names, if the outcome name
+    carries it (old team-named shape). Returns (price|None, 'home'|'away'|'draw'|None)."""
+    price = None
+    named = None
+    for o in outcomes or []:
+        if o.get("price") is None:
+            continue
+        nm = _slug(o.get("name") or o.get("outcome_name"))
+        p = _num(o.get("price"))
+        if nm in ("no",):
+            continue
+        if nm in ("tie", "draw"):
+            return p, "draw"
+        if nm in ("yes",):
+            price = p  # affirmative, side comes from the market id suffix
+        elif home_slug and (home_slug in nm or nm in home_slug):
+            return p, "home"
+        elif away_slug and (away_slug in nm or nm in away_slug):
+            return p, "away"
+    return price, named
+
+
+def _market_1x2_for(market_list, event_urn, home_slug, away_slug):
+    """Map cached per-match moneyline markets to {home_win, draw, away_win}.
+
+    Kalshi posts one binary per outcome of a fixture (KXWCGAME-<date><HOMEAWY>-<XXX>
+    where XXX is a team iso3 or TIE). The outcome name is generic ("Yes"/"Tie"),
+    so the side is taken from the id suffix resolved through related_team_urns;
+    older markets that name the outcome after the team are still honored."""
+    home = draw = away = None
+    for m in market_list:
+        if not isinstance(m, dict):
+            continue
+        iso3 = _iso3_to_slug(m.get("related_team_urns"))
+        # Match by event_urn (primary) or the related team pair (event_urn-link lag).
+        matches = bool(event_urn) and m.get("event_urn") == event_urn
+        if not matches:
+            pair = set(iso3.values())
+            matches = home_slug in pair and away_slug in pair
+        if not matches:
+            continue
+        price, side = _affirmative_outcome(m.get("outcomes"), home_slug, away_slug)
+        if price is None:
+            continue
+        if side is None:  # resolve side from the market id suffix (team code / TIE)
+            suffix = str(m.get("id") or "").rsplit("-", 1)[-1].lower()
+            suffix = _FIFA_TO_ISO3.get(suffix, suffix)  # FIFA/IOC -> ISO-3166
+            if suffix == "tie":
+                side = "draw"
+            elif iso3.get(suffix) == home_slug:
+                side = "home"
+            elif iso3.get(suffix) == away_slug:
+                side = "away"
+        if side == "home" and home is None:
+            home = price
+        elif side == "away" and away is None:
+            away = price
+        elif side == "draw" and draw is None:
+            draw = price
+    # Require BOTH win sides; draw inferred from the overround when absent.
+    if home is None or away is None:
+        return None
+    out = {"home_win": home, "draw": draw if draw is not None else 0.0, "away_win": away}
+    if draw is None:
+        out["draw"] = max(0.0, 1.0 - home - away)
+    return out
+
+
+def simulate_bracket(request_data):
+    try:
+        p = _params(request_data)
+        bracket = p.get("bracket") or {}
+        rounds = bracket.get("rounds") or []
+        if not rounds:
+            return {"status": False, "data": {"simulation": {}}, "message": "No bracket supplied."}
+
+        team_index = p.get("team_index") or {}
+        markets = [m for m in (p.get("markets") or []) if isinstance(m, dict)]
+        cfg = p.get("config") or {}
+        n_sims = int(cfg.get("n_sims") or 20000)
+        market_weight = _num(cfg.get("market_weight"), 0.65)
+        rho = _num(cfg.get("rho"), -0.12)
+        tie_scale = _num(cfg.get("tie_break_scale"), 0.6)
+        seed = int(cfg.get("seed") or 42)
+        xg = dict(_DEFAULT_XG)
+        xg.update(cfg.get("xg_params") or {})
+
+        # Rankings indexed by slugified team name (robust to URN scheme).
+        rank_by_slug = {}
+        for r in team_index.values():
+            if isinstance(r, dict) and r.get("team_name"):
+                rank_by_slug[_slug(r["team_name"])] = r
+
+        def rank(slug):
+            return rank_by_slug.get(slug, {"power_score": 0.5})
+
+        def pair_adv(a, b):
+            """P(a advances vs b), memoized, model-only (neutral)."""
+            key = (a, b)
+            cached = _adv_memo.get(key)
+            if cached is not None:
+                return cached
+            ph, _reg = _advance_prob(rank(a), rank(b), xg, rho, tie_scale)
+            _adv_memo[key] = ph
+            _adv_memo[(b, a)] = 1.0 - ph
+            return ph
+
+        _adv_memo = {}
+        name_by_slug = bracket.get("name_by_slug") or {}
+
+        # --- R32: model + market-blended per-match probabilities (reported) ---
+        r32 = rounds[0]["matches"]
+        r32_probs = []   # P(home advances) per match
+        r32_report = []
+        for m in r32:
+            hs, as_ = m["home_slug"], m["away_slug"]
+            if m.get("winner_slug"):
+                p_home = 1.0 if m["winner_slug"] == hs else 0.0
+                r32_probs.append(p_home)
+                r32_report.append({
+                    "event_urn": m.get("event_urn"),
+                    "home": m["home_name"], "away": m["away_name"],
+                    "status": "completed", "winner": name_by_slug.get(m["winner_slug"]),
+                    "home_advance_prob": p_home, "source": "result"})
+                continue
+            reg = _regulation_1x2(rank(hs), rank(as_), xg, rho)
+            mkt = _market_1x2_for(markets, m.get("event_urn"), hs, as_)
+            blended, used_mkt = _blend_market(reg, mkt, market_weight)
+            php = _num(rank(hs).get("power_score"), 0.5)
+            pap = _num(rank(as_).get("power_score"), 0.5)
+            edge = max(-0.15, min(0.15, (php - pap) * tie_scale))
+            p_home = blended["home_win"] + blended["draw"] * (0.5 + edge)
+            p_home = max(0.02, min(0.98, p_home))
+            r32_probs.append(p_home)
+            r32_report.append({
+                "event_urn": m.get("event_urn"),
+                "home": m["home_name"], "away": m["away_name"], "status": "scheduled",
+                "model_1x2": {k: round(reg[k], 4) for k in ("home_win", "draw", "away_win")},
+                "market_1x2": ({k: round(_num(mkt.get(k)), 4) for k in ("home_win", "draw", "away_win")}
+                               if used_mkt else None),
+                "blended_home_advance_prob": round(p_home, 4),
+                "source": "model+market" if used_mkt else "model"})
+
+        # --- Monte Carlo ---
+        rng = random.Random(seed)
+        n_rounds = len(rounds)
+        # Positional reach labels: winning round ri "reaches" the next round's
+        # name, and the last round's winner reaches "champion". Robust to any
+        # field size / round naming.
+        round_names = [rnd["name"] for rnd in rounds]
+
+        def reached_label(ri):
+            return "champion" if ri == n_rounds - 1 else round_names[ri + 1]
+
+        # reach[slug][label] and winner_counts[round_idx][match_idx][slug]
+        reach = {}
+        winner_counts = [[{} for _ in rnd["matches"]] for rnd in rounds]
+
+        def bump_reach(slug, rname):
+            d = reach.setdefault(slug, {})
+            d[rname] = d.get(rname, 0) + 1
+
+        first_round = round_names[0]
+        for _ in range(n_sims):
+            # Round 0
+            prev = []
+            for j, m in enumerate(r32):
+                hs, as_ = m["home_slug"], m["away_slug"]
+                bump_reach(hs, first_round)
+                bump_reach(as_, first_round)
+                w = hs if rng.random() < r32_probs[j] else as_
+                prev.append(w)
+                winner_counts[0][j][w] = winner_counts[0][j].get(w, 0) + 1
+                bump_reach(w, reached_label(0))
+            # Subsequent rounds
+            for ri in range(1, n_rounds):
+                cur = []
+                for j, m in enumerate(rounds[ri]["matches"]):
+                    f0, f1 = m["feeders"]
+                    a = prev[f0] if f0 < len(prev) else None
+                    b = prev[f1] if f1 < len(prev) else None
+                    if a is None and b is None:
+                        w = None
+                    elif a is None:
+                        w = b
+                    elif b is None:
+                        w = a
+                    else:
+                        w = a if rng.random() < pair_adv(a, b) else b
+                    cur.append(w)
+                    if w is not None:
+                        winner_counts[ri][j][w] = winner_counts[ri][j].get(w, 0) + 1
+                        bump_reach(w, reached_label(ri))
+                prev = cur
+
+        # --- Advancement matrix ---
+        adv_rounds = round_names + ["champion"]
+        final_round = round_names[-1]  # round whose winner is champion
+        advancement = []
+        for slug, counts in reach.items():
+            row = {"team": name_by_slug.get(slug, slug)}
+            for rn in adv_rounds:
+                row[rn] = round(counts.get(rn, 0) / n_sims, 4)
+            advancement.append(row)
+        advancement.sort(
+            key=lambda r: tuple(r.get(rn, 0) for rn in (["champion", final_round] + round_names[::-1])),
+            reverse=True)
+
+        champion_leaderboard = [
+            {"team": r["team"], "champion_prob": r["champion"],
+             "reach_final_prob": r.get(final_round, 0)}
+            for r in advancement if r["champion"] > 0][:16]
+
+        # --- Most-likely ("perfect") bracket: modal winner per match ---
+        def modal(counts):
+            if not counts:
+                return None
+            slug = max(counts, key=counts.get)
+            return {"team": name_by_slug.get(slug, slug),
+                    "win_share": round(counts[slug] / n_sims, 4)}
+
+        perfect = []
+        for ri, rnd in enumerate(rounds):
+            picks = [modal(winner_counts[ri][j]) for j in range(len(rnd["matches"]))]
+            perfect.append({"round": rnd["name"], "winners": picks})
+        champion = perfect[-1]["winners"][0] if perfect and perfect[-1]["winners"] else None
+
+        simulation = {
+            "n_sims": n_sims,
+            "config": {"market_weight": market_weight, "rho": rho,
+                       "tie_break_scale": tie_scale, "seed": seed, "xg_params": xg},
+            "champion": champion,
+            "champion_leaderboard": champion_leaderboard,
+            "advancement": advancement,
+            "perfect_bracket": perfect,
+            "r32_matches": r32_report,
+            "bracket_warnings": bracket.get("warnings", []),
+            "disclaimer": DISCLAIMER,
+        }
+        msg = (f"Simulated {n_sims} tournaments over {n_rounds} rounds. "
+               f"Champion: {champion['team'] if champion else 'n/a'} "
+               f"({champion['win_share'] if champion else 0:.1%}).")
+        return {"status": True, "data": {"simulation": simulation}, "message": msg}
+    except Exception as e:
+        import traceback
+        return {"status": False, "data": {"simulation": {}},
+                "message": f"simulate_bracket error: {e} | {traceback.format_exc()[-400:]}"}
+
+
+def main(request_data):
+    return build_bracket(request_data)

--- a/agent-templates/world-cup-intelligence/wcbracket-engine.yml
+++ b/agent-templates/world-cup-intelligence/wcbracket-engine.yml
@@ -1,0 +1,10 @@
+connector:
+  name: "wcbracket-engine"
+  description: "World Cup bracket-simulation engine (additive/exploration): builds the knockout tree from cached events and Monte Carlo simulates it forward to a perfect bracket, anchored to per-match Kalshi/Polymarket prices where available. Informational only."
+  filename: "wcbracket-engine.py"
+  filetype: "pyscript"
+  commands:
+    - name: "Build knockout bracket"
+      value: "build_bracket"
+    - name: "Simulate bracket"
+      value: "simulate_bracket"

--- a/agent-templates/world-cup-intelligence/workflows/wcbracket-get-bracket.yml
+++ b/agent-templates/world-cup-intelligence/workflows/wcbracket-get-bracket.yml
@@ -1,0 +1,35 @@
+workflow:
+  name: wcbracket-get-bracket
+  title: World Cup Bracket Sim - Get Latest Bracket
+  description: |
+    Read-only. Serves the most recent worldcup:bracket-simulation document
+    (champion odds, advancement matrix, the most-likely bracket). Informational.
+
+  context-variables:
+    debugger:
+      enabled: true
+  inputs:
+    from_date: "$.get('from_date', '')"
+  outputs:
+    simulation: "$.get('simulation', {})"
+    workflow-status: "$.get('simulation', {}) and 'executed' or 'skipped'"
+  tasks:
+    - type: document
+      name: load-simulation
+      description: Latest bracket-simulation snapshot (optionally by cutoff date).
+      config:
+        action: search
+        search-limit: 1
+        search-sorters: ["updated", -1]
+        search-vector: false
+      filters:
+        name: "'worldcup:bracket-simulation'"
+      outputs:
+        simulation: |
+          next(
+            (
+              d.get('value', {}) for d in ($.get('documents', []) or [])
+              if not $.get('from_date') or d.get('value', {}).get('from_date') == $.get('from_date')
+            ),
+            ($.get('documents', []) or [{}])[0].get('value', {}) if $.get('documents') else {}
+          )

--- a/agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml
+++ b/agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml
@@ -1,0 +1,205 @@
+workflow:
+  name: wcbracket-simulate
+  title: World Cup Bracket Sim - Simulate Perfect Bracket
+  description: |
+    Additive/exploration. Forward-simulates the World Cup knockout bracket from a
+    cutoff date (default today's first knockout game) through the Final and stores
+    a worldcup:bracket-simulation document. Reuses worldcup-market-intelligence's
+    power ranking (FIFA seed + group results), builds the knockout tree from cached
+    worldcup:event docs, and Monte Carlo simulates it with analytic Dixon-Coles
+    pairwise advance probabilities anchored to per-match Kalshi/Polymarket moneyline
+    where available. Read-only / informational -- not betting advice.
+
+  context-variables:
+    debugger:
+      enabled: true
+    api-football:
+      x-apisports-key: $TEMP_CONTEXT_VARIABLE_API_FOOTBALL_API_KEY
+  inputs:
+    league: "$.get('league', '1')"
+    season: "$.get('season', '2026')"
+    from_date: "$.get('from_date', '2026-06-28')"
+    n_sims: "$.get('n_sims', 20000)"
+    market_weight: "$.get('market_weight', 0.65)"
+    min_games_full_confidence: "$.get('min_games_full_confidence', 3)"
+  outputs:
+    champion: "$.get('simulation', {}).get('champion', {})"
+    field_size: "$.get('bracket', {}).get('field_size', 0)"
+    bracket_simulation_id: "$.get('bracket_simulation_id')"
+    workflow-status: "$.get('simulation', {}) and 'executed' or 'skipped'"
+  tasks:
+    # 1. All WC fixtures from api-football; finished ones drive the power ranking
+    #    and resolve completed knockout matches.
+    - type: connector
+      name: fetch-fixtures
+      description: All World Cup fixtures (finished + scheduled) from api-football.
+      connector:
+        name: api-football
+        command: get-fixtures
+      inputs:
+        league: "$.get('league', '1')"
+        season: "$.get('season', '2026')"
+      outputs:
+        finished_fixtures: "[f for f in $.get('response', []) if ((f.get('fixture', {}) or {}).get('status', {}) or {}).get('short') in ('FT', 'AET', 'PEN')]"
+        all_fixtures: "$.get('response', [])"
+
+    # 2. FIFA-ranking seed prior (optional).
+    - type: document
+      name: load-seed-ratings
+      description: FIFA-ranking seed prior for the power ranking.
+      continue_on_error: true
+      config:
+        action: search
+        search-limit: 100
+        search-vector: false
+      filters:
+        name: "'worldcup:fifa-ranking'"
+      outputs:
+        seed_ratings: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    # 3. Group-relative power ranking blended with the FIFA seed.
+    - type: connector
+      name: compute-power-ranking
+      description: Team strengths from finished fixtures + FIFA seed.
+      connector:
+        name: worldcup-market-intelligence
+        command: compute_power_ranking
+      inputs:
+        finished_fixtures: "$.get('finished_fixtures', [])"
+        seed_ratings: "$.get('seed_ratings', [])"
+        min_games_full_confidence: "$.get('min_games_full_confidence', 3)"
+      outputs:
+        team_index: "$.get('team_index', {})"
+        field_size_ranked: "$.get('field_size', 0)"
+
+    # 4. Knockout events (from cutoff date) shaped for the engine. Date filtering
+    #    is done in the output expression (in-workflow doc search ignores operator
+    #    filters).
+    - type: document
+      name: load-events
+      description: Cached worldcup:event docs (all); build_bracket filters to the cutoff date.
+      config:
+        action: search
+        search-limit: 500
+        search-vector: false
+      filters:
+        name: "'worldcup:event'"
+      outputs:
+        # Shape every event; the cutoff filter is applied in the engine
+        # (build_bracket from_date) — a `$.get('from_date')` reference inside this
+        # comprehension's if-clause would run in a scope that can't see `$`.
+        knockout_events: |
+          [
+            {
+              'event_urn': d.get('value', {}).get('_id'),
+              'af_id': str((d.get('value', {}).get('provider_ids', {}) or {}).get('api_football') or ''),
+              'start_date': d.get('value', {}).get('schema:startDate'),
+              'status': (d.get('value', {}).get('sport:status') or 'ns'),
+              'teams': [
+                {'name': c.get('name'), 'qualifier': c.get('sport:qualifier')}
+                for c in (d.get('value', {}).get('sport:competitors') or [])
+              ]
+            }
+            for d in ($.get('documents', []) or [])
+            if d.get('value', {}).get('_id')
+          ]
+
+    # 5. Per-match moneyline markets (Kalshi KXWCGAME + 3-way) for the anchor.
+    - type: document
+      name: load-markets
+      description: Cached moneyline markets; spreads/totals excluded.
+      continue_on_error: true
+      config:
+        action: search
+        search-limit: 1000
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+      outputs:
+        markets: |
+          [
+            {
+              'event_urn': d.get('value', {}).get('event_urn'),
+              'id': d.get('value', {}).get('id'),
+              'market_type': d.get('value', {}).get('market_type'),
+              'related_team_urns': d.get('value', {}).get('related_team_urns') or [],
+              'outcomes': d.get('value', {}).get('outcomes') or []
+            }
+            for d in ($.get('documents', []) or [])
+            if d.get('value', {}).get('event_urn')
+            and (
+              str(d.get('value', {}).get('id', '')).startswith('kalshi:KXWCGAME')
+              or (d.get('value', {}).get('market_type') in ('moneyline', 'h2h', 'match_winner', '1x2', '3way'))
+            )
+          ]
+
+    # 6. Build the knockout tree (resolves completed matches from finished fixtures).
+    - type: connector
+      name: build-bracket
+      description: Construct the R32 -> Final tree.
+      connector:
+        name: wcbracket-engine
+        command: build_bracket
+      inputs:
+        knockout_events: "$.get('knockout_events', [])"
+        finished_fixtures: "$.get('finished_fixtures', [])"
+        fixtures: "$.get('all_fixtures', [])"
+        from_date: "$.get('from_date', '2026-06-28')"
+      outputs:
+        bracket: "$.get('bracket', {})"
+
+    # 7. Monte Carlo the bracket forward.
+    - type: connector
+      name: simulate-bracket
+      description: Simulate the tournament, market-anchored where priced.
+      condition: "$.get('bracket', {}).get('rounds')"
+      connector:
+        name: wcbracket-engine
+        command: simulate_bracket
+      inputs:
+        bracket: "$.get('bracket', {})"
+        team_index: "$.get('team_index', {})"
+        markets: "$.get('markets', [])"
+        config: |
+          {
+            'n_sims': $.get('n_sims', 20000),
+            'market_weight': $.get('market_weight', 0.65),
+            'seed': 42
+          }
+      outputs:
+        simulation: "$.get('simulation', {})"
+
+    # 8. Persist the simulation snapshot.
+    - type: document
+      name: store-simulation
+      description: Store the bracket-simulation document.
+      condition: "$.get('simulation', {})"
+      config:
+        action: update
+        embed-vector: false
+        force-update: true
+      filters:
+        name: "'worldcup:bracket-simulation'"
+        metadata.from_date: "str($.get('from_date'))"
+      documents:
+        worldcup:bracket-simulation: |
+          {
+            'from_date': $.get('from_date'),
+            'season': $.get('season'),
+            'field_size': $.get('bracket', {}).get('field_size'),
+            'champion': $.get('simulation', {}).get('champion'),
+            'champion_leaderboard': $.get('simulation', {}).get('champion_leaderboard'),
+            'advancement': $.get('simulation', {}).get('advancement'),
+            'perfect_bracket': $.get('simulation', {}).get('perfect_bracket'),
+            'r32_matches': $.get('simulation', {}).get('r32_matches'),
+            'tree': $.get('bracket', {}).get('rounds'),
+            'config': $.get('simulation', {}).get('config'),
+            'bracket_warnings': $.get('bracket', {}).get('warnings'),
+            'n_sims': $.get('simulation', {}).get('n_sims'),
+            'disclaimer': $.get('simulation', {}).get('disclaimer')
+          }
+      metadata:
+        from_date: "str($.get('from_date'))"
+        season: "str($.get('season'))"
+      outputs:
+        bracket_simulation_id: "$.get('documents')[0].get('_id') if $.get('documents') else None"


### PR DESCRIPTION
Additive, non-disruptive World Cup knockout bracket simulator deployed to the world-cup-intelligence pod.

## What it does
Forward-simulates the WC2026 knockout bracket (R32→Final) via Monte Carlo over analytic Dixon-Coles pairwise advance probabilities, anchored to per-match Kalshi 3-way moneyline where priced and carried by the model elsewhere. Emits champion odds, per-team advancement matrix, and the single most-likely ("perfect") bracket. Ships an **inactive** on-demand agent (never auto-schedules).

New: `wcbracket-engine.{py,yml}` (build_bracket + simulate_bracket), `workflows/wcbracket-simulate.yml`, `workflows/wcbracket-get-bracket.yml`, `agents/wcbracket-simulator.yml`, design doc, `_install.yml` v0.6.0.

## Fixes made during smoke-test on live pod data
1. **Knockout-round filter** — build by api-football `league.round` (exclude "group"), not a date cutoff. The 06-28 final group games kicked off before the first knockout and a date cutoff leaked them in (and dedup then dropped a real R32 match). Now exactly 16 distinct R32 matchups.
2. **from_date filter moved into the engine** — a `$.get('from_date')` reference inside a workflow list-comprehension if-clause silently yields zero rows (engine evals `$` as a local; comprehension scopes only see globals).
3. **Market matcher for the knockout 3-way shape** — Kalshi posts three YES/NO binaries per fixture (`-XXX`/`-YYY`/`-TIE`); side is resolved from the market-id suffix via `related_team_urns`, with the older team-named shape still honored and a team-pair fallback when event_urn linking lags.
4. **FIFA/IOC → ISO-3166 team-code alias** — Kalshi suffixes use FIFA codes (RSA/GER/NED/SUI/POR/CRO/ALG…) but our team URNs use ISO-3166 (zaf/deu/nld/che/prt/hrv/dza…); without the alias those 5 knockout matches never anchored.

## Validation (live, n_sims=20000)
field_size 16, no warnings, **16/16 R32 anchored** to market, champion Argentina 16.4% / France 12.0% / Mexico 9.5%, perfect bracket 5 rounds, leaderboard ≈ 1.0, clean name-matching across all 32 teams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)