### PR TITLE
feat(worldcup): cross-source Kalshi↔Polymarket market pairing

### DIFF
--- a/agent-templates/world-cup-intelligence/mappings/worldcup-market-normalization.yml
+++ b/agent-templates/world-cup-intelligence/mappings/worldcup-market-normalization.yml
@@ -17,7 +17,3 @@ mappings:
           },
           "data_quality_notes": []
         }
-      edge_candidates: |
-        []
-      warnings: |
-        ["Edge detection is not yet implemented: cross-source outcome pairing is pending, so no edge candidates are produced."]

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -120,6 +120,25 @@ class TestNormalizeMarketSources:
         ids = {m["cache_id"] for m in result["data"]["markets"]}
         assert "polymarket:2735826" in ids and "polymarket:2415458" in ids
 
+    def test_advance_market_tagged_by_round(self):
+        # Per-nation 'reach round X' binaries carry no sportsMarketType; the
+        # round is detected from the question/slug so pairing can bucket them.
+        r16 = _poly_record(id="2415420", question="Will Mexico reach the Round of 16 at the 2026 FIFA World Cup?",
+                           slug="will-mexico-reach-the-round-of-16-at-the-2026-fifa-world-cup")
+        sf = _poly_record(id="9001", question="Will Brazil reach the Semifinals at the 2026 FIFA World Cup?",
+                          slug="will-brazil-reach-the-semifinals")
+        result = normalize_market_sources({"params": {"polymarket_markets": {"markets": [r16, sf]}}})
+        by_id = {m["cache_id"]: m for m in result["data"]["markets"]}
+        assert by_id["polymarket:2415420"]["market_type"] == "advance_r16"
+        assert by_id["polymarket:9001"]["market_type"] == "advance_sf"
+
+    def test_moneyline_market_type_preserved_over_advance(self):
+        # A plain game moneyline keeps its provider market type (no false advance tag).
+        ml = _poly_record(id="2735826", question="Will Mexico win on 2026-06-30?",
+                          slug="fifwc-mex-ecu-2026-06-30-mex", sports_market_type="moneyline")
+        result = normalize_market_sources({"params": {"polymarket_markets": {"markets": [ml]}}})
+        assert result["data"]["markets"][0]["market_type"] == "moneyline"
+
     def test_metadata_is_upsert_key(self):
         result = normalize_market_sources(
             {"params": {"polymarket_markets": {"markets": [_poly_record()]}}}

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -2245,3 +2245,64 @@ class TestPairCrossSource:
 
 MEX_ECU = ("urn:machina:sport:soccer:team:mexico:mex",
            "urn:machina:sport:soccer:team:ecuador:ecu")
+
+
+class TestCrossSourceEndToEnd:
+    """Full chain on realistic payloads: normalize -> link -> pair.
+
+    Guards the production-shape gotcha: cached Kalshi game legs name the YES
+    side "Yes" (not the team), so pairing must discriminate via the ticker
+    suffix / iso3, not the outcome name.
+    """
+    TEAMS = [
+        {"_id": "urn:machina:sport:soccer:team:mexico:mex", "name": "Mexico"},
+        {"_id": "urn:machina:sport:soccer:team:ecuador:ecu", "name": "Ecuador"},
+    ]
+    EVENTS = [{"_id": "urn:machina:sport:soccer:event:mexico-vs-ecuador:20260701:wor",
+               "sport:competitors": [{"@id": "urn:machina:sport:soccer:team:mexico:mex"},
+                                     {"@id": "urn:machina:sport:soccer:team:ecuador:ecu"}]}]
+
+    def _kalshi_payload(self):
+        # Shape returned by sports-skills invoke_kalshi search_markets (no
+        # yes_sub_title -> normalized YES name becomes "Yes").
+        def leg(suffix, last_price):
+            return {"ticker": f"KXWCGAME-26JUN30MEXECU-{suffix}",
+                    "event_ticker": "KXWCGAME-26JUN30MEXECU",
+                    "title": "Mexico vs Ecuador Winner?", "status": "active",
+                    "last_price": last_price, "volume": 1000}
+        return {"markets": [leg("MEX", 43), leg("ECU", 23), leg("TIE", 33)]}
+
+    def _poly_payload(self):
+        # Shape returned by sports-skills invoke_polymarket search_markets.
+        def mk(mid, q, slug, price):
+            return {"id": mid, "question": q, "slug": slug, "sports_market_type": "moneyline",
+                    "outcomes": [{"name": "Yes", "price": price}, {"name": "No", "price": round(1 - price, 3)}],
+                    "clob_token_ids": [f"{mid}-y", f"{mid}-n"], "volume": "100000", "spread": 0.01}
+        return {"markets": [
+            mk("1", "Will Mexico win on 2026-06-30?", "fifwc-mex-ecu-2026-06-30-mex", 0.435),
+            mk("2", "Will Ecuador win on 2026-06-30?", "fifwc-mex-ecu-2026-06-30-ecu", 0.225),
+            mk("3", "Will Mexico vs. Ecuador end in a draw?", "fifwc-mex-ecu-2026-06-30-draw", 0.335),
+        ]}
+
+    def test_normalize_link_pair_produces_cross_source_edges(self):
+        norm = normalize_market_sources({"params": {
+            "kalshi_markets": self._kalshi_payload(),
+            "polymarket_markets": self._poly_payload(),
+            "status": "all"}})["data"]["markets"]
+        # both venues, all three legs each
+        assert sum(1 for m in norm if m["source"] == "kalshi") == 3
+        assert sum(1 for m in norm if m["source"] == "polymarket") == 3
+
+        linked = link_market_entities({"params": {
+            "markets": norm, "teams": self.TEAMS, "events": self.EVENTS}})["data"]["normalized_markets"]
+        assert all(m["event_urn"] == self.EVENTS[0]["_id"] for m in linked)
+
+        pairs = pair_cross_source({"params": {"markets": linked}})["data"]["pairs"]
+        by_outcome = {p["outcome"]: p for p in pairs}
+        assert set(by_outcome) == {"mexico", "ecuador", "DRAW"}
+        # Kalshi YES leg discriminated by ticker suffix despite "Yes" outcome name
+        assert by_outcome["mexico"]["kalshi_yes"] == 0.43
+        assert by_outcome["mexico"]["poly_yes"] == 0.435
+        # every leg paired across both venues -> an edge on each
+        assert all("edge_bps" in p for p in pairs)
+        assert by_outcome["ecuador"]["cheaper_venue"] == "polymarket"

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -45,6 +45,7 @@ build_signal_ledger_rows = _module.build_signal_ledger_rows
 compute_clv = _module.compute_clv
 compute_clv_report = _module.compute_clv_report
 _result_outcome = _module._result_outcome
+pair_cross_source = _module.pair_cross_source
 
 
 def _kalshi_record(**overrides):
@@ -2071,3 +2072,106 @@ class TestComputeClvReport:
                 + [_clv_row("CLV-", 1) for _ in range(2)] + [_clv_row("CLV-", 0) for _ in range(8)])
         rep = compute_clv_report({"params": {"clv_rows": rows}})["data"]["clv_report"]
         assert rep["z_test"]["z"] == 2.683 and rep["win_rates"]["gap_pp"] == 60.0
+
+
+class TestPairCrossSource:
+    MEX = "urn:machina:sport:soccer:team:mexico:mex"
+    ECU = "urn:machina:sport:soccer:team:ecuador:ecu"
+    EV = "urn:machina:sport:soccer:event:mexico-vs-ecuador:20260701:wor"
+
+    def _game_markets(self):
+        rel = [MEX_ECU[0], MEX_ECU[1]]
+        return [
+            {"cache_id": "kalshi:MEX", "source": "kalshi", "title": "Mexico vs Ecuador Winner?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Reg Time: Mexico", "price": 0.43}, {"name": "No", "price": 0.56}]},
+            {"cache_id": "kalshi:ECU", "source": "kalshi", "title": "Mexico vs Ecuador Winner?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Reg Time: Ecuador", "price": 0.23}, {"name": "No", "price": 0.76}]},
+            {"cache_id": "kalshi:TIE", "source": "kalshi", "title": "Mexico vs Ecuador Winner?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Tie", "price": 0.33}, {"name": "No", "price": 0.66}]},
+            {"cache_id": "polymarket:mex", "source": "polymarket", "title": "Will Mexico win on 2026-06-30?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.435}, {"name": "No", "price": 0.565}]},
+            {"cache_id": "polymarket:ecu", "source": "polymarket", "title": "Will Ecuador win on 2026-06-30?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.225}, {"name": "No", "price": 0.775}]},
+            {"cache_id": "polymarket:draw", "source": "polymarket", "title": "Will Mexico vs. Ecuador end in a draw?",
+             "event_urn": self.EV, "related_team_urns": rel, "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.335}, {"name": "No", "price": 0.665}]},
+        ]
+
+    def _rows_by_outcome(self, markets):
+        r = pair_cross_source({"params": {"markets": markets}})["data"]
+        return {row["outcome"]: row for row in r["pairs"]}, r
+
+    def test_pairs_game_moneyline_three_outcomes(self):
+        rows, r = self._rows_by_outcome(self._game_markets())
+        assert set(rows) == {"mexico", "ecuador", "DRAW"}
+        assert rows["mexico"]["kalshi_yes"] == 0.43 and rows["mexico"]["poly_yes"] == 0.435
+        assert rows["ecuador"]["edge_bps"] == -62
+        assert rows["mexico"]["edge_bps"] == 29
+        assert rows["DRAW"]["edge_bps"] == 34
+        # sorted by absolute edge, largest first
+        assert abs(r["pairs"][0]["edge_bps"]) >= abs(r["pairs"][-1]["edge_bps"])
+
+    def test_devig_fair_probs_sum_to_one_per_source(self):
+        # De-vig normalizes each source's 3-way to sum to 1.0; displayed fair
+        # values are rounded to 4dp, so allow sub-bps rounding drift.
+        rows, _ = self._rows_by_outcome(self._game_markets())
+        k = sum(rows[o]["kalshi_fair"] for o in rows)
+        p = sum(rows[o]["poly_fair"] for o in rows)
+        assert abs(k - 1.0) <= 0.001 and abs(p - 1.0) <= 0.001
+
+    def test_cheaper_venue_marked(self):
+        rows, _ = self._rows_by_outcome(self._game_markets())
+        # Ecuador YES is cheaper on Polymarket (0.2261 fair) than Kalshi (0.2323)
+        assert rows["ecuador"]["cheaper_venue"] == "polymarket"
+
+    def test_single_source_yields_no_edge(self):
+        kalshi_only = [m for m in self._game_markets() if m["source"] == "kalshi"]
+        rows, _ = self._rows_by_outcome(kalshi_only)
+        assert rows["mexico"]["poly_yes"] is None
+        assert "edge_bps" not in rows["mexico"]
+
+    def test_skips_unreliable_leg(self):
+        markets = self._game_markets()
+        markets[0]["price_quality"] = "unreliable"  # kalshi mexico
+        rows, _ = self._rows_by_outcome(markets)
+        # mexico bucket still present (poly side), but no kalshi price / edge
+        assert rows["mexico"]["kalshi_yes"] is None
+        assert "edge_bps" not in rows["mexico"]
+
+    def test_advance_pairs_by_team_and_round(self):
+        markets = [
+            {"cache_id": "polymarket:adv-mex", "source": "polymarket", "market_type": "advance_r16",
+             "title": "Will Mexico reach the Round of 16 at the 2026 FIFA World Cup?",
+             "event_urn": None, "related_team_urns": [MEX_ECU[0]], "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.63}, {"name": "No", "price": 0.37}]},
+            {"cache_id": "kalshi:adv-mex", "source": "kalshi", "market_type": "advance_r16",
+             "title": "Mexico to reach Round of 16?",
+             "event_urn": None, "related_team_urns": [MEX_ECU[0]], "price_quality": "ok",
+             "outcomes": [{"name": "Mexico", "price": 0.60}, {"name": "No", "price": 0.40}]},
+        ]
+        rows, _ = self._rows_by_outcome(markets)
+        assert "mexico" in rows
+        row = rows["mexico"]
+        assert row["kind"] == "advance"
+        # advance markets are independent binaries -> not de-vigged, fair == raw
+        assert row["kalshi_yes"] == 0.60 and row["poly_yes"] == 0.63
+        assert row["kalshi_fair"] == 0.60 and row["poly_fair"] == 0.63
+        assert row["edge_bps"] == 300
+
+    def test_outright_futures_unpairable_skipped(self):
+        markets = [
+            {"cache_id": "polymarket:win", "source": "polymarket", "title": "Will Mexico win the 2026 World Cup?",
+             "event_urn": None, "related_team_urns": [MEX_ECU[0]], "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.05}]},
+        ]
+        r = pair_cross_source({"params": {"markets": markets}})["data"]
+        assert r["pairs"] == []
+
+
+MEX_ECU = ("urn:machina:sport:soccer:team:mexico:mex",
+           "urn:machina:sport:soccer:team:ecuador:ecu")

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -154,6 +154,12 @@ class TestNormalizeMarketSources:
         result = normalize_market_sources({"params": {"polymarket_markets": {"markets": [ml]}}})
         assert result["data"]["markets"][0]["market_type"] == "moneyline"
 
+    def test_warns_when_one_venue_returns_no_records(self):
+        # Kalshi-only sync -> warn that cross-source pairing is unavailable.
+        result = normalize_market_sources(
+            {"params": {"kalshi_markets": {"markets": [_kalshi_record()]}, "status": "all"}})
+        assert any("Polymarket returned no records" in w for w in result["data"]["warnings"])
+
     def test_metadata_is_upsert_key(self):
         result = normalize_market_sources(
             {"params": {"polymarket_markets": {"markets": [_poly_record()]}}}

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -425,6 +425,35 @@ class TestDetectMarketEdges:
         assert cands[0]["edge_bps"] == 300
         assert cands[0]["direction"] == "buy_all_no"
 
+    def test_cross_venue_moneyline_from_event_urn(self):
+        # Both venues priced for one game, paired on event_urn (no match_markets).
+        EV = "urn:machina:sport:soccer:event:mexico-vs-ecuador:20260701:wor"
+        rel = ["urn:machina:sport:soccer:team:mexico:mex", "urn:machina:sport:soccer:team:ecuador:ecu"]
+
+        def k(cid, name, price):
+            return {"cache_id": cid, "source": "kalshi", "title": "Mexico vs Ecuador Winner?",
+                    "event_urn": EV, "related_team_urns": rel, "price_quality": "ok",
+                    "outcomes": [{"name": name, "price": price}, {"name": "No", "price": round(1 - price, 2)}]}
+
+        def p(cid, title, price):
+            return {"cache_id": cid, "source": "polymarket", "title": title,
+                    "event_urn": EV, "related_team_urns": rel, "price_quality": "ok",
+                    "outcomes": [{"name": "Yes", "price": price}, {"name": "No", "price": round(1 - price, 2)}]}
+
+        cached = [
+            k("kalshi:MEX", "Reg Time: Mexico", 0.50), k("kalshi:ECU", "Reg Time: Ecuador", 0.30),
+            k("kalshi:TIE", "Tie", 0.20),
+            p("polymarket:mex", "Will Mexico win on 2026-06-30?", 0.55),
+            p("polymarket:ecu", "Will Ecuador win on 2026-06-30?", 0.25),
+            p("polymarket:draw", "Will Mexico vs. Ecuador end in a draw?", 0.20),
+        ]
+        r = detect_market_edges({"params": {"cached_markets": cached, "min_edge_bps": 50}})
+        cv = [c for c in r["data"]["edge_candidates"] if c["candidate_type"] == "cross_venue_moneyline"]
+        mex = next(c for c in cv if c["outcome"] == "mexico")
+        assert mex["edge_bps"] == 500
+        assert mex["cheaper_venue"] == "kalshi"
+        assert mex["kalshi_price"] == 0.50 and mex["polymarket_price"] == 0.55
+
     def test_efficient_book_no_edge(self):
         cached = [
             _leg("kalshi:G-A", "G", "A", 0.50),

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -98,6 +98,28 @@ class TestNormalizeMarketSources:
         assert len(markets) == 1
         assert [o["token_id"] for o in markets[0]["outcomes"]] == ["tok-yes", "tok-no"]
 
+    def test_polymarket_game_moneyline_passes_relevance_via_fifwc_slug(self):
+        # Game markets are titled by team with no "World Cup" wording; the
+        # fifwc-* slug is the only relevance signal (regression for U1).
+        record = _poly_record(id="2735826", question="Will Mexico win on 2026-06-30?",
+                              slug="fifwc-mex-ecu-2026-06-30-mex",
+                              outcomes=[{"name": "Yes", "price": 0.435}, {"name": "No", "price": 0.565}],
+                              clob_token_ids=["t-yes", "t-no"])
+        result = normalize_market_sources({"params": {"polymarket_markets": {"markets": [record]}}})
+        markets = result["data"]["markets"]
+        assert len(markets) == 1 and markets[0]["source"] == "polymarket"
+        assert markets[0]["title"] == "Will Mexico win on 2026-06-30?"
+
+    def test_foreach_accumulated_polymarket_payloads(self):
+        # The per-fixture sweep passes [bulk] + one {'markets': [...]} per
+        # foreach iteration; records in every wrapper must be extracted.
+        bulk = {"markets": [_poly_record()]}  # futures via "FIFA World Cup" wording
+        sweep = {"markets": [_poly_record(id="2735826", question="Will Mexico win on 2026-06-30?",
+                                          slug="fifwc-mex-ecu-2026-06-30-mex")]}
+        result = normalize_market_sources({"params": {"polymarket_markets": [bulk, sweep]}})
+        ids = {m["cache_id"] for m in result["data"]["markets"]}
+        assert "polymarket:2735826" in ids and "polymarket:2415458" in ids
+
     def test_metadata_is_upsert_key(self):
         result = normalize_market_sources(
             {"params": {"polymarket_markets": {"markets": [_poly_record()]}}}

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -132,6 +132,21 @@ class TestNormalizeMarketSources:
         assert by_id["polymarket:2415420"]["market_type"] == "advance_r16"
         assert by_id["polymarket:9001"]["market_type"] == "advance_sf"
 
+    def test_advance_round_qf_and_final_and_gating(self):
+        qf = _poly_record(id="9002", question="Will France reach the Quarterfinals at the 2026 FIFA World Cup?",
+                          slug="will-france-reach-the-quarterfinals")
+        fin = _poly_record(id="9003", question="Will Spain reach the Final at the 2026 FIFA World Cup?",
+                           slug="will-spain-reach-the-final")
+        # A knockout moneyline that mentions a round but is NOT a "reach" market
+        # must stay a moneyline (advance tag is gated on "reach").
+        final_game = _poly_record(id="9004", question="Will Argentina win the Final on 2026-07-19?",
+                                  slug="fifwc-arg-fra-2026-07-19-arg", sports_market_type="moneyline")
+        result = normalize_market_sources({"params": {"polymarket_markets": {"markets": [qf, fin, final_game]}}})
+        by_id = {m["cache_id"]: m for m in result["data"]["markets"]}
+        assert by_id["polymarket:9002"]["market_type"] == "advance_qf"
+        assert by_id["polymarket:9003"]["market_type"] == "advance_final"
+        assert by_id["polymarket:9004"]["market_type"] == "moneyline"
+
     def test_moneyline_market_type_preserved_over_advance(self):
         # A plain game moneyline keeps its provider market type (no false advance tag).
         ml = _poly_record(id="2735826", question="Will Mexico win on 2026-06-30?",
@@ -2144,6 +2159,10 @@ class TestComputeClvReport:
         assert rep["z_test"]["z"] == 2.683 and rep["win_rates"]["gap_pp"] == 60.0
 
 
+MEX_ECU = ("urn:machina:sport:soccer:team:mexico:mex",
+           "urn:machina:sport:soccer:team:ecuador:ecu")
+
+
 class TestPairCrossSource:
     MEX = "urn:machina:sport:soccer:team:mexico:mex"
     ECU = "urn:machina:sport:soccer:team:ecuador:ecu"
@@ -2212,6 +2231,52 @@ class TestPairCrossSource:
         # mexico bucket still present (poly side), but no kalshi price / edge
         assert rows["mexico"]["kalshi_yes"] is None
         assert "edge_bps" not in rows["mexico"]
+        # Dropping one leg leaves Kalshi's book incomplete (ecu+tie=0.56); its
+        # surviving legs must NOT be de-vigged against that short total and
+        # must NOT manufacture an edge on ecuador/DRAW.
+        assert rows["ecuador"]["kalshi_fair"] is None
+        assert "edge_bps" not in rows["ecuador"]
+        assert "edge_bps" not in rows["DRAW"]
+
+    def test_incomplete_book_does_not_fabricate_edge(self):
+        # Kalshi carries only the Mexico leg; Polymarket has the full 3-way.
+        # De-vigging the lone Kalshi leg to 1.0 would fabricate a huge edge.
+        markets = [m for m in self._game_markets()
+                   if m["cache_id"] in ("kalshi:MEX", "polymarket:mex", "polymarket:ecu", "polymarket:draw")]
+        rows, _ = self._rows_by_outcome(markets)
+        assert rows["mexico"]["kalshi_yes"] == 0.43      # raw price still shown
+        assert rows["mexico"]["kalshi_fair"] is None     # but not de-vigged
+        assert "edge_bps" not in rows["mexico"]          # and no fabricated edge
+
+    def test_fuzzy_fallback_matches_typo(self):
+        # "ngland" is not an exact/substring/iso3 match for "england" but the
+        # difflib ratio is >= 0.85, so the fuzzy fallback should resolve it.
+        EV = "urn:machina:sport:soccer:event:england-vs-wales:20260615:wor"
+        eng = "urn:machina:sport:soccer:team:england:eng"
+        wal = "urn:machina:sport:soccer:team:wales:wal"
+        m = {"cache_id": "polymarket:x", "source": "polymarket",
+             "title": "Will Ngland win on 2026-06-15?", "event_urn": EV,
+             "related_team_urns": [eng, wal], "price_quality": "ok",
+             "outcomes": [{"name": "Yes", "price": 0.5}, {"name": "No", "price": 0.5}]}
+        rows, _ = self._rows_by_outcome([m])
+        assert "england" in rows and "wales" not in rows
+
+    def test_fuzzy_does_not_collide_near_distinct_nations(self):
+        # Iran/Iraq differ by one char (ratio 0.75 < 0.85): a Kalshi leg whose
+        # only discriminator is the iso3 ticker suffix must bucket to exactly
+        # one nation, never cross-match the other.
+        EV = "urn:machina:sport:soccer:event:iran-vs-iraq:20260615:wor"
+        iran = "urn:machina:sport:soccer:team:iran:irn"
+        iraq = "urn:machina:sport:soccer:team:iraq:irq"
+
+        def kalshi(cid, suffix, price):
+            return {"cache_id": cid, "source": "kalshi", "title": "Iran vs Iraq Winner?",
+                    "slug": f"KXWCGAME-26JUN15IRNIRQ-{suffix}", "event_urn": EV,
+                    "related_team_urns": [iran, iraq], "price_quality": "ok",
+                    "outcomes": [{"name": "Yes", "price": price}, {"name": "No", "price": round(1 - price, 3)}]}
+        rows, _ = self._rows_by_outcome([kalshi("kalshi:IRN", "IRN", 0.6), kalshi("kalshi:IRQ", "IRQ", 0.4)])
+        assert rows["iran"]["kalshi_yes"] == 0.6
+        assert rows["iraq"]["kalshi_yes"] == 0.4
 
     def test_advance_pairs_by_team_and_round(self):
         markets = [
@@ -2241,10 +2306,6 @@ class TestPairCrossSource:
         ]
         r = pair_cross_source({"params": {"markets": markets}})["data"]
         assert r["pairs"] == []
-
-
-MEX_ECU = ("urn:machina:sport:soccer:team:mexico:mex",
-           "urn:machina:sport:soccer:team:ecuador:ecu")
 
 
 class TestCrossSourceEndToEnd:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml
@@ -12,14 +12,19 @@ workflow:
     include_reasoning: "$.get('include_reasoning', False)"
   outputs:
     comparison: "$.get('comparison', {})"
+    edge_candidates: "$.get('edge_candidates', [])"
+    count: "len($.get('edge_candidates', []))"
+    warnings: "$.get('pair_warnings', [])"
     workflow-status: "$.get('comparison', {}) != {} and 'executed' or 'skipped'"
   tasks:
     - type: document
       name: lookup-markets
       description: Load normalized markets for comparison from the same pod document store.
       config:
+        # 500, not 50: cross-source pairing needs the full tournament book (both
+        # venues across all fixtures + advance rounds), which exceeds 50.
         action: search
-        search-limit: 50
+        search-limit: 500
         search-vector: false
       filters:
         name: "'worldcup:market-cache'"
@@ -34,3 +39,16 @@ workflow:
         market_type: "$.get('market_type', 'all')"
       outputs:
         comparison: "$.get('comparison', {'markets': $.get('markets', []), 'data_quality_notes': []})"
+
+    - type: connector
+      name: pair-cross-source
+      description: Pair Kalshi/Polymarket markets on event_urn (games) or advance round, de-vig, and emit cross-source edges.
+      connector:
+        name: worldcup-market-intelligence
+        command: pair_cross_source
+      inputs:
+        markets: "$.get('markets', [])"
+      outputs:
+        # $ is the connector data payload (envelope already stripped).
+        edge_candidates: "$.get('pairs', [])"
+        pair_warnings: "$.get('warnings', [])"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml
@@ -1,7 +1,7 @@
 workflow:
   name: worldcup-find-market-edges
   title: World Cup Intelligence - Find Market Edges
-  description: Identify informational price dislocations and arbitrage candidates across Kalshi/Polymarket (within-venue book sums + cross-venue draw lines). Does not execute trades.
+  description: Identify informational price dislocations and arbitrage candidates across Kalshi/Polymarket (within-venue book sums + full 3-way cross-venue moneyline/advance lines, paired on canonical event_urn). Does not execute trades.
 
   context-variables:
     debugger:

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
@@ -141,6 +141,30 @@ workflow:
       outputs:
         polymarket_games: "[$.get('data', {})] if $.get('status') else []"
 
+    # Tournament advance markets (reach Round of 16 / QF / SF / Final) live as
+    # per-nation binaries under a few Polymarket events; the keyword search
+    # above catches them only sparsely. Query each round's event title for
+    # comprehensive per-nation coverage. Normalization tags market_type
+    # advance_<round> so cross-source pairing can bucket nation-vs-nation.
+    - type: connector
+      name: fetch-polymarket-advance
+      description: Polymarket tournament advance markets (reach Round of 16 / QF / SF / Final).
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_polymarket
+      foreach:
+        concurrent: false
+        name: poly_advance_query_item
+        expr: $
+        value: "['Reach Round of 16', 'Reach Quarterfinals', 'Reach Semifinals', 'Reach Final']"
+      inputs:
+        command: "'search_markets'"
+        query: "$.get('poly_advance_query_item', '')"
+        limit: "60"
+      outputs:
+        polymarket_advance: "[$.get('data', {})] if $.get('status') else []"
+
     - type: connector
       name: normalize-market-sources
       description: Normalize Sports Skills, Kalshi, and Polymarket market payloads into cacheable WorldCupMarket records.
@@ -149,7 +173,7 @@ workflow:
         command: normalize_market_sources
       inputs:
         sports_skills_markets: "$.get('sports_skills_markets', {})"
-        polymarket_markets: "[$.get('polymarket_markets', {})] + ($.get('polymarket_games', []) or [])"
+        polymarket_markets: "[$.get('polymarket_markets', {})] + ($.get('polymarket_games', []) or []) + ($.get('polymarket_advance', []) or [])"
         kalshi_markets: "[$.get('kalshi_markets', {})] + ($.get('kalshi_upcoming', []) or [])"
         query: "$.get('search_query', 'FIFA World Cup')"
         source: "$.get('source', 'all')"

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml
@@ -115,6 +115,32 @@ workflow:
       outputs:
         kalshi_upcoming: "[$.get('data', {})] if $.get('status') else []"
 
+    # Polymarket game moneylines are titled by team ("Mexico vs. Ecuador" /
+    # "Will Mexico win on …") and slugged fifwc-<a>-<b>-<date>, so the broad
+    # "FIFA World Cup" keyword search above never surfaces them. Mirror the
+    # Kalshi per-fixture sweep: one moneyline query per upcoming fixture. The
+    # normalization relevance gate (now incl. the fifwc slug term) filters.
+    - type: connector
+      name: fetch-polymarket-games
+      description: Per-fixture Polymarket moneyline fetch for upcoming matchdays (one team query per fixture via foreach).
+      condition: "len($.get('upcoming_team_queries', [])) > 0"
+      continue_on_error: true
+      connector:
+        name: sports-skills
+        command: invoke_polymarket
+      foreach:
+        concurrent: false
+        name: poly_team_query_item
+        expr: $
+        value: "$.get('upcoming_team_queries', [])"
+      inputs:
+        command: "'search_markets'"
+        query: "$.get('poly_team_query_item', '')"
+        sports_market_types: "'moneyline'"
+        limit: "50"
+      outputs:
+        polymarket_games: "[$.get('data', {})] if $.get('status') else []"
+
     - type: connector
       name: normalize-market-sources
       description: Normalize Sports Skills, Kalshi, and Polymarket market payloads into cacheable WorldCupMarket records.
@@ -123,7 +149,7 @@ workflow:
         command: normalize_market_sources
       inputs:
         sports_skills_markets: "$.get('sports_skills_markets', {})"
-        polymarket_markets: "$.get('polymarket_markets', {})"
+        polymarket_markets: "[$.get('polymarket_markets', {})] + ($.get('polymarket_games', []) or [])"
         kalshi_markets: "[$.get('kalshi_markets', {})] + ($.get('kalshi_upcoming', []) or [])"
         query: "$.get('search_query', 'FIFA World Cup')"
         source: "$.get('source', 'all')"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2683,6 +2683,162 @@ def compute_market_movers(request_data: dict[str, Any]) -> dict[str, Any]:
     return {"status": True, "data": {"movers": movers, "count": len(movers)}}
 
 
+def _team_slug_from_urn(urn: Any) -> str:
+    """Team slug segment of a canonical team URN (…:team:<slug>:<iso3>)."""
+    parts = _text(urn).split(":")
+    return parts[-2] if len(parts) >= 2 else ""
+
+
+def _market_subject(market: dict[str, Any]) -> str:
+    """Discriminating subject of a market: a team name, or 'draw'.
+
+    Kalshi game legs carry the team in the first outcome name ("Reg Time:
+    Mexico" / "Tie"); Polymarket legs carry it in the question ("Will Mexico
+    win …" / "… end in a draw?"). Both reduce to the subject the YES side bets.
+    """
+    name0 = _lower((market.get("outcomes") or [{}])[0].get("name")).replace("reg time:", "").strip()
+    if name0 and name0 not in ("yes", "no"):
+        return name0
+    title = _lower(market.get("title"))
+    if "draw" in title or "tie" in title:
+        return "draw"
+    m = re.search(r"will\s+(.+?)\s+(?:win|reach|advance)", title)
+    if m:
+        return m.group(1).strip()
+    slug = _lower(market.get("slug"))
+    return slug.rsplit("-", 1)[-1] if slug else ""
+
+
+def _pair_bucket(market: dict[str, Any]) -> str | None:
+    """Canonical pairing bucket: a related team URN, 'DRAW', or None (unpairable).
+
+    Buckets come from related_team_urns (already alias-resolved by
+    link_market_entities), so this only has to pick WHICH related team the
+    market's YES refers to — by the discriminating subject text.
+    """
+    subject = _market_subject(market)
+    if "draw" in subject or "tie" in subject:
+        return "DRAW"
+    related = [u for u in (market.get("related_team_urns") or []) if u]
+    if not related:
+        return None
+    if len(related) == 1:
+        return related[0]
+    subj_slug = _slugify(subject)
+    subj_slug = _MARKET_TEAM_ALIASES.get(subj_slug, subj_slug)
+    best, best_ratio = None, 0.0
+    for urn in related:
+        team_slug = _team_slug_from_urn(urn)
+        if not team_slug:
+            continue
+        if team_slug == subj_slug or team_slug in subj_slug:
+            return urn
+        ratio = difflib.SequenceMatcher(None, team_slug, subj_slug).ratio()
+        if ratio > best_ratio:
+            best_ratio, best = ratio, urn
+    return best if best_ratio >= 0.85 else None
+
+
+def pair_cross_source(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Pair normalized markets across Kalshi/Polymarket and report cross-source edges.
+
+    Pairs on the canonical event_urn (games) or market_type round (advance
+    markets) already stamped by link_market_entities — no dependency on
+    sports-skills match_markets. Game groups (mutually exclusive home/away/draw)
+    are de-vigged so each source's YES prices sum to 1.0 before comparison;
+    advance markets are independent binaries and are NOT de-vigged (fair == raw).
+    Unreliable quotes are dropped so thin/stale books can't throw fake edges.
+    edge_bps = (poly_fair - kalshi_fair) * 10000, computed from the displayed
+    (4dp) fair probabilities. Read-only / informational — not betting advice.
+
+    Params:
+      - markets: linked WorldCupMarket[] (carry event_urn / related_team_urns)
+      - min_edge_bps: floor for reporting a row that HAS an edge (default 0)
+      - limit: max pairs (default 100)
+    """
+    params = _params(request_data)
+    try:
+        min_edge_bps = int(params.get("min_edge_bps") or 0)
+    except (TypeError, ValueError):
+        min_edge_bps = 0
+    try:
+        limit = max(1, min(int(params.get("limit") or 100), 500))
+    except (TypeError, ValueError):
+        limit = 100
+
+    markets = [m for m in _as_list(params.get("markets"))
+               if isinstance(m, dict) and m.get("price_quality") != "unreliable"]
+
+    # group_key -> {"kind", "by_source": {source: {bucket: yes_price}}}
+    groups: dict[tuple, dict[str, Any]] = {}
+    for m in markets:
+        bucket = _pair_bucket(m)
+        if bucket is None:
+            continue
+        event_urn = _text(m.get("event_urn"))
+        mtype = _lower(m.get("market_type"))
+        if event_urn:
+            group_key, kind = ("game", event_urn), "game"
+        elif mtype.startswith("advance"):
+            group_key, kind = ("advance", mtype), "advance"
+        else:
+            continue  # outright futures / props — no cross-source counterpart
+        price = _yes_price(m)
+        if price is None:
+            continue
+        g = groups.setdefault(group_key, {"kind": kind, "by_source": {}})
+        g["by_source"].setdefault(_text(m.get("source")), {})[bucket] = price
+
+    pairs: list[dict[str, Any]] = []
+    for group_key, g in groups.items():
+        kind = g["kind"]
+        by_source = g["by_source"]
+        # De-vig only mutually-exclusive game books; advance binaries stay raw.
+        fair_by_source: dict[str, dict[str, float]] = {}
+        for source, buckets in by_source.items():
+            if kind == "game":
+                total = sum(buckets.values())
+                fair_by_source[source] = {b: (p / total if total else None) for b, p in buckets.items()}
+            else:
+                fair_by_source[source] = dict(buckets)
+        for bucket in sorted({b for buckets in by_source.values() for b in buckets}):
+            k_yes = by_source.get("kalshi", {}).get(bucket)
+            p_yes = by_source.get("polymarket", {}).get(bucket)
+            k_fair = fair_by_source.get("kalshi", {}).get(bucket)
+            p_fair = fair_by_source.get("polymarket", {}).get(bucket)
+            k_fair = round(k_fair, 4) if k_fair is not None else None
+            p_fair = round(p_fair, 4) if p_fair is not None else None
+            row = {
+                "group_key": group_key[1],
+                "kind": kind,
+                "outcome": "DRAW" if bucket == "DRAW" else _team_slug_from_urn(bucket),
+                "team_urn": None if bucket == "DRAW" else bucket,
+                "kalshi_yes": round(k_yes, 6) if k_yes is not None else None,
+                "poly_yes": round(p_yes, 6) if p_yes is not None else None,
+                "kalshi_fair": k_fair,
+                "poly_fair": p_fair,
+            }
+            if k_fair is not None and p_fair is not None:
+                row["edge_bps"] = round((p_fair - k_fair) * 10000)
+                row["cheaper_venue"] = "kalshi" if k_fair < p_fair else "polymarket"
+            pairs.append(row)
+
+    if min_edge_bps > 0:
+        pairs = [r for r in pairs if "edge_bps" not in r or abs(r["edge_bps"]) >= min_edge_bps]
+    pairs.sort(key=lambda r: abs(r.get("edge_bps", 0)), reverse=True)
+    pairs = pairs[:limit]
+
+    warnings = []
+    if not markets:
+        warnings.append("No reliable markets supplied -- run worldcup-sync-market-sources first.")
+    elif not any("edge_bps" in r for r in pairs):
+        warnings.append(
+            "No cross-source pairs found -- both Kalshi and Polymarket must cover the same fixture/outcome."
+        )
+
+    return {"status": True, "data": {"pairs": pairs, "count": len(pairs), "warnings": warnings}}
+
+
 # Live status set — fixtures considered in-play for coverage cadence.
 _LIVE_STATUS = {"1H", "HT", "2H", "ET", "BT", "P", "SUSP", "INT", "LIVE"}
 _FINAL_STATUS = {"FT", "AET", "PEN"}

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -875,6 +875,31 @@ def detect_market_edges(request_data):
             ],
         })
 
+    # 2b. Cross-venue full 3-way moneyline + advance lines, paired on the
+    # canonical event_urn / advance round already stamped on each market — no
+    # dependency on match_markets. Generalizes the draw-only detector above to
+    # every outcome; both may fire on the draw line, callers dedupe by edge_bps.
+    for row in pair_cross_source({"params": {"markets": cached, "min_edge_bps": min_edge_bps}})["data"]["pairs"]:
+        if row.get("edge_bps") is None:
+            continue
+        candidates.append({
+            "candidate_type": "cross_venue_moneyline",
+            "group_key": row.get("group_key"),
+            "kind": row.get("kind"),
+            "outcome": row.get("outcome"),
+            "team_urn": row.get("team_urn"),
+            "kalshi_price": row.get("kalshi_yes"),
+            "polymarket_price": row.get("poly_yes"),
+            "kalshi_fair": row.get("kalshi_fair"),
+            "polymarket_fair": row.get("poly_fair"),
+            "edge_bps": abs(row["edge_bps"]),
+            "cheaper_venue": row.get("cheaper_venue"),
+            "caveats": [
+                "Fair prices are de-vigged within each venue; compare net of fees, liquidity, and resolution rules.",
+                "Draw/advance lines may differ in resolution rules (90-min vs incl. extra time) across venues.",
+            ],
+        })
+
     # 3. Model-vs-market gaps (only when forecasts are supplied). Appended to the
     # same list; when `forecasts` is absent this block is a no-op and the two
     # legacy detectors above are byte-identical.
@@ -889,7 +914,8 @@ def detect_market_edges(request_data):
     if not cached:
         warnings.append("No cached markets supplied -- run worldcup-sync-market-sources first.")
     if not params.get("matches"):
-        warnings.append("No match pairs supplied -- cross-venue draw detection skipped (within-venue only).")
+        warnings.append("No match_markets pairs supplied -- legacy cross_venue_draw skipped; "
+                        "cross_venue_moneyline still runs via canonical event_urn pairing.")
     if not candidates:
         warnings.append("No dislocations >= " + str(min_edge_bps) + " bps found. Markets look efficiently priced.")
 

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -208,6 +208,26 @@ def _binary_price_quality(outcomes: list[dict[str, Any]]) -> str:
     return "ok"
 
 
+def _advance_round(record: dict[str, Any]) -> str | None:
+    """Tag tournament 'reach round X' markets so cross-source pairing can bucket
+    them by round. Polymarket carries these as per-nation binaries under events
+    like world-cup-nation-to-reach-round-of-16 (sportsMarketType is null), so we
+    detect from the slug/title rather than a market-type field.
+    """
+    text = _lower(_first(record, "slug", "ticker", "market_ticker")) + " " + _lower(
+        _first(record, "title", "question")
+    )
+    if "round of 16" in text or "round-of-16" in text:
+        return "advance_r16"
+    if "quarterfinal" in text or "quarter-final" in text or "quarter final" in text:
+        return "advance_qf"
+    if "semifinal" in text or "semi-final" in text or "semi final" in text:
+        return "advance_sf"
+    if "reach the final" in text or "reach-the-final" in text or "to-reach-final" in text or "nation-to-reach-final" in text:
+        return "advance_final"
+    return None
+
+
 def _normalize_record(source: str, record: dict[str, Any], fetched_at: str) -> dict[str, Any] | None:
     if not isinstance(record, dict):
         return None
@@ -275,7 +295,12 @@ def _normalize_record(source: str, record: dict[str, Any], fetched_at: str) -> d
         "description": _text(_first(record, "description", "rules", "subtitle")) or None,
         "slug": _text(_first(record, "slug", "ticker", "market_ticker")) or None,
         "status": status,
-        "market_type": _text(_first(record, "sports_market_type", "type", "category", "market_type")) or None,
+        # Advance-round tag (advance_r16 / _qf / _sf / _final) takes precedence
+        # so cross-source pairing can group per-nation 'reach round X' binaries;
+        # otherwise the provider's own market type (e.g. moneyline) carries.
+        "market_type": _advance_round(record)
+        or _text(_first(record, "sports_market_type", "type", "category", "market_type"))
+        or None,
         "outcomes": outcomes,
         "price_quality": price_quality,
         "volume": _first(record, "volume", "volume_24h", "dollar_volume", "volume_fp"),

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2598,6 +2598,14 @@ def link_market_entities(request_data: dict[str, Any]) -> dict[str, Any]:
     """
     params = _params(request_data)
     index = _market_team_index(_as_list(params.get("teams")))
+    # iso3 -> urn, to resolve Polymarket game slugs (fifwc-<a>-<b>-<date>) whose
+    # titles name only one team (the other is an abbreviated iso3 code).
+    iso3_to_urn: dict[str, str] = {}
+    for t in _as_list(params.get("teams")):
+        if isinstance(t, dict):
+            urn = _text(_first(t, "_id", "@id", "id"))
+            if urn:
+                iso3_to_urn[urn.split(":")[-1]] = urn
     by_pair: dict[frozenset, str] = {}
     for ev in _as_list(params.get("events")):
         if not isinstance(ev, dict):
@@ -2617,6 +2625,15 @@ def link_market_entities(request_data: dict[str, Any]) -> dict[str, Any]:
             " ".join(_text(o.get("name")) for o in (m.get("outcomes") or []) if isinstance(o, dict)),
         ])
         related = _match_team_urns(_slugify(text), index)
+        # Polymarket game legs name only one team; recover the pair from the
+        # fifwc-<a>-<b>-<date> slug's two iso3 codes so event_urn resolves.
+        if len(related) < 2:
+            slug_match = re.match(r"fifwc-([a-z]{3})-([a-z]{3})-\d", _lower(m.get("slug")))
+            if slug_match:
+                pair = [iso3_to_urn.get(slug_match.group(1)), iso3_to_urn.get(slug_match.group(2))]
+                pair = [u for u in pair if u]
+                if len(pair) == 2:
+                    related = pair
         m["competition_urn"] = WC_COMPETITION_URN
         m["related_team_urns"] = related
         m["event_urn"] = by_pair.get(frozenset(related)) if len(related) == 2 else None
@@ -2784,9 +2801,13 @@ def _pair_bucket(market: dict[str, Any]) -> str | None:
     best, best_ratio = None, 0.0
     for urn in related:
         team_slug = _team_slug_from_urn(urn)
+        # iso3 is the trailing URN segment (…:team:mexico:mex). Cached Kalshi
+        # game legs name the YES side "Yes", so the only discriminator is the
+        # ticker suffix (…-MEX) the slug carries — match it against the iso3.
+        iso3 = _text(urn).split(":")[-1]
         if not team_slug:
             continue
-        if team_slug == subj_slug or team_slug in subj_slug:
+        if subj_slug in (team_slug, iso3) or team_slug in subj_slug:
             return urn
         ratio = difflib.SequenceMatcher(None, team_slug, subj_slug).ratio()
         if ratio > best_ratio:

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -26,6 +26,10 @@ WORLD_CUP_TERMS = (
     # carry no World Cup wording — the ticker in the haystack is the signal.
     "kxwc",
     "worldcup",
+    # Polymarket World Cup game event slugs (e.g. fifwc-mex-ecu-2026-06-30-mex).
+    # Game-market titles ("Will Mexico win on 2026-06-30?") carry no World Cup
+    # wording — the slug prefix is the signal.
+    "fifwc",
 )
 
 

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -217,6 +217,12 @@ def _advance_round(record: dict[str, Any]) -> str | None:
     text = _lower(_first(record, "slug", "ticker", "market_ticker")) + " " + _lower(
         _first(record, "title", "question")
     )
+    # Advance markets are always phrased "... reach the <round>" / slugged
+    # "...-to-reach-...". Gate on that so a knockout-game moneyline that merely
+    # mentions a round ("Will Argentina win the final?") is NOT mis-tagged as an
+    # advance market and stays a moneyline.
+    if "reach" not in text:
+        return None
     if "round of 16" in text or "round-of-16" in text:
         return "advance_r16"
     if "quarterfinal" in text or "quarter-final" in text or "quarter final" in text:
@@ -2799,7 +2805,10 @@ def _pair_bucket(market: dict[str, Any]) -> str | None:
     subj_slug = _slugify(subject)
     subj_slug = _MARKET_TEAM_ALIASES.get(subj_slug, subj_slug)
     best, best_ratio = None, 0.0
-    for urn in related:
+    # Longest team slug first so a team whose slug is a prefix of another in the
+    # same fixture (guinea / guinea-bissau, congo / congo-dr) can't shadow the
+    # more specific match in the `team_slug in subj_slug` substring branch.
+    for urn in sorted(related, key=lambda u: len(_team_slug_from_urn(u)), reverse=True):
         team_slug = _team_slug_from_urn(urn)
         # iso3 is the trailing URN segment (…:team:mexico:mex). Cached Kalshi
         # game legs name the YES side "Yes", so the only discriminator is the
@@ -2874,7 +2883,18 @@ def pair_cross_source(request_data: dict[str, Any]) -> dict[str, Any]:
         for source, buckets in by_source.items():
             if kind == "game":
                 total = sum(buckets.values())
-                fair_by_source[source] = {b: (p / total if total else None) for b, p in buckets.items()}
+                # De-vig ONLY a complete mutually-exclusive book. An incomplete
+                # book — a leg never ingested, dropped as unreliable, or a
+                # partial continue_on_error fetch — sums well below 1.0; dividing
+                # the survivors by that short total inflates them past their true
+                # probability and manufactures a large false cross-source edge.
+                # A complete 2-/3-way book sums to ~1.0 plus a small overround,
+                # so gate on a sane band; outside it, fair is unknown (None) and
+                # no edge is emitted for that source's legs.
+                if 0.90 <= total <= 1.20:
+                    fair_by_source[source] = {b: p / total for b, p in buckets.items()}
+                else:
+                    fair_by_source[source] = {b: None for b in buckets}
             else:
                 fair_by_source[source] = dict(buckets)
         for bucket in sorted({b for buckets in by_source.values() for b in buckets}):

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -451,6 +451,16 @@ def normalize_market_sources(request_data: dict[str, Any]) -> dict[str, Any]:
         warnings.append("Kalshi returned records, but none matched the World Cup/status/source filters.")
     if poly_records and not any(m.get("source") == "polymarket" for m in markets):
         warnings.append("Polymarket returned records, but none matched the World Cup/status/source filters.")
+    # Asymmetric ingestion is the common failure mode: each fetch task runs
+    # under continue_on_error, so one venue can silently come back empty and
+    # leave a single-venue cache. Cross-source pairing needs both venues, so
+    # surface the gap rather than letting it look like a clean sync.
+    if kalshi_records and not poly_records:
+        warnings.append("Polymarket returned no records this sync (fetch may have failed); "
+                        "cache will be Kalshi-only and cross-source pairing is unavailable.")
+    if poly_records and not kalshi_records:
+        warnings.append("Kalshi returned no records this sync (fetch may have failed); "
+                        "cache will be Polymarket-only and cross-source pairing is unavailable.")
 
     return {
         "status": True,

--- a/docs/plans/2026-06-30-001-feat-cross-source-market-pairing-plan.md
+++ b/docs/plans/2026-06-30-001-feat-cross-source-market-pairing-plan.md
@@ -1,0 +1,220 @@
+# feat: Cross-source Kalshi↔Polymarket market pairing for World Cup Intelligence
+
+**Created:** 2026-06-30
+**Type:** feat
+**Depth:** Deep
+**Target template:** `agent-templates/world-cup-intelligence`
+**Origin:** solo plan (no upstream brainstorm); validated prototype at `scratchpad/prototype_cross_source.py`
+
+---
+
+## Summary
+
+Kalshi game moneylines are ingested per-fixture; Polymarket's equivalent markets are not, because the sync only keyword-searches `"FIFA World Cup"` — which never matches a Polymarket market titled "Mexico vs. Ecuador". As a result there is nothing to compare apples-to-apples, and the cross-source surfaces are inert: `worldcup-market-normalization.yml` hardcodes `edge_candidates: []` with a "pairing pending" warning, and `detect_market_edges`' `cross_venue_draw` detector can never fire (no Polymarket draw line in cache).
+
+This plan (1) closes the Polymarket ingestion gap — per-fixture moneylines **and** the tournament "reach Round of 16 / QF / SF / Final" advance markets — and (2) adds a `pair_cross_source` engine command that pairs markets on the canonical `event_urn` already stamped by `link_market_entities`, de-vigs each book, and emits a cross-source edge in bps. The paired output replaces the dead stub in the compare workflow and extends `find-market-edges` from draw-only to full 3-way cross-venue.
+
+Prices already confirmed live to align tightly (Mexico 0.435 / 0.43, Ecuador 0.225 / 0.23, Draw 0.335 / 0.33 across Polymarket/Kalshi), so the value is real once both sides land in cache.
+
+---
+
+## Problem Frame
+
+- **What's broken:** Polymarket per-game and per-nation-advance markets never enter `worldcup:market-cache`. The `"FIFA World Cup"` keyword search returns futures/props but not game markets (titled by team).
+- **Downstream effect:** `cross_venue_draw` in `detect_market_edges` is unreachable; the compare workflow's `edge_candidates` is a hardcoded `[]`; users cannot see both venues' price for the same outcome.
+- **Why now:** World Cup knockout stage is live; both venues carry deep, liquid moneylines for the same games (Kalshi $2–9M/game; Polymarket $1–4M liquidity/game).
+
+---
+
+## Requirements
+
+- **R1.** Polymarket per-fixture 3-way moneyline markets (win/lose/draw per game) land in `worldcup:market-cache`, normalized to the existing `WorldCupMarket` schema, for upcoming fixtures within the sync horizon.
+- **R2.** Polymarket tournament advance markets (reach Round of 16 / Quarterfinals / Semifinals / Final) land in cache, one normalized record per nation, mapped to the nation's team URN.
+- **R3.** Newly-fetched Polymarket game markets pass the World Cup relevance gate (today they would be filtered out — slug prefix `fifwc-` is not a recognized term).
+- **R4.** A `pair_cross_source` engine command groups linked markets by `event_urn` (games) or advance-bucket (nation + round), aligns outcomes to a canonical key (team URN or `DRAW`), de-vigs each source across the group, and returns paired rows with both raw prices, both fair (de-vigged) probabilities, and the cross-source edge in bps.
+- **R5.** `worldcup-compare-market-sources` returns real `edge_candidates` from `pair_cross_source`, replacing the `[]` stub and the "pairing pending" warning.
+- **R6.** `worldcup-find-market-edges` surfaces full 3-way cross-venue moneyline dislocations (not just the draw line), via `event_urn` pairing rather than depending on `sports-skills match_markets`.
+- **R7.** No trading/execution, no new providers, no change to the core `WorldCupMarket` field set. Read-only intelligence with existing disclaimers preserved.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Pair on `event_urn`, not `match_markets`.** `link_market_entities` already stamps a canonical `event_urn` + `related_team_urns` on every market. Pairing on that is deterministic, same-pod, and needs no extra cross-venue API call. The existing `cross_venue_draw` detector depends on `sports-skills match_markets`, which is brittle and currently returns nothing for WC. The prototype validated `event_urn` pairing end-to-end. (see `scratchpad/prototype_cross_source.py`)
+- **KTD2 — Reuse the existing `sports-skills invoke_polymarket` path.** It already exposes `get_sports_events`, `get_todays_events`, and `get_sports_markets` — no new connector or direct Gamma dependency. Ingestion is fixed by calling a *better command*, mirroring the `fetch-kalshi-upcoming` per-fixture sweep already in the sync.
+- **KTD3 — De-vig before comparing.** Raw YES prices carry each book's overround; the apples-to-apples comparison is between de-vigged fair probabilities (normalize each source's 3-way to sum to 1.0). Report both raw and fair, with `edge_bps` computed on fair.
+- **KTD4 — Advance markets keyed by `(team_urn, round)`, not `event_urn`.** Advance markets have no fixture; they are one Polymarket event per round (48 per-nation binaries, `groupItemTitle` = nation, `sportsMarketType: null`). Detect by event-slug prefix `world-cup-nation-to-reach-`; bucket by team URN within a round. Kalshi coverage may be absent for some rounds — pairing degrades gracefully to a single-source row.
+- **KTD5 — Skip `unreliable` quotes in pairing.** Mirror `detect_market_edges`: drop `price_quality == "unreliable"` legs so settled/thin books (sum ≠ 1.0) can't throw fake edges.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+  subgraph Ingest["worldcup-sync-market-sources (extended)"]
+    A[foreach upcoming worldcup:event] --> B[invoke_polymarket get_sports_events / by-fixture]
+    C[fetch advance events:<br/>world-cup-nation-to-reach-*] --> D
+    B --> D[normalize_market_sources<br/>+ fifwc relevance term]
+    D --> E[link_market_entities<br/>stamps event_urn / team URNs]
+    E --> F[(worldcup:market-cache)]
+  end
+  F --> G[pair_cross_source<br/>group by event_urn or team_urn+round]
+  G --> H[de-vig per source → edge_bps]
+  H --> I[worldcup-compare-market-sources<br/>real edge_candidates]
+  H --> J[worldcup-find-market-edges<br/>cross_venue_moneyline candidates]
+```
+
+Pairing key resolution (directional):
+```
+for market in linked_markets where price_quality != "unreliable":
+    if market.event_urn:            key_group = market.event_urn          # game
+    elif advance_round(market):     key_group = (team_urn, round)         # advance
+    bucket = team_urn(outcome_subject) or "DRAW"
+group by (key_group, source) → de-vig YES across buckets → align buckets across sources → edge_bps
+```
+
+---
+
+## Implementation Units
+
+### U1. Polymarket per-fixture moneyline ingestion
+
+**Goal:** Fetch each upcoming fixture's Polymarket 3-way moneyline and land it in cache (R1, R3).
+**Dependencies:** none
+**Files:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml` (add a `fetch-polymarket-upcoming` task mirroring `fetch-kalshi-upcoming`; feed its output into `normalize-market-sources` via `polymarket_markets`)
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` (add `"fifwc"` to `WORLD_CUP_TERMS`, line ~19)
+
+**Approach:** Reuse the `upcoming_team_queries` foreach already computed from `worldcup:event` docs. For each, call `sports-skills invoke_polymarket` with a command that returns the game's markets — prefer `get_sports_events` (events carry nested `markets`) or per-fixture resolution; filter to `sportsMarketType == "moneyline"`. Per KTD2, no new connector. The relevance gate in `_market_matches` must accept `fifwc-` slugs (R3) — adding `"fifwc"` to `WORLD_CUP_TERMS` is the minimal fix.
+
+**Patterns to follow:** `fetch-kalshi-upcoming` task (foreach, `continue_on_error: true`, `concurrent: false`); the `polymarket_markets` input shape already accepted by `normalize_market_sources` (`_extract_source_records`).
+
+**Test scenarios:**
+- A Polymarket moneyline event (`fifwc-mex-ecu-2026-06-30`, 3 markets) normalizes to 3 `WorldCupMarket` records with `source: "polymarket"`, prices in 0–1, `price_quality: "ok"`.
+- A market with slug `fifwc-*` and no "world cup" wording in title passes the relevance gate after the `WORLD_CUP_TERMS` change; an unrelated `nba-*` slug still fails it.
+- `event_urn` is stamped by `link_market_entities` for the Mexico–Ecuador game (both team URNs resolved).
+
+**Verification:** After a sync, `worldcup-search-markets {source: "polymarket", team: "Mexico"}` returns the moneyline legs (not just props), each with a resolved `event_urn`.
+
+### U2. Polymarket advance-market ingestion
+
+**Goal:** Ingest the four "reach Round of 16 / QF / SF / Final" events as per-nation normalized records (R2).
+**Dependencies:** U1 (shares the normalize/link path and the `WORLD_CUP_TERMS` change)
+**Files:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml` (add a `fetch-polymarket-advance` task)
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` (`_polymarket_outcomes` / `_normalize_record`: use `groupItemTitle` as the outcome subject when present; tag a `market_type` like `advance_r16`)
+
+**Approach:** Fetch the four known advance events by slug (`world-cup-nation-to-reach-round-of-16`, `-quarterfinals`, `-semifinals`, `-final`). Each yields ~48 per-nation binaries with `groupItemTitle` = nation and `sportsMarketType: null`; detect by event-slug prefix `world-cup-nation-to-reach-`. Normalize one record per nation, subject = `groupItemTitle`, mapped to team URN by `link_market_entities`. Skip `0/1` placeholder books via the existing `unreliable` flag.
+
+**Patterns to follow:** existing Polymarket futures already in cache (e.g. `polymarket:2415420` "Will Mexico reach the Round of 16") — same shape, just fetched comprehensively per nation.
+
+**Test scenarios:**
+- The R16 event (48 markets) normalizes to one record per nation; `related_team_urns` resolves the nation via `groupItemTitle`.
+- A `0 / 1` per-nation book is flagged `price_quality: "unreliable"`.
+- `market_type` distinguishes advance rounds so pairing can bucket by round (KTD4).
+
+**Verification:** `worldcup-search-markets {source: "polymarket", query: "reach the Round of 16"}` returns multiple nations, each team-URN-linked.
+
+### U3. `pair_cross_source` engine command
+
+**Goal:** Pure function that pairs normalized markets across sources and computes de-vigged cross-source edges (R4).
+**Dependencies:** none (operates on normalized records; testable with fixtures)
+**Files:**
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` (new `pair_cross_source(request_data)`, plus small helpers `_pair_bucket`, `_devig` — port from prototype)
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py` (tests)
+
+**Approach:** Port `scratchpad/prototype_cross_source.py`. Input: linked `WorldCupMarket[]`. Drop `unreliable` (KTD5). Group by `event_urn` (games) or `(team_urn, round)` (advance, KTD4). Within a group, bucket each leg's subject to a team URN or `DRAW` (Kalshi subject = outcome name minus "Reg Time:"; Polymarket subject = `groupItemTitle` / "Will X win" / slug suffix). De-vig YES per source across the group (KTD3). Emit rows: `{event_urn|bucket_key, outcome, kalshi_yes, poly_yes, kalshi_fair, poly_fair, edge_bps, cheaper_venue}`. Return `{status, data: {pairs, count, warnings}}` matching engine convention (envelope stripped by the runtime).
+
+**Technical design:** directional — see the pairing-key pseudo-code in High-Level Technical Design; the prototype is the reference implementation.
+
+**Test scenarios:**
+- *Happy path:* Mexico–Ecuador with both sources present → 3 rows (mexico/ecuador/DRAW); `edge_bps` matches the prototype within rounding (≈29/-62/34).
+- *Single source:* only Kalshi legs present → rows with `poly_yes: null`, no `edge_bps`, no crash.
+- *De-vig:* raw YES summing to 1.05 normalizes to fair probs summing to 1.0.
+- *Unreliable skip:* a settled leg (0.99/1.00) is excluded from its group.
+- *Advance bucket:* Polymarket "Mexico reach R16" pairs with a Kalshi R16 market (if present) under `(mexico_urn, r16)`; with no Kalshi counterpart, returns a single-source row.
+- *Fuzzy team match:* "Reg Time: Mexico" and `groupItemTitle: "Mexico"` bucket to the same team URN; near-distinct nations do not collide.
+
+**Verification:** `pytest tests/test_worldcup_market_intelligence.py -k pair_cross_source` passes; manual run on live cache reproduces the prototype table.
+
+### U4. Wire pairing into `worldcup-compare-market-sources`
+
+**Goal:** Return real `edge_candidates` from `pair_cross_source`, removing the dead stub (R5).
+**Dependencies:** U3
+**Files:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml` (add a `pair-cross-source` connector task after `lookup-markets`)
+- `agent-templates/world-cup-intelligence/mappings/worldcup-market-normalization.yml` (drop the hardcoded `edge_candidates: []` and the "pairing pending" warning; source `edge_candidates` from the task output)
+
+**Approach:** Insert a connector task calling `worldcup-market-intelligence.pair_cross_source` on the loaded cache; map its `pairs` into the `comparison.edge_candidates` output. Keep `markets_by_source` as-is. Remove the now-false warning.
+
+**Test scenarios:**
+- Workflow returns `comparison.edge_candidates` with ≥1 paired row when both sources are cached for a live game.
+- The "Edge detection is not yet implemented…" warning is gone.
+- `markets_by_source` still splits kalshi/polymarket unchanged.
+
+**Verification:** `execute_workflow worldcup-compare-market-sources {query: "Mexico Ecuador"}` returns populated `edge_candidates`.
+
+### U5. Extend `find-market-edges` to full 3-way cross-venue
+
+**Goal:** Surface cross-venue moneyline dislocations beyond the draw line (R6).
+**Dependencies:** U3
+**Files:**
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` (`detect_market_edges`: add a `cross_venue_moneyline` candidate family fed by `pair_cross_source`, pairing on `event_urn`)
+- `agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml` (no longer hard-depend on `match_markets` for cross-venue; pass paired rows)
+
+**Approach:** Compute pairs via `pair_cross_source` inside `detect_market_edges` (or pass them in) and emit a `cross_venue_moneyline` candidate per outcome where `|poly_fair - kalshi_fair| * 10000 >= min_edge_bps`, carrying `cheaper_venue` and the resolution-rule caveats. Keep the legacy `cross_venue_draw` path for backward compatibility, but `event_urn` pairing supersedes it where both venues are cached. Preserve `unreliable` filtering and the 0.0-unpriced guard already present.
+
+**Test scenarios:**
+- Both venues cached for a game with a 70 bps Ecuador divergence → a `cross_venue_moneyline` candidate at `min_edge_bps=50`, suppressed at `min_edge_bps=100`.
+- Draw-line edge still detected (no regression to `cross_venue_draw`).
+- No `match_markets` input → cross-venue still works via `event_urn` (the prior code skipped entirely).
+- Unreliable leg present → excluded, no fake edge.
+
+**Verification:** `execute_workflow worldcup-find-market-edges {min_edge_bps: 50}` returns `cross_venue_moneyline` candidates with both venue prices.
+
+### U6. Test consolidation and live verification
+
+**Goal:** Lock behavior with fixtures and confirm against live data.
+**Dependencies:** U1–U5
+**Files:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py` (normalization fixtures for the new Polymarket game + advance shapes; pairing assertions if not already added in U3)
+
+**Approach:** Add fixtures captured from the live Gamma payloads (game event + one advance event), asserting normalization and pairing. Run the full market-intelligence test module.
+**Execution note:** Implement U3's `pair_cross_source` test-first against the prototype's known output, then make ingestion (U1/U2) green.
+
+**Test scenarios:** covered by U1–U3 + U5 scenarios; this unit ensures they run together and adds the captured-payload fixtures.
+
+**Verification:** full `pytest` for the module passes; one live `execute_workflow` of compare + find-edges shows paired output for a current game.
+
+---
+
+## Scope Boundaries
+
+**In scope:** Polymarket per-fixture moneyline + advance ingestion; `pair_cross_source`; wiring into compare and find-edges; relevance-gate fix; tests.
+
+**Deferred to Follow-Up Work:**
+- Kalshi-side advance-market ingestion parity (if Kalshi lists per-nation advance series) — pairing degrades to single-source until then.
+- Hourly cross-source snapshotting / movement of the *edge* itself.
+- Promoting cross-source edges into signals/CLV.
+
+**Out of scope (product identity):** any order placement, personalized financial advice, or new venues beyond Kalshi/Polymarket.
+
+---
+
+## Risks & Dependencies
+
+- **Polymarket fetch command coverage.** `get_sports_events` may not window by horizon the way `fetch-kalshi-upcoming` does; if it returns all sports, WC filtering + the `fifwc` relevance term must carry the load. Mitigation: filter by slug prefix `fifwc-` at the task or normalize layer. (resolve at implementation)
+- **Context-variable collision.** The sync file documents that connector-call inputs named `query`/`limit` clobber workflow state. New Polymarket tasks must use collision-free input names (follow the existing `search_query`/`max_markets` convention).
+- **Advance-market team mapping.** `groupItemTitle` nation names must resolve through the team crosswalk/alias map (e.g. "South Korea" → `korea-republic`, "DR Congo"). Mitigation: extend `_MARKET_TEAM_ALIASES` as gaps surface.
+- **Asymmetric advance coverage.** Kalshi may not offer matching advance markets; `pair_cross_source` must emit single-source rows without error (covered by U3 tests).
+- **Resolution-rule mismatch.** Draw lines differ (90-min vs incl. extra time) across venues; caveats already exist in `detect_market_edges` and must be carried on `cross_venue_moneyline` rows.
+
+---
+
+## Sources & Research
+
+- Prototype (validated live, 2026-06-30): `scratchpad/prototype_cross_source.py` — proved `event_urn` pairing + de-vig; output Mexico 29 bps / Ecuador −62 bps / Draw 34 bps.
+- Live confirmation: Polymarket `fifwc-mex-ecu-2026-06-30` carries the full 3-way moneyline; `world-cup-nation-to-reach-*` events carry 48 per-nation advance binaries.
+- Existing engine surfaces: `detect_market_edges` (within-venue book-sum, cross-venue draw, model-vs-market), `link_market_entities` (`event_urn` stamping), `normalize_market_sources` / `_normalize_record` (unified schema), `WORLD_CUP_TERMS` relevance gate.
+- Connector capability: `sports-skills invoke_polymarket` exposes `get_sports_events` / `get_todays_events` / `get_sports_markets`.


### PR DESCRIPTION
## Summary

Closes the **Polymarket per-fixture ingestion gap** and adds **cross-source (Kalshi↔Polymarket) market pairing** to the World Cup Intelligence template. Previously only Kalshi game moneylines reached the cache (the sync keyword-searched `"FIFA World Cup"`, which never matches a Polymarket market titled "Mexico vs. Ecuador"), so apples-to-apples comparison was impossible and the cross-source surfaces were inert (`edge_candidates: []` stub + a "pairing pending" warning).

Now both venues' game moneylines **and** tournament advance markets land in `worldcup:market-cache` under one schema, and a new `pair_cross_source` engine command pairs them on the canonical `event_urn` (games) or advance round, de-vigs each book, and reports the cross-source edge in bps.

Validated live during build: Mexico vs Ecuador priced **0.435/0.225/0.335** on Polymarket vs **0.43/0.23/0.33** on Kalshi — tight, real, and now comparable.

## Key decisions

- **Pair on `event_urn`, not `match_markets`** — `link_market_entities` already stamps a canonical `event_urn`; pairing on it is deterministic and needs no extra cross-venue call. Generalizes the old draw-only `cross_venue_draw` detector to the full 3-way.
- **Reuse the existing `sports-skills invoke_polymarket` path** — fix ingestion by calling a better command (`search_markets` with `sports_market_types=moneyline`, per-fixture sweep mirroring `fetch-kalshi-upcoming`); no new connector.
- **De-vig before comparing** — raw prices carry each book's overround; the edge is computed on de-vigged fair probabilities.

## Implementation units

| U | Change |
|---|--------|
| U3 | `pair_cross_source` engine command (de-vig, cross-source edge) |
| U1 | Polymarket per-fixture moneyline ingestion + `fifwc` relevance term |
| U2 | Polymarket advance-market ingestion + `advance_<round>` tagging |
| U4 | Wire pairing into `compare-market-sources`; remove the dead stub |
| U5 | `cross_venue_moneyline` in `find-market-edges` (event_urn pairing) |
| U6 | End-to-end test on realistic payloads |

## Testing

- 187 unit tests pass (`tests/test_worldcup_market_intelligence.py`), up from the pre-existing suite.
- End-to-end `normalize → link → pair` test on production-shape payloads (caught two real gotchas during build: cached Kalshi legs are named `"Yes"` — discriminated via ticker-suffix/iso3; Polymarket game legs name only one team — paired via the `fifwc-<a>-<b>-<date>` slug).

## Code review (compound-engineering Tier 2, 5 reviewers)

A **P1 found by two reviewers independently and verified by executing the code** was fixed before this PR: `pair_cross_source` de-vigged each source over only the legs it carried, so a missing leg (not ingested, or dropped by the `unreliable` filter) inflated the survivors past 1.0 and **fabricated large false arbitrage edges**. Fix: de-vig only a complete book (overround band 0.90–1.20); otherwise `fair=None` and no edge. Plus hardening: advance-tag gated on "reach"; longest-slug-first bucketing (prefix-collision guard); single-venue-sync warning. Project-standards review clean (no-OpenAI/Vertex rule respected).

## Known residuals (deferred, non-blocking)

- **Relocate `pair_cross_source` nearer its caller** and **extract a shared fuzzy-matcher** — deferred as cosmetic churn in a 4.4k-line file per repo CLAUDE.md ("don't refactor things that aren't broken"). The two fuzzy matchers (`_fuzzy_slug_in_text` windowed n-gram vs `_pair_bucket` direct ratio) are different algorithms; merging them would couple unrelated call sites.
- **`cross_venue_draw` / `cross_venue_moneyline` draw double-emission** — only overlaps when `match_markets` returns data (never for WC today); documented in-code.

## Post-Deploy Monitoring & Validation

This change is **not yet deployed** — the live MCP runs the production pod, so end-to-end verification requires importing this branch's templates to the pod.

After deploy:
- **Run** `worldcup-sync-market-sources`, then `worldcup-search-markets {source: "polymarket", team: "Mexico"}` — expect Polymarket **moneyline** legs (not just props), each with a resolved `event_urn`.
- **Run** `worldcup-compare-market-sources {query: "Mexico Ecuador"}` — expect populated `edge_candidates` (no "pairing pending" warning).
- **Run** `worldcup-find-market-edges {min_edge_bps: 50}` — expect `cross_venue_moneyline` candidates with both venue prices and `cheaper_venue`.
- **Healthy signal:** edges cluster within a few hundred bps (the two books agree closely); fair probabilities per game sum to ~1.0.
- **Failure signal / rollback trigger:** any `edge_bps` in the thousands (the fabricated-edge class this PR fixed) or `fair > 1.0` — revert and investigate de-vig. Single-venue-sync warning firing persistently means a Polymarket fetch path is failing.
- **Owner/window:** verify within the first sync cycle (~15 min) after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
