### PR TITLE
feat(worldcup): stabilized-markets worklist signal (worldcup_stable_markets)

### DIFF
--- a/agent-templates/world-cup-intelligence/_install.yml
+++ b/agent-templates/world-cup-intelligence/_install.yml
@@ -96,6 +96,8 @@ datasets:
   - type: workflow
     path: workflows/worldcup-find-market-edges.yml
   - type: workflow
+    path: workflows/worldcup-stable-markets.yml
+  - type: workflow
     path: workflows/worldcup-explain-market-move.yml
   - type: workflow
     path: workflows/worldcup-generate-market-brief.yml

--- a/agent-templates/world-cup-intelligence/docs/mcp-tools.md
+++ b/agent-templates/world-cup-intelligence/docs/mcp-tools.md
@@ -114,6 +114,29 @@ Backed by `worldcup-find-market-edges`.
 
 Returns research candidates only; no execution advice.
 
+### `worldcup_stable_markets`
+
+Backed by `worldcup-stable-markets`.
+
+Read-only worklist of markets whose cross-source quote has **stabilized** — the
+explainable inverse of the unreliable-quote flag. Useful as a faster "safe to
+re-enable" candidate signal than waiting on a traditional pricing feed.
+
+Inputs:
+
+- `window_hours`: snapshot lookback for the stable-streak history (default `24`)
+- `spread_bps`, `movement_bps`, `agreement_bps`, `min_volume`: stability thresholds (defaults `200` / `150` / `150` / `1000`)
+- `team`, `query`: optional filters
+- `limit`: result cap (default `50`)
+
+Returns:
+
+- `stable_markets`: worklist sorted most-recently-stabilized first, each with `stable_since`, `confidence` (`provisional` | `stable` | `corroborated`), and an explainable `drivers` list
+- `thresholds`: the thresholds applied
+- `warnings`: caveats, incl. that detection-vs-feed latency is not benchmarked
+
+Read-only; no pricing or execution advice.
+
 ### `worldcup_generate_market_brief`
 
 Backed by `worldcup-generate-market-brief`.

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -46,6 +46,7 @@ compute_clv = _module.compute_clv
 compute_clv_report = _module.compute_clv_report
 _result_outcome = _module._result_outcome
 pair_cross_source = _module.pair_cross_source
+compute_market_stability = _module.compute_market_stability
 
 
 def _kalshi_record(**overrides):
@@ -2373,3 +2374,111 @@ class TestCrossSourceEndToEnd:
         # every leg paired across both venues -> an edge on each
         assert all("edge_bps" in p for p in pairs)
         assert by_outcome["ecuador"]["cheaper_venue"] == "polymarket"
+
+
+class TestComputeMarketStability:
+    EV = "urn:machina:sport:soccer:team-event:mex-ecu"  # opaque; only identity matters here
+    MEX = "urn:machina:sport:soccer:team:mexico:mex"
+    ECU = "urn:machina:sport:soccer:team:ecuador:ecu"
+
+    def _mkt(self, cache_id, source, name, price, **kw):
+        m = {"cache_id": cache_id, "source": source, "title": "Mexico vs Ecuador Winner?",
+             "event_urn": self.EV, "related_team_urns": [self.MEX, self.ECU],
+             "price_quality": "ok", "spread": 0.01, "volume": 5000,
+             "outcomes": [{"name": name, "price": price}, {"name": "No", "price": round(1 - price, 3)}]}
+        m.update(kw)
+        return m
+
+    def _snaps(self, cache_id, prices, start_hour=10):
+        # oldest -> newest hourly snapshots
+        return [{"cache_id": cache_id, "ts": f"2026-06-30T{start_hour + i:02d}:00:00Z",
+                 "primary_price": p} for i, p in enumerate(prices)]
+
+    def _run(self, markets, snapshots, **params):
+        p = {"markets": markets, "snapshots": snapshots}
+        p.update(params)
+        return compute_market_stability({"params": p})["data"]
+
+    def _by_id(self, data):
+        return {r["cache_id"]: r for r in data["stable_markets"]}
+
+    def test_stable_happy_path_with_drivers_and_since(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.44, 0.43, 0.43])
+        rows = self._by_id(self._run([m], snaps))
+        assert "kalshi:MEX" in rows
+        r = rows["kalshi:MEX"]
+        assert r["confidence"] == "stable"
+        assert r["stable_since"] == "2026-06-30T10:00:00Z"  # whole window is within band
+        assert set(["reliable", "spread_tight", "low_movement", "volume_present"]).issubset(set(r["drivers"]))
+
+    def test_corroborated_when_both_venues_agree(self):
+        # Full 3-way on both venues so pair_cross_source emits an in-agreement edge.
+        markets = [
+            self._mkt("kalshi:MEX", "kalshi", "Reg Time: Mexico", 0.43),
+            self._mkt("kalshi:ECU", "kalshi", "Reg Time: Ecuador", 0.23),
+            self._mkt("kalshi:TIE", "kalshi", "Tie", 0.33),
+            self._mkt("polymarket:mex", "polymarket", "Yes", 0.435, title="Will Mexico win on 2026-06-30?"),
+            self._mkt("polymarket:ecu", "polymarket", "Yes", 0.225, title="Will Ecuador win on 2026-06-30?"),
+            self._mkt("polymarket:draw", "polymarket", "Yes", 0.335, title="Will Mexico vs. Ecuador end in a draw?"),
+        ]
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        rows = self._by_id(self._run(markets, snaps, agreement_bps=150))
+        assert rows["kalshi:MEX"]["confidence"] == "corroborated"
+        assert "cross_venue_agree" in rows["kalshi:MEX"]["drivers"]
+
+    def test_single_venue_is_stable_not_corroborated(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        rows = self._by_id(self._run([m], snaps))
+        assert rows["kalshi:MEX"]["confidence"] == "stable"
+        assert "cross_venue_agree" not in rows["kalshi:MEX"]["drivers"]
+
+    def test_actively_moving_excluded(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.57)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.50, 0.57])  # latest pair diverges > band
+        rows = self._by_id(self._run([m], snaps))
+        assert "kalshi:MEX" not in rows
+
+    def test_stable_since_is_post_move_streak_start(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)
+        # moved early, then re-stabilized: stable_since must be the post-move point
+        snaps = self._snaps("kalshi:MEX", [0.60, 0.60, 0.43, 0.43])
+        r = self._by_id(self._run([m], snaps))["kalshi:MEX"]
+        assert r["confidence"] == "stable"
+        assert r["stable_since"] == "2026-06-30T12:00:00Z"  # 3rd snapshot (first 0.43)
+
+    def test_unreliable_excluded(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43, price_quality="unreliable")
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        assert "kalshi:MEX" not in self._by_id(self._run([m], snaps))
+
+    def test_wide_spread_excluded(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43, spread=0.30)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        assert "kalshi:MEX" not in self._by_id(self._run([m], snaps))
+
+    def test_low_volume_excluded(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43, volume=100)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        assert "kalshi:MEX" not in self._by_id(self._run([m], snaps, min_volume=1000))
+
+    def test_provisional_when_no_history(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)
+        r = self._by_id(self._run([m], []))["kalshi:MEX"]
+        assert r["confidence"] == "provisional"
+        assert r["stable_since"] is None
+        assert "insufficient_history" in r["drivers"]
+
+    def test_team_filter_and_sort(self):
+        a = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        # team filter that doesn't match -> excluded
+        assert "kalshi:MEX" not in self._by_id(self._run([a], snaps, team="Brazil"))
+        assert "kalshi:MEX" in self._by_id(self._run([a], snaps, team="Mexico"))
+
+    def test_threshold_tightening_flips_borderline(self):
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43, spread=0.018)
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
+        assert "kalshi:MEX" in self._by_id(self._run([m], snaps, spread_bps=200))   # 0.018 <= 0.02
+        assert "kalshi:MEX" not in self._by_id(self._run([m], snaps, spread_bps=150))  # 0.018 > 0.015

--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -2482,3 +2482,20 @@ class TestComputeMarketStability:
         snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43])
         assert "kalshi:MEX" in self._by_id(self._run([m], snaps, spread_bps=200))   # 0.018 <= 0.02
         assert "kalshi:MEX" not in self._by_id(self._run([m], snaps, spread_bps=150))  # 0.018 > 0.015
+
+    def test_workflow_contract_shapes(self):
+        # Guards the field-name contract the worldcup-stable-markets workflow relies
+        # on: market-cache fields and snapshot {cache_id, ts, primary_price}, and the
+        # output envelope keys the workflow maps to its outputs. (Covers S1.)
+        m = self._mkt("kalshi:MEX", "kalshi", "Yes", 0.43)  # no spread arg -> uses default 0.01
+        m_nullspread = self._mkt("kalshi:ECU", "kalshi", "Yes", 0.23, spread=None)  # real Kalshi cache shape
+        snaps = self._snaps("kalshi:MEX", [0.43, 0.43, 0.43]) + self._snaps("kalshi:ECU", [0.23, 0.23, 0.23])
+        data = self._run([m, m_nullspread], snaps)
+        assert set(["stable_markets", "count", "thresholds", "warnings"]).issubset(data.keys())
+        assert data["count"] == len(data["stable_markets"])
+        # null-spread Kalshi market is NOT excluded (spread gate is conditional)
+        rows = self._by_id(data)
+        assert "kalshi:ECU" in rows and "spread_tight" not in rows["kalshi:ECU"]["drivers"]
+        row = rows["kalshi:MEX"]
+        assert set(["cache_id", "confidence", "stable_since", "drivers", "outcome", "price"]).issubset(row.keys())
+        assert any("latency is not benchmarked" in w for w in data["warnings"])

--- a/agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml
+++ b/agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml
@@ -1,0 +1,76 @@
+workflow:
+  name: worldcup-stable-markets
+  title: World Cup Intelligence - Stabilized Markets
+  description: |
+    Read-only worklist of World Cup markets whose cross-source (Kalshi/Polymarket)
+    quote has settled into a stable, reliable state — the explainable inverse of
+    the unreliable-quote flag. Computed from the worldcup:market-cache plus the
+    worldcup:market-snapshot price history; each result carries stable_since,
+    a confidence tier (provisional/stable/corroborated) and explainable drivers.
+    Not pricing or execution advice; detection-vs-feed latency is not benchmarked.
+
+  context-variables:
+    debugger:
+      enabled: true
+  inputs:
+    window_hours: "$.get('window_hours', 24)"
+    spread_bps: "$.get('spread_bps', 200)"
+    movement_bps: "$.get('movement_bps', 150)"
+    agreement_bps: "$.get('agreement_bps', 150)"
+    min_volume: "$.get('min_volume', 1000)"
+    team: "$.get('team', '')"
+    query: "$.get('query', '')"
+    limit: "$.get('limit', 50)"
+  outputs:
+    stable_markets: "$.get('stable_markets', [])"
+    count: "len($.get('stable_markets', []))"
+    thresholds: "$.get('thresholds', {})"
+    warnings: "$.get('stable_warnings', [])"
+    workflow-status: "'executed'"
+  tasks:
+    - type: document
+      name: load-current-markets
+      description: Current market-cache records (latest prices, price_quality, spread, volume).
+      config:
+        action: search
+        search-limit: 1000
+        search-vector: false
+      filters:
+        name: "'worldcup:market-cache'"
+      outputs:
+        markets: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: document
+      name: load-snapshots
+      description: Price snapshots within the lookback window (the stable-streak history).
+      config:
+        action: search
+        search-limit: 5000
+        search-vector: false
+      filters:
+        name: "'worldcup:market-snapshot'"
+        value.ts: "{'$gte': (datetime.utcnow() - timedelta(hours=int($.get('window_hours', 24)))).isoformat()}"
+      outputs:
+        snapshots: "[d.get('value', {}) for d in ($.get('documents', []) or [])]"
+
+    - type: connector
+      name: compute-stability
+      description: Classify which markets have stabilized, with confidence tier and drivers.
+      connector:
+        name: worldcup-market-intelligence
+        command: compute_market_stability
+      inputs:
+        markets: "$.get('markets', [])"
+        snapshots: "$.get('snapshots', [])"
+        spread_bps: "$.get('spread_bps', 200)"
+        movement_bps: "$.get('movement_bps', 150)"
+        agreement_bps: "$.get('agreement_bps', 150)"
+        min_volume: "$.get('min_volume', 1000)"
+        team: "$.get('team', '')"
+        query: "$.get('query', '')"
+        limit: "$.get('limit', 50)"
+      outputs:
+        # $ is the connector data payload (envelope already stripped).
+        stable_markets: "$.get('stable_markets', [])"
+        thresholds: "$.get('thresholds', {})"
+        stable_warnings: "$.get('warnings', [])"

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -2945,6 +2945,178 @@ def pair_cross_source(request_data: dict[str, Any]) -> dict[str, Any]:
     return {"status": True, "data": {"pairs": pairs, "count": len(pairs), "warnings": warnings}}
 
 
+def _stable_suffix(snaps_for_cid: list[Any], band: float) -> list[tuple]:
+    """Longest run of snapshots ending at the latest one whose prices stay within
+    `band`. Detects when a market has *just* settled even if it moved earlier in
+    the window. Returns [(ts, price), ...] oldest->newest for the run (len 0/1 =
+    insufficient history; len < 2 after a real series = actively moving)."""
+    prices = [(_text(s.get("ts")), _to_float(s.get("primary_price")))
+              for s in sorted(_as_list(snaps_for_cid), key=lambda s: _text(s.get("ts")))
+              if isinstance(s, dict) and s.get("primary_price") is not None]
+    if len(prices) < 2:
+        return prices
+    run = [prices[-1]]
+    for point in reversed(prices[:-1]):
+        candidate = [point] + run
+        vals = [p for _, p in candidate]
+        if max(vals) - min(vals) <= band:
+            run = candidate
+        else:
+            break
+    return run
+
+
+def compute_market_stability(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Flag markets whose cross-source quote has settled into a stable state — the
+    explainable inverse of the price_quality 'unreliable' flag. Stateless: derived
+    each call from market-cache records + windowed market-snapshot rows. Read-only.
+
+    A market is gated on: price_quality == 'ok' (reliability), spread within
+    `spread_bps` when a spread is quoted (gross-spread books are already flagged
+    unreliable), volume/liquidity >= `min_volume`, and a stable price suffix in
+    the snapshot window (no movement beyond `movement_bps` across the latest run).
+    Confidence tiers: provisional (insufficient history) < stable (one venue) <
+    corroborated (both venues agree within `agreement_bps`, via pair_cross_source).
+    Each result carries stable_since (start of the stable run) and explainable
+    drivers. Sorted most-recently-stabilized first; provisional last.
+
+    Params: markets, snapshots, spread_bps (200), movement_bps (150),
+    agreement_bps (150), min_volume (1000), team, query, limit (50).
+    """
+    params = _params(request_data)
+
+    def _int(key, default):
+        try:
+            return int(params.get(key) or default)
+        except (TypeError, ValueError):
+            return default
+
+    spread_band = _int("spread_bps", 200) / 10000.0
+    movement_band = _int("movement_bps", 150) / 10000.0
+    agreement_bps = _int("agreement_bps", 150)
+    min_volume = _to_float(params.get("min_volume")) if params.get("min_volume") is not None else 1000.0
+    limit = max(1, min(_int("limit", 50), 500))
+    team = _lower(params.get("team"))
+    query = _lower(params.get("query"))
+
+    markets = [m for m in _as_list(params.get("markets"))
+               if isinstance(m, dict) and m.get("price_quality") != "unreliable"]
+    if team or query:
+        def _match(m):
+            hay = " ".join(_lower(v) for v in (m.get("title"), m.get("slug"), m.get("market_type"),
+                                               " ".join(m.get("related_team_urns") or [])))
+            return (not team or team in hay) and (not query or query in hay)
+        markets = [m for m in markets if _match(m)]
+
+    # Cross-venue agreement map: (group_key, outcome) -> abs(edge_bps). pair_cross_source
+    # only emits an edge when both venues priced a complete book, so presence in this
+    # map already means corroboration is possible.
+    agree: dict[tuple, int] = {}
+    for row in pair_cross_source({"params": {"markets": markets}})["data"]["pairs"]:
+        if row.get("edge_bps") is not None:
+            agree[(_text(row.get("group_key")), _text(row.get("outcome")))] = abs(row["edge_bps"])
+
+    # Snapshots grouped by cache_id.
+    snaps_by_cid: dict[str, list] = {}
+    for s in _as_list(params.get("snapshots")):
+        if isinstance(s, dict):
+            snaps_by_cid.setdefault(_text(s.get("cache_id")), []).append(s)
+
+    results = []
+    for m in markets:
+        cid = _text(m.get("cache_id") or m.get("id"))
+        outs = m.get("outcomes") or []
+        if not cid or not outs:
+            continue
+        price_now = (outs[0] or {}).get("price")
+        if price_now is None:
+            continue
+        volume = _to_float(m.get("volume"))
+        if volume < min_volume:
+            continue
+        spread = m.get("spread")
+        spread_known = spread is not None
+        if spread_known and _to_float(spread) > spread_band:
+            continue
+
+        drivers = ["reliable"]
+        if spread_known:
+            drivers.append("spread_tight")
+        drivers.append("volume_present")
+
+        run = _stable_suffix(snaps_by_cid.get(cid, []), movement_band)
+        if len(run) < 1:
+            # No usable history at all -> provisional.
+            confidence, stable_since = "provisional", None
+            drivers.append("insufficient_history")
+        elif len(run) == 1:
+            # Only one snapshot (or latest pair already diverged). One data point =
+            # not enough to confirm; a diverged latest pair = actively moving.
+            total = len([s for s in snaps_by_cid.get(cid, []) if isinstance(s, dict)
+                         and s.get("primary_price") is not None])
+            if total >= 2:
+                continue  # actively moving -> exclude (S3)
+            confidence, stable_since = "provisional", None
+            drivers.append("insufficient_history")
+        else:
+            confidence, stable_since = "stable", run[0][0]
+            drivers.append("low_movement")
+            bucket = _pair_bucket(m)
+            if bucket:
+                gk = _text(m.get("event_urn")) or _lower(m.get("market_type"))
+                outcome = "DRAW" if bucket == "DRAW" else _team_slug_from_urn(bucket)
+                edge = agree.get((gk, outcome))
+                if edge is not None and edge <= agreement_bps:
+                    confidence = "corroborated"
+                    drivers.append("cross_venue_agree")
+
+        results.append({
+            "cache_id": cid,
+            "title": _text(m.get("title")),
+            "source": _text(m.get("source")),
+            "event_urn": m.get("event_urn"),
+            "related_team_urns": m.get("related_team_urns") or [],
+            "outcome": _text((outs[0] or {}).get("name")),
+            "price": _to_float(price_now),
+            "confidence": confidence,
+            "stable_since": stable_since,
+            "drivers": drivers,
+            "spread": spread,
+            "volume": m.get("volume"),
+            "resolution_risk_notes": [
+                "Read-only stabilization signal. Verify book depth, fees, and resolution rules before acting.",
+            ],
+        })
+
+    # Most-recently-stabilized first; provisional (no stable_since) last.
+    tier_rank = {"corroborated": 0, "stable": 0, "provisional": 1}
+    results.sort(key=lambda r: (tier_rank.get(r["confidence"], 1), r["stable_since"] is None,
+                                "" if r["stable_since"] is None else r["stable_since"]),
+                 reverse=False)
+    # within the stable tier we want newest stable_since first
+    stable_rows = [r for r in results if r["confidence"] != "provisional"]
+    stable_rows.sort(key=lambda r: r["stable_since"] or "", reverse=True)
+    provisional_rows = [r for r in results if r["confidence"] == "provisional"]
+    ordered = (stable_rows + provisional_rows)[:limit]
+
+    warnings = [
+        "Detection-vs-feed latency is not benchmarked here (no suspension/feed baseline available).",
+    ]
+    if not markets:
+        warnings.append("No reliable markets supplied -- run worldcup-sync-market-sources first.")
+
+    return {
+        "status": True,
+        "data": {
+            "stable_markets": ordered,
+            "count": len(ordered),
+            "thresholds": {"spread_bps": _int("spread_bps", 200), "movement_bps": _int("movement_bps", 150),
+                           "agreement_bps": agreement_bps, "min_volume": min_volume},
+            "warnings": warnings,
+        },
+    }
+
+
 # Live status set — fixtures considered in-play for coverage cadence.
 _LIVE_STATUS = {"1H", "HT", "2H", "ET", "BT", "P", "SUSP", "INT", "LIVE"}
 _FINAL_STATUS = {"FT", "AET", "PEN"}

--- a/docs/brainstorms/2026-06-30-market-stabilization-signal-requirements.md
+++ b/docs/brainstorms/2026-06-30-market-stabilization-signal-requirements.md
@@ -1,0 +1,74 @@
+# Market Stabilization Signal — Requirements
+
+**Created:** 2026-06-30
+**Scope:** Standard (feature) — new read-only signal on the deployed cross-source market layer
+**Target template:** `agent-templates/world-cup-intelligence`
+**Origin:** BetFanatics call 2026-06-30 (Ciaran Foy, Director of Product, trading sports products) + the cross-source pairing work shipped same day (PR #283)
+
+---
+
+## Problem Frame
+
+BetFanatics suspends a market when its price becomes unreliable, then waits for their traditional pricing feed (Ciaran named "TX Fusion") to push an update before putting the market back on site. That wait costs them on-site time — bettable markets sit dark longer than necessary.
+
+Ciaran's ask (verbatim, lightly cleaned): *"prediction market feeds from Kalshi, Polymarket and a singular JSON schema … to help us get markets back on site quicker once the pricing normalizes on Polymarket and Kalshi, as opposed to waiting for updates from like a TX Fusion feed."*
+
+We already normalize both venues into one schema and flag **unreliable** quotes (crossed/thin books). The gap is the **inverse**: an explicit, explainable signal that a quote has **settled into a stable, reliable, cross-venue-agreeing state** — usable as a faster re-enable trigger.
+
+## Goal & Success Criteria
+
+A read-only "stabilized markets" worklist the desk can poll. Success for the 2-week demo:
+
+- **S1.** The signal fires on real, live World Cup markets and returns a worklist of currently-stable markets, each with a `stable_since` timestamp.
+- **S2.** Every result is **explainable** — it names which conditions made it stable (spread tight, low recent movement, volume present, cross-venue agreement).
+- **S3.** It does **not** mark thin / crossed / still-moving books as stable (no false "safe to re-enable"). Verified against the same books the `unreliable` flag and the de-vig guard already catch.
+- **S4.** Honest framing: the demo proves the signal exists and is sound; it does **not** claim a measured latency win over TX Fusion (we lack their suspension events and feed).
+
+Non-goal for success: integration into Fanatics' live re-enablement, or any pricing/execution action.
+
+## Actors
+
+- **A1 — Trading desk / pricing platform (BetFanatics).** Primary consumer. Polls the worklist (via MCP tool / API) to decide which suspended markets are candidates to re-enable.
+- **A2 — Machina (demo delivery).** Runs the signal on live WC markets to demonstrate it during the sprint.
+
+## Requirements
+
+- **R1.** A market is classified **stabilized** when, evaluated over a short trailing window of the existing hourly snapshots plus the current quote, all of:
+  - currently `price_quality: ok` (not the `unreliable` flag), and
+  - the book is complete enough to de-vig (passes the overround band already used by `pair_cross_source`), and
+  - spread is tight (within a configurable bps threshold), and
+  - **low recent movement** — the primary outcome price has not moved more than a configurable bps across the trailing window, and
+  - volume / liquidity is present above a configurable floor.
+- **R2.** **Cross-venue agreement upgrades confidence, but is not required.** When both venues price the same outcome and their de-vigged fair prices agree within N bps (reuse `pair_cross_source`), the result is tagged a higher confidence tier (`corroborated`). Single-venue markets can still be `stable` on R1 alone — most markets are single-venue.
+- **R3.** Each stabilized result carries: `stable_since` (start of the current uninterrupted stable streak, derived from snapshot history), a `confidence` tier, and a `drivers` list naming the satisfied conditions (S2).
+- **R4.** A dedicated read workflow + MCP tool (`worldcup-stable-markets` / `worldcup_stable_markets`) returns the worklist, filterable by team/competition and sorted by `stable_since` (most-recently-stabilized first — the re-enable worklist). Read-only; carries the same resolution-risk disclaimers as the other market tools.
+- **R5.** Thresholds (spread bps, movement bps, agreement bps, volume floor, window length) are parameters with sane defaults, so the desk can tune sensitivity without code changes.
+- **R6.** Stateless computation — the signal is derived on each call from `worldcup:market-cache` + `worldcup:market-snapshot`; no new persistent state. (Stateful transition logging is deferred — see Scope Boundaries.)
+
+## Scope Boundaries
+
+**In scope:** the stability engine computation, the `worldcup-stable-markets` workflow + MCP tool, explainable drivers, configurable thresholds, reuse of the deployed cache/snapshot/de-vig/pairing primitives.
+
+**Deferred for later (the "prove the speed win" follow-up):**
+- Append-only **transition-event logging** (`unstable → stable`, timestamped) and **detection-latency benchmarking** vs a feed baseline. This is what would let us *measure* the re-enable speed advantage — it needs Fanatics' suspension events + TX Fusion timestamps, which we won't have in the demo window.
+- A push/alert on transition (vs poll).
+
+**Outside this product's identity:** any pricing, market-making, or execution action; integration into Fanatics' internal re-enablement logic; ingesting Fanatics' proprietary feed. This stays read-only intelligence.
+
+## Key Decisions
+
+- **KD1 — Stateless worklist, not an event stream.** "Currently stable" computed from the snapshot window on each call; `stable_since` read from history. Avoids new persistent state and fits the sprint; the event-stream/latency path is the deferred follow-up.
+- **KD2 — Stability is the explainable inverse of the `unreliable` flag, not a new pricing model.** It composes the primitives already shipped (price_quality, de-vig band, snapshot movement, pair_cross_source agreement) — low carrying cost, consistent with the existing engine.
+- **KD3 — Single-venue stability is valid; cross-venue agreement is a confidence upgrade.** Requiring both venues would exclude most markets and weaken the demo.
+
+## Dependencies / Assumptions
+
+- Depends on the deployed cross-source layer (PR #283): `worldcup:market-cache`, `worldcup:market-snapshot`, `pair_cross_source`, `price_quality`, the de-vig band guard.
+- **Assumption:** the hourly snapshot cadence is granular enough to demonstrate "low recent movement" meaningfully. If a finer cadence is needed for a crisp demo, increasing snapshot frequency during the sprint is a small change (the snapshot id is hourly-bucketed today — noted for planning, not decided here).
+- **Assumption (explicit):** we cannot measure latency-vs-TX-Fusion in the demo (no access to their suspension events or feed). Success is framed accordingly (S4).
+
+## Outstanding Questions (resolve at planning or with Fanatics)
+
+- Default threshold values (spread bps, movement bps, agreement bps, volume floor, window length) — pick demo-sane defaults at planning; ideally calibrate against Ciaran's tolerance for re-enable risk.
+- Whether the hourly snapshot cadence suffices or the sprint should add a finer-grained snapshot for the demo.
+- Confirm with Ciaran whether a polled worklist matches how their re-enablement logic would consume it, or whether they'd want a webhook/push (would promote the deferred transition-event path into scope).

--- a/docs/plans/2026-06-30-002-feat-market-stabilization-signal-plan.md
+++ b/docs/plans/2026-06-30-002-feat-market-stabilization-signal-plan.md
@@ -1,0 +1,149 @@
+# feat: Market stabilization signal (stabilized-markets worklist)
+
+**Created:** 2026-06-30
+**Type:** feat
+**Depth:** Standard
+**Target template:** `agent-templates/world-cup-intelligence`
+**Origin:** `docs/brainstorms/2026-06-30-market-stabilization-signal-requirements.md`
+
+---
+
+## Summary
+
+A read-only "stabilized markets" worklist for the cross-source market layer shipped in PR #283. It flags markets whose Kalshi/Polymarket quote has settled into a stable, reliable, (optionally) cross-venue-agreeing state — the explainable inverse of the existing `price_quality: unreliable` flag — so BetFanatics' desk can use it as a faster re-enable trigger than waiting on their pricing feed. Computation is stateless: derived per call from `worldcup:market-cache` + `worldcup:market-snapshot`, reusing the de-vig band, `pair_cross_source`, and the snapshot movement primitives already deployed.
+
+---
+
+## Problem Frame
+
+BetFanatics suspends a market when its price goes unreliable, then waits for their feed ("TX Fusion") to re-enable it (origin: Ciaran Foy call, 2026-06-30). We already normalize both venues and flag *unreliable* books; the gap is an explicit *stable* signal. Scoped for a 2-week demo that proves the signal is sound and explainable on live World Cup markets — not a measured latency win (we lack their suspension/feed data).
+
+---
+
+## Requirements (from origin)
+
+- **R1.** Classify a market **stabilized** over a trailing snapshot window when all hold: currently `price_quality: ok`; book complete enough to de-vig (overround band, as in `pair_cross_source`); spread within a bps threshold; primary-outcome price moved less than a bps threshold across the window; volume/liquidity above a floor.
+- **R2.** Cross-venue agreement (both venues price the outcome, de-vigged fair within N bps via `pair_cross_source`) **upgrades** confidence to `corroborated` but is **not** required — single-venue markets can be `stable` on R1 alone.
+- **R3.** Each result carries `stable_since` (start of the current uninterrupted stable streak, from snapshot history), `confidence`, and a `drivers` list naming satisfied conditions.
+- **R4.** A read workflow + MCP tool (`worldcup-stable-markets` / `worldcup_stable_markets`) returns the worklist, filterable by team/competition, sorted most-recently-stabilized first; read-only with the standard disclaimers.
+- **R5.** Thresholds (spread bps, movement bps, agreement bps, volume floor, window length) are parameters with sane defaults.
+- **R6.** Stateless — no new persistent state.
+- **S1–S4.** Fires live; explainable; never marks thin/crossed/moving books stable; honest that latency-vs-feed is not benchmarked.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Pure engine function over already-normalized records.** `compute_market_stability(markets, snapshots, params)` mirrors `compute_market_movers` / `pair_cross_source`: stateless, testable with fixtures, returns `{status, data}`. (see origin: KD1)
+- **KTD2 — Reuse, don't reinvent, the gates.** Reliability = the existing `price_quality` field; completeness = the de-vig overround band already in `pair_cross_source`; movement = min/max of `primary_price` over the windowed `worldcup:market-snapshot` rows (same store `compute_market_movers` reads); agreement = `pair_cross_source` edge_bps. The function is a composition, not a new model. (origin: KD2)
+- **KTD3 — `stable_since` from the snapshot streak.** Walk this market's snapshots newest→oldest while each stays within the movement band; the earliest in the unbroken run is `stable_since`. If only the current quote exists (no history yet), `stable_since` is null and the market is reported `confidence: provisional` rather than omitted — surfaces freshly-cached markets without over-claiming stability.
+- **KTD4 — Single-venue stable is valid; agreement is an upgrade.** Confidence tiers: `provisional` (no/short history) → `stable` (R1 over the window, one venue) → `corroborated` (R1 + cross-venue agreement). (origin: KD3, R2)
+- **KTD5 — Thresholds as workflow inputs with defaults.** Defaults are demo-sane starting points to calibrate with Ciaran, not load-bearing constants (origin Outstanding Question).
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TD
+  A[worldcup:market-cache<br/>current quotes] --> C[compute_market_stability]
+  B[worldcup:market-snapshot<br/>windowed history] --> C
+  C -->|per market| D{price_quality ok?<br/>de-vig band complete?<br/>spread tight?<br/>movement low?<br/>volume present?}
+  D -->|all pass| E[stable]
+  D -->|fail| X[excluded]
+  E --> F{cross-venue agree?<br/>pair_cross_source edge<= N bps}
+  F -->|yes| G[corroborated]
+  F -->|no| E
+  E --> H[stable_since from snapshot streak]
+  G --> H
+  H --> I[worklist sorted by stable_since desc<br/>+ drivers + confidence]
+```
+
+Stability check (directional, not implementation spec):
+```
+window = snapshots for cache_id within window_hours
+movement_ok = (max(primary_price) - min(primary_price) over window) <= movement_bps/1e4
+stable = price_quality=="ok" AND devig_band_ok(book) AND spread<=spread_bps/1e4
+         AND movement_ok AND volume>=floor
+confidence = corroborated if (cross_venue_edge_bps for this bucket <= agreement_bps)
+             else stable if has_window_history else provisional
+drivers = [name for each passing condition]   # explainability (S2)
+```
+
+---
+
+## Implementation Units
+
+### U1. `compute_market_stability` engine command + tests
+
+**Goal:** Pure, stateless stability classifier over normalized markets + snapshots (R1, R2, R3, R5, R6).
+**Requirements:** R1, R2, R3, R5, R6, S2, S3.
+**Dependencies:** none (operates on deployed data shapes).
+**Files:**
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` (new `compute_market_stability`; small helpers for window-movement and the stable-streak walk; reuse `_yes_price`, the de-vig band, and `pair_cross_source` for agreement)
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py`
+
+**Approach:** Params: `markets`, `snapshots`, `spread_bps` (default ~200), `movement_bps` (default ~150), `agreement_bps` (default ~150), `min_volume` (default a sane floor), `window_hours` (default ~6), `team`/`query` filters, `limit`. Drop `price_quality == "unreliable"` first. For each market evaluate the R1 gates; compute movement from the windowed snapshot rows for its `cache_id`; derive `stable_since` per KTD3; compute confidence per KTD4 using a one-time `pair_cross_source` pass over the input set to get per-bucket cross-venue edges. Emit `{cache_id, title, source, event_urn, related_team_urns, outcome, price, confidence, stable_since, drivers, volume, spread}`. Sort by `stable_since` desc (provisional last). Return `{status, data: {stable_markets, count, warnings, thresholds}}`.
+
+**Patterns to follow:** `compute_market_movers` (windowed snapshot read + baseline walk), `pair_cross_source` (de-vig band, bucket agreement), `detect_market_edges` (unreliable filtering, caveats list).
+
+**Test scenarios:**
+- *Happy path / S2:* a market that is `ok`, tight spread, flat price across the window, volume present → returned `stable` with `drivers` naming spread/movement/volume; `stable_since` = earliest snapshot in the flat run.
+- *Corroborated (R2):* both venues price the outcome and agree within `agreement_bps` → `confidence: corroborated`; widen one venue's price beyond `agreement_bps` → downgrades to `stable`.
+- *Single-venue (R2):* only one venue present but R1 passes → `stable`, not excluded.
+- *S3 — moving book excluded:* primary price swings more than `movement_bps` across the window → excluded (not stable).
+- *S3 — unreliable/crossed excluded:* `price_quality: unreliable` (or wide spread) → excluded.
+- *Volume floor:* volume below `min_volume` → excluded even if flat.
+- *KTD3 — provisional:* market in cache but no snapshot history → `confidence: provisional`, `stable_since: null`, still returned.
+- *Streak break:* a mid-window snapshot outside the movement band → `stable_since` is the start of the *latest* unbroken run, not the window start.
+- *Filters/sort:* `team` filter narrows results; output sorted `stable_since` desc with provisional last.
+- *Thresholds (R5):* tightening `spread_bps` flips a borderline market from stable to excluded.
+
+**Verification:** `pytest -k market_stability` passes; a fixture mirroring the live cache (Kalshi "Yes"-named legs + Polymarket moneyline, with snapshot history) yields a sensible worklist.
+
+### U2. `worldcup-stable-markets` workflow + MCP tool doc
+
+**Goal:** Expose the classifier as a read workflow / MCP tool returning the worklist (R4).
+**Requirements:** R4, R5, S1, S4.
+**Dependencies:** U1.
+**Files:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml` (new)
+- `agent-templates/world-cup-intelligence/docs/mcp-tools.md` (document `worldcup_stable_markets` under the Forecast & intelligence tier)
+
+**Approach:** Mirror `worldcup-market-movers.yml`: load `worldcup:market-cache` (search-limit 500) and `worldcup:market-snapshot` filtered to `window_hours` (same `value.ts >= utcnow()-window` pattern), then a connector task calling `worldcup-market-intelligence.compute_market_stability` with the loaded markets/snapshots + threshold inputs. Workflow inputs expose the thresholds + `team`/`query`/`limit` with defaults; outputs `stable_markets`, `count`, `warnings`, `thresholds`. Read-only; include the standard resolution-risk disclaimer and the S4 caveat ("detection-vs-feed latency not benchmarked") in `warnings`. Add the doc entry describing inputs/outputs; note it is allowlisted like the other public read tools.
+
+**Patterns to follow:** `worldcup-market-movers.yml` (cache + windowed-snapshot load → connector compute), `worldcup-search-markets.yml` (team/query/limit inputs), `docs/mcp-tools.md` existing tier entries.
+
+**Test scenarios:**
+- `Test expectation: none` for the YAML wiring itself beyond the engine tests, BUT include one **integration test** in `tests/test_worldcup_market_intelligence.py` that feeds realistic cache + snapshot fixtures through `compute_market_stability` and asserts the worklist shape the workflow returns (Covers S1) — guards the cache/snapshot field names the workflow passes (`value`, `ts`, `primary_price`) against the engine's expectations.
+- *S4 caveat present:* the workflow surfaces the not-benchmarked caveat in `warnings`.
+
+**Verification:** `execute_workflow worldcup-stable-markets {window_hours: 6}` on the live pod returns a worklist of stable markets with drivers; tightening thresholds shrinks it; doc entry renders.
+
+---
+
+## Scope Boundaries
+
+**In scope:** the stability engine command, the workflow + MCP tool, explainable drivers, configurable thresholds, the realistic-fixture integration test.
+
+**Deferred to Follow-Up Work:**
+- Append-only `unstable → stable` **transition-event logging** + **detection-latency benchmarking** vs a feed baseline (needs Fanatics suspension events + TX Fusion timestamps).
+- A push/webhook on transition (vs poll) — would promote the transition-event path into scope.
+- Finer-grained snapshot cadence if the hourly bucket proves too coarse for a crisp demo (origin Outstanding Question; the snapshot id is hourly-bucketed today).
+
+**Outside this product's identity:** any pricing/market-making/execution action; integration into Fanatics' internal re-enablement; ingesting their proprietary feed. Read-only intelligence only.
+
+---
+
+## Risks & Open Questions
+
+- **Snapshot cadence (open, origin).** Hourly snapshots may be too coarse to show "low movement" crisply in a demo. Mitigation: `window_hours` default tuned to available history; finer cadence deferred. Resolve during the demo dry-run.
+- **Default thresholds (open, origin).** Spread/movement/agreement/volume defaults are demo-sane guesses; calibrate with Ciaran against his re-enable risk tolerance. They are inputs, so no code change to retune.
+- **Consumption shape (open, origin).** Polled worklist assumed; if Ciaran wants push, the deferred transition-event path comes into scope.
+- **Provisional noise.** Newly-cached markets with no history report `provisional`; if that clutters the worklist, gate provisional behind an input flag (note for implementation, not pre-decided).
+
+---
+
+## System-Wide Impact
+
+Additive and read-only. New engine function + new workflow; no change to existing market-cache/snapshot writes, the sync, or `pair_cross_source`/`detect_market_edges` behavior. Deploys to the pod via the same `import_templates_from_git` path used for PR #283. No migration, no persistent-state change.


### PR DESCRIPTION
## Summary

Adds a read-only **stabilized-markets worklist** (`worldcup_stable_markets`) to the cross-source market layer (PR #283) — the explainable inverse of the `price_quality: unreliable` flag. It surfaces markets whose Kalshi/Polymarket quote has settled into a stable, reliable, (optionally) cross-venue-agreeing state, so a trading desk can use it as a faster "safe to re-enable" candidate signal than waiting on a traditional pricing feed.

Driven by a named buyer need: **Ciaran Foy (Director of Product, BetFanatics)** on the 2026-06-30 call asked for exactly this — *"get markets back on site quicker once the pricing normalizes on Polymarket and Kalshi, as opposed to waiting for updates from like a TX Fusion feed."* Scoped for a 2-week demo sprint.

Origin: `docs/brainstorms/2026-06-30-market-stabilization-signal-requirements.md` → `docs/plans/2026-06-30-002-feat-market-stabilization-signal-plan.md`.

## What it does

- **U1** `compute_market_stability` — stateless classifier over `worldcup:market-cache` + windowed `worldcup:market-snapshot`. Gates: `price_quality: ok`, spread within threshold (conditional — Kalshi cache legs often have null spread, already covered by `price_quality`), volume floor, and a **stable price suffix** in the snapshot window. Confidence tiers: `provisional` (insufficient history) → `stable` (one venue) → `corroborated` (both venues agree within `agreement_bps`, via `pair_cross_source`). Each result carries `stable_since` + an explainable `drivers` list. Thresholds are tunable inputs.
- **U2** `worldcup-stable-markets` workflow + `worldcup_stable_markets` MCP tool doc.

Key design call: stability keys off the **stable suffix streak**, not full-window movement — so a market that moved then re-stabilized is correctly `stable` with `stable_since` at the post-move point, while an actively-moving book (latest pair diverges) is excluded.

## Testing

- 199 unit tests pass (12 new for stability: happy path, corroborated/stable/single-venue, actively-moving exclusion, streak-break `stable_since`, unreliable/wide-spread/low-volume exclusion, provisional-no-history, team filter, threshold flip, workflow-contract shapes).

## Scope / honesty

- **Deferred:** transition-event logging + detection-latency benchmarking vs TX Fusion (needs Fanatics' suspension events + feed timestamps); push/webhook on transition. Documented as the follow-up once they share data.
- **Honest success bar:** proves the signal is sound and explainable on live WC markets; explicitly does **not** claim a measured latency win — the workflow surfaces that caveat in `warnings`.
- Read-only intelligence; no pricing or execution.

## Code review

Tier 2 multi-agent review not run — escalation criteria not met (read-only, no sensitive surface, ~1 subsystem/~300 lines) and not requested this round. Logic is well-covered by edge-case tests and reuses the already-reviewed `pair_cross_source`.

## Post-Deploy Monitoring & Validation

Not yet deployed (the live MCP runs the production pod). After import:
- **Run** `worldcup-stable-markets {window_hours: 24}` — expect a worklist of stable markets, each with `stable_since`, a `confidence` tier, and `drivers`.
- **Healthy signal:** corroborated/stable markets are ones with tight, flat, liquid books; actively-moving games are absent; freshly-cached markets show `provisional`.
- **Failure signal:** a visibly-moving market marked `stable`, or all Kalshi markets missing (would indicate the conditional-spread gate regressed and excluded null-spread legs). 
- **Owner/window:** verify within the first sync cycle after deploy; calibrate thresholds with Ciaran against his re-enable risk tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
