### PR TITLE
feat: nvidia-nim connector (chat) governed by operational config

### DIFF
--- a/.github/workflows/test-nvidia-nim.yml
+++ b/.github/workflows/test-nvidia-nim.yml
@@ -1,0 +1,28 @@
+name: Test NVIDIA NIM connector
+
+on:
+  pull_request:
+    paths:
+      - "connectors/nvidia-nim/**"
+      - ".github/workflows/test-nvidia-nim.yml"
+  push:
+    branches: [main]
+    paths:
+      - "connectors/nvidia-nim/**"
+      - ".github/workflows/test-nvidia-nim.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  connector-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install hermetic test dependencies
+        run: python -m pip install pytest requests
+      - name: Run NVIDIA NIM connector tests
+        run: python -m pytest connectors/nvidia-nim/tests -q

--- a/connectors/nvidia-nim/README.md
+++ b/connectors/nvidia-nim/README.md
@@ -1,0 +1,45 @@
+# NVIDIA NIM connector
+
+Chat inference on an NVIDIA NIM endpoint (OpenAI-compatible `/v1`), for the
+Machina private runtime. The endpoint and the model allowlist are
+**operational config** — injected on the runtime by the deployment, never
+supplied by workflow YAML. A template may choose a model *within* the
+allowlist; it cannot point the runtime at an arbitrary URL (the connector
+fails closed on any `base_url` coming from a workflow).
+
+## Environment (operational config)
+
+| Env | Required | Meaning |
+|---|---|---|
+| `NVIDIA_NIM_CHAT_BASE_URL` | yes | NIM endpoint, e.g. `http://nemotron-nim:8001/v1` |
+| `NVIDIA_NIM_CHAT_MODEL` | yes | Default model, e.g. `nvidia/nemotron-3-super-120b-a12b` |
+| `NVIDIA_NIM_ALLOWED_MODELS` | no | CSV allowlist; defaults to just the default model |
+| `NVIDIA_NIM_TIMEOUT_SECONDS` | no | Request timeout (default 70 — Nemotron with reasoning needs >18s for structured answers) |
+| `NVIDIA_NIM_MAX_OUTPUT_TOKENS` | no | Hard cap applied to `max_tokens` |
+| `NVIDIA_NIM_API_KEY` | no | Local NIMs don't validate it |
+
+Embeddings are deliberately **separate**: the retrieval facade on
+machina-client-api owns them under the `RETRIEVAL_NIM_*` envs. This
+connector is chat only.
+
+## Commands
+
+- `invoke_chat` (Prompt) — returns a LangChain `ChatOpenAI` wired to the NIM
+  endpoint; the engine runs the prompt against it. Honors `model_name`
+  (allowlist-checked), `temperature`, `max_tokens` (capped by
+  `NVIDIA_NIM_MAX_OUTPUT_TOKENS`).
+- `list_models` — models served by the endpoint alongside the allowlist.
+- `health` — private-runtime receipt: operational config present, endpoint
+  reachable, default model served. Used by the
+  `nvidia-nim-test-credentials` workflow.
+
+## Usage in a workflow prompt task
+
+```yaml
+- type: prompt
+  name: my-analysis
+  connector:
+    name: nvidia-nim
+    command: invoke_chat
+    model: nvidia/nemotron-3-super-120b-a12b   # must be in the allowlist
+```

--- a/connectors/nvidia-nim/README.md
+++ b/connectors/nvidia-nim/README.md
@@ -13,10 +13,10 @@ fails closed on any `base_url` coming from a workflow).
 |---|---|---|
 | `NVIDIA_NIM_CHAT_BASE_URL` | yes | NIM endpoint, e.g. `http://nemotron-nim:8001/v1` |
 | `NVIDIA_NIM_CHAT_MODEL` | yes | Default model, e.g. `nvidia/nemotron-3-super-120b-a12b` |
-| `NVIDIA_NIM_ALLOWED_MODELS` | no | CSV allowlist; defaults to just the default model |
-| `NVIDIA_NIM_TIMEOUT_SECONDS` | no | Request timeout (default 70 — Nemotron with reasoning needs >18s for structured answers) |
-| `NVIDIA_NIM_MAX_OUTPUT_TOKENS` | no | Hard cap applied to `max_tokens` |
-| `NVIDIA_NIM_API_KEY` | no | Local NIMs don't validate it |
+| `NVIDIA_NIM_CHAT_ALLOWED_MODELS` | no | CSV allowlist; defaults to just the default model |
+| `NVIDIA_NIM_CHAT_TIMEOUT_SECONDS` | no | Request timeout (default 70 — Nemotron with reasoning needs >18s for structured answers) |
+| `NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS` | no | Hard cap applied to `max_tokens` |
+| `NVIDIA_NIM_CHAT_API_KEY` | no | Local NIMs don't validate it |
 
 Embeddings are deliberately **separate**: the retrieval facade on
 machina-client-api owns them under the `RETRIEVAL_NIM_*` envs. This
@@ -27,10 +27,12 @@ connector is chat only.
 - `invoke_chat` (Prompt) — returns a LangChain `ChatOpenAI` wired to the NIM
   endpoint; the engine runs the prompt against it. Honors `model_name`
   (allowlist-checked), `temperature`, `max_tokens` (capped by
-  `NVIDIA_NIM_MAX_OUTPUT_TOKENS`).
+  `NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS`).
 - `list_models` — models served by the endpoint alongside the allowlist.
-- `health` — private-runtime receipt: operational config present, endpoint
-  reachable, default model served. Used by the
+- `health` — operational config present, endpoint reachable, default model served.
+- `completion_receipt` — sends a small, non-streaming chat completion and
+  records the served model, response ID, output, and token usage. Together
+  with `health`, this is the executable private-runtime receipt used by the
   `nvidia-nim-test-credentials` workflow.
 
 ## Usage in a workflow prompt task

--- a/connectors/nvidia-nim/_install.yml
+++ b/connectors/nvidia-nim/_install.yml
@@ -1,0 +1,23 @@
+setup:
+  title: NVIDIA NIM
+  description: Chat inference on an NVIDIA NIM endpoint (OpenAI-compatible), governed by operational-config allowlists.
+  category:
+    - ai-models
+  estimatedTime: 5 minutes
+  features:
+    - Chat completions on Nemotron and other NIM-served models
+    - Endpoint and model allowlist from NVIDIA_NIM_* operational config (never workflow YAML)
+    - Health and list-models commands for private-runtime receipts
+  requirements:
+    - NVIDIA-NIM-Chat-Base-URL
+    - NVIDIA-NIM-Chat-Model
+  status: available
+  value: connectors/nvidia-nim
+  version: 1.0.0
+
+datasets:
+  - type: "connector"
+    path: "nvidia-nim.yml"
+
+  - type: "workflow"
+    path: "test-credentials.yml"

--- a/connectors/nvidia-nim/_install.yml
+++ b/connectors/nvidia-nim/_install.yml
@@ -6,14 +6,14 @@ setup:
   estimatedTime: 5 minutes
   features:
     - Chat completions on Nemotron and other NIM-served models
-    - Endpoint and model allowlist from NVIDIA_NIM_* operational config (never workflow YAML)
-    - Health and list-models commands for private-runtime receipts
+    - Endpoint and model allowlist from NVIDIA_NIM_CHAT_* operational config (never workflow YAML)
+    - Health, completion, and list-models commands for private-runtime receipts
   requirements:
     - NVIDIA-NIM-Chat-Base-URL
     - NVIDIA-NIM-Chat-Model
   status: available
   value: connectors/nvidia-nim
-  version: 1.0.0
+  version: 1.1.0
 
 datasets:
   - type: "connector"

--- a/connectors/nvidia-nim/nvidia-nim.py
+++ b/connectors/nvidia-nim/nvidia-nim.py
@@ -3,7 +3,7 @@ NVIDIA NIM chat connector — OpenAI-compatible /v1 endpoint resolved from
 OPERATIONAL CONFIG ONLY (private-runtime requirement).
 
 The endpoint and the model allowlist come from the runtime environment
-(NVIDIA_NIM_* envs injected by the deployment), never from workflow YAML:
+(NVIDIA_NIM_CHAT_* envs injected by the deployment), never from workflow YAML:
 a template can pick a model within the allowlist, but cannot point the
 runtime at an arbitrary URL. Embeddings are deliberately separate
 (RETRIEVAL_NIM_* on the client-api retrieval facade).
@@ -11,11 +11,11 @@ runtime at an arbitrary URL. Embeddings are deliberately separate
 Env contract:
   NVIDIA_NIM_CHAT_BASE_URL      e.g. http://nemotron-nim:8001/v1 (required)
   NVIDIA_NIM_CHAT_MODEL         default model, e.g. nvidia/nemotron-3-super-120b-a12b (required)
-  NVIDIA_NIM_ALLOWED_MODELS     csv allowlist (default: just the default model)
-  NVIDIA_NIM_TIMEOUT_SECONDS    request timeout (default 70 — Nemotron with
-                                reasoning needs >18s for structured answers)
-  NVIDIA_NIM_MAX_OUTPUT_TOKENS  optional hard cap on max_tokens
-  NVIDIA_NIM_API_KEY            optional; local NIMs don't validate it
+  NVIDIA_NIM_CHAT_ALLOWED_MODELS     csv allowlist (default: just the default model)
+  NVIDIA_NIM_CHAT_TIMEOUT_SECONDS    request timeout (default 70 — Nemotron with
+                                     reasoning needs >18s for structured answers)
+  NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS  optional hard cap on max_tokens
+  NVIDIA_NIM_CHAT_API_KEY            optional; local NIMs don't validate it
 """
 
 import os
@@ -26,18 +26,37 @@ import requests
 def _operational_config():
     base_url = (os.environ.get("NVIDIA_NIM_CHAT_BASE_URL") or "").strip().rstrip("/")
     default_model = (os.environ.get("NVIDIA_NIM_CHAT_MODEL") or "").strip()
-    allowed_raw = os.environ.get("NVIDIA_NIM_ALLOWED_MODELS") or default_model
+    allowed_raw = os.environ.get("NVIDIA_NIM_CHAT_ALLOWED_MODELS") or default_model
     allowed = tuple(m.strip() for m in allowed_raw.split(",") if m.strip())
-    timeout = float(os.environ.get("NVIDIA_NIM_TIMEOUT_SECONDS") or 70)
+    timeout = float(os.environ.get("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS") or 70)
+    if timeout <= 0:
+        raise ValueError("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS must be greater than zero")
     return base_url, default_model, allowed, timeout
 
 
 def _models_headers():
     headers = {}
-    api_key = os.environ.get("NVIDIA_NIM_API_KEY")
+    api_key = os.environ.get("NVIDIA_NIM_CHAT_API_KEY")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     return headers
+
+
+def _config_value_error(error):
+    return {
+        "status": "error",
+        "message": f"Invalid NVIDIA NIM chat operational config: {error}",
+    }
+
+
+def _output_token_cap():
+    raw = os.environ.get("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS")
+    if not raw:
+        return None
+    value = int(raw)
+    if value <= 0:
+        raise ValueError("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS must be greater than zero")
+    return value
 
 
 def _config_error():
@@ -51,7 +70,11 @@ def _config_error():
 
 def invoke_chat(params):
     """Build a ChatOpenAI wired to the NIM endpoint (the engine runs the prompt)."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    params = params or {}
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     if not base_url or not default_model:
         return _config_error()
@@ -78,17 +101,15 @@ def invoke_chat(params):
     if model not in allowed:
         return {
             "status": "error",
-            "message": f"Model '{model}' is not in NVIDIA_NIM_ALLOWED_MODELS "
+            "message": f"Model '{model}' is not in NVIDIA_NIM_CHAT_ALLOWED_MODELS "
                        f"({', '.join(allowed)}).",
         }
 
     try:
-        from langchain_openai import ChatOpenAI
-
         kwargs = {
             "base_url": base_url,
             "model": model,
-            "api_key": os.environ.get("NVIDIA_NIM_API_KEY") or "not-needed",
+            "api_key": os.environ.get("NVIDIA_NIM_CHAT_API_KEY") or "not-needed",
             "timeout": timeout,
         }
 
@@ -96,13 +117,13 @@ def invoke_chat(params):
             max_tokens = params.get("max_tokens")
             if max_tokens is None:
                 max_tokens = params.get("params", {}).get("max_tokens")
-            cap = os.environ.get("NVIDIA_NIM_MAX_OUTPUT_TOKENS")
+            cap = _output_token_cap()
             if max_tokens is not None and cap:
-                kwargs["max_tokens"] = min(int(max_tokens), int(cap))
+                kwargs["max_tokens"] = min(int(max_tokens), cap)
             elif max_tokens is not None:
                 kwargs["max_tokens"] = int(max_tokens)
             elif cap:
-                kwargs["max_tokens"] = int(cap)
+                kwargs["max_tokens"] = cap
 
             temperature = params.get("temperature")
             if temperature is None:
@@ -115,6 +136,8 @@ def invoke_chat(params):
                 "message": f"Invalid generation params (max_tokens/temperature must be numeric): {e}",
             }
 
+        from langchain_openai import ChatOpenAI
+
         llm = ChatOpenAI(**kwargs)
 
         return {"status": True, "data": llm, "message": "Model loaded."}
@@ -124,7 +147,10 @@ def invoke_chat(params):
 
 def list_models(params):
     """List models served by the NIM endpoint, alongside the allowlist."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     if not base_url:
         return _config_error()
@@ -145,9 +171,94 @@ def list_models(params):
         return {"status": "error", "message": f"Error listing NIM models: {str(e)}"}
 
 
+def completion_receipt(params):
+    """Execute one small chat completion to prove the configured NIM serves inference."""
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+        cap = _output_token_cap()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
+
+    if not base_url or not default_model:
+        return _config_error()
+    if default_model not in allowed:
+        return {
+            "status": "error",
+            "message": f"Default model '{default_model}' is not in "
+                       "NVIDIA_NIM_CHAT_ALLOWED_MODELS.",
+        }
+
+    max_tokens = min(32, cap) if cap else 32
+    body = {
+        "model": default_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "/no_think Reply with exactly MACHINA_NIM_OK.",
+            }
+        ],
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+    headers = {"Content-Type": "application/json", **_models_headers()}
+
+    try:
+        response = requests.post(
+            f"{base_url}/chat/completions",
+            headers=headers,
+            json=body,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        choices = payload.get("choices") or []
+        message = choices[0].get("message", {}) if choices else {}
+        content = message.get("content")
+        if isinstance(content, list):
+            content = "".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+        content = str(content or "").strip()
+        if not content:
+            raise ValueError("completion response did not contain message content")
+
+        usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+        return {
+            "status": True,
+            "data": {
+                "completed": True,
+                "endpoint": base_url,
+                "requested_model": default_model,
+                "response_model": payload.get("model") or default_model,
+                "response_id": payload.get("id") or "",
+                "output": content[:200],
+                "usage": {
+                    key: usage[key]
+                    for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+                    if key in usage
+                },
+            },
+            "message": "NIM completion receipt succeeded.",
+        }
+    except Exception as error:
+        return {
+            "status": "error",
+            "data": {
+                "completed": False,
+                "endpoint": base_url,
+                "requested_model": default_model,
+            },
+            "message": f"NIM completion receipt failed: {str(error)}",
+        }
+
+
 def health(params):
     """Private-runtime receipt: config present, endpoint reachable, default model served."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     checks = []
 
@@ -170,7 +281,7 @@ def health(params):
         "check": "default_model_allowlisted",
         "ok": default_allowed,
         "detail": default_model if default_allowed
-        else f"'{default_model}' missing from NVIDIA_NIM_ALLOWED_MODELS",
+        else f"'{default_model}' missing from NVIDIA_NIM_CHAT_ALLOWED_MODELS",
     })
     if not default_allowed:
         return {

--- a/connectors/nvidia-nim/nvidia-nim.py
+++ b/connectors/nvidia-nim/nvidia-nim.py
@@ -1,0 +1,194 @@
+"""
+NVIDIA NIM chat connector — OpenAI-compatible /v1 endpoint resolved from
+OPERATIONAL CONFIG ONLY (private-runtime requirement).
+
+The endpoint and the model allowlist come from the runtime environment
+(NVIDIA_NIM_* envs injected by the deployment), never from workflow YAML:
+a template can pick a model within the allowlist, but cannot point the
+runtime at an arbitrary URL. Embeddings are deliberately separate
+(RETRIEVAL_NIM_* on the client-api retrieval facade).
+
+Env contract:
+  NVIDIA_NIM_CHAT_BASE_URL      e.g. http://nemotron-nim:8001/v1 (required)
+  NVIDIA_NIM_CHAT_MODEL         default model, e.g. nvidia/nemotron-3-super-120b-a12b (required)
+  NVIDIA_NIM_ALLOWED_MODELS     csv allowlist (default: just the default model)
+  NVIDIA_NIM_TIMEOUT_SECONDS    request timeout (default 70 — Nemotron with
+                                reasoning needs >18s for structured answers)
+  NVIDIA_NIM_MAX_OUTPUT_TOKENS  optional hard cap on max_tokens
+  NVIDIA_NIM_API_KEY            optional; local NIMs don't validate it
+"""
+
+import os
+
+import requests
+
+
+def _operational_config():
+    base_url = (os.environ.get("NVIDIA_NIM_CHAT_BASE_URL") or "").strip().rstrip("/")
+    default_model = (os.environ.get("NVIDIA_NIM_CHAT_MODEL") or "").strip()
+    allowed_raw = os.environ.get("NVIDIA_NIM_ALLOWED_MODELS") or default_model
+    allowed = tuple(m.strip() for m in allowed_raw.split(",") if m.strip())
+    timeout = float(os.environ.get("NVIDIA_NIM_TIMEOUT_SECONDS") or 70)
+    return base_url, default_model, allowed, timeout
+
+
+def _models_headers():
+    headers = {}
+    api_key = os.environ.get("NVIDIA_NIM_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _config_error():
+    return {
+        "status": "error",
+        "message": "NVIDIA NIM operational config missing: set "
+                   "NVIDIA_NIM_CHAT_BASE_URL and NVIDIA_NIM_CHAT_MODEL on the "
+                   "runtime (never in workflow YAML).",
+    }
+
+
+def invoke_chat(params):
+    """Build a ChatOpenAI wired to the NIM endpoint (the engine runs the prompt)."""
+    base_url, default_model, allowed, timeout = _operational_config()
+
+    if not base_url or not default_model:
+        return _config_error()
+
+    # Fail closed on endpoint injection: the URL is operational config.
+    supplied_url = (
+        params.get("base_url")
+        or params.get("params", {}).get("base_url")
+        or params.get("headers", {}).get("base_url")
+    )
+    if supplied_url and str(supplied_url).strip().rstrip("/") != base_url:
+        return {
+            "status": "error",
+            "message": "base_url is operational config for nvidia-nim; "
+                       "remove it from the workflow.",
+        }
+
+    requested = (
+        params.get("model_name")
+        or params.get("params", {}).get("model_name")
+        or ""
+    ).strip()
+    model = requested or default_model
+    if model not in allowed:
+        return {
+            "status": "error",
+            "message": f"Model '{model}' is not in NVIDIA_NIM_ALLOWED_MODELS "
+                       f"({', '.join(allowed)}).",
+        }
+
+    try:
+        from langchain_openai import ChatOpenAI
+
+        kwargs = {
+            "base_url": base_url,
+            "model": model,
+            "api_key": os.environ.get("NVIDIA_NIM_API_KEY") or "not-needed",
+            "timeout": timeout,
+        }
+
+        max_tokens = params.get("max_tokens")
+        if max_tokens is None:
+            max_tokens = params.get("params", {}).get("max_tokens")
+        cap = os.environ.get("NVIDIA_NIM_MAX_OUTPUT_TOKENS")
+        if max_tokens is not None and cap:
+            kwargs["max_tokens"] = min(int(max_tokens), int(cap))
+        elif max_tokens is not None:
+            kwargs["max_tokens"] = int(max_tokens)
+        elif cap:
+            kwargs["max_tokens"] = int(cap)
+
+        temperature = params.get("temperature")
+        if temperature is None:
+            temperature = params.get("params", {}).get("temperature")
+        if temperature is not None:
+            kwargs["temperature"] = float(temperature)
+
+        llm = ChatOpenAI(**kwargs)
+
+        return {"status": True, "data": llm, "message": "Model loaded."}
+    except Exception as e:
+        return {"status": "error", "message": f"Error loading NIM model: {str(e)}"}
+
+
+def list_models(params):
+    """List models served by the NIM endpoint, alongside the allowlist."""
+    base_url, default_model, allowed, timeout = _operational_config()
+
+    if not base_url:
+        return _config_error()
+
+    try:
+        response = requests.get(
+            f"{base_url}/models", headers=_models_headers(), timeout=min(timeout, 15)
+        )
+        response.raise_for_status()
+        served = [m.get("id") for m in response.json().get("data", []) if m.get("id")]
+
+        return {
+            "status": True,
+            "data": {"models": served, "allowed": list(allowed), "default": default_model},
+            "message": "Models retrieved successfully.",
+        }
+    except Exception as e:
+        return {"status": "error", "message": f"Error listing NIM models: {str(e)}"}
+
+
+def health(params):
+    """Private-runtime receipt: config present, endpoint reachable, default model served."""
+    base_url, default_model, allowed, timeout = _operational_config()
+
+    checks = []
+
+    configured = bool(base_url and default_model)
+    checks.append({
+        "check": "operational_config",
+        "ok": configured,
+        "detail": "NVIDIA_NIM_CHAT_BASE_URL + NVIDIA_NIM_CHAT_MODEL set" if configured
+        else "missing NVIDIA_NIM_CHAT_BASE_URL / NVIDIA_NIM_CHAT_MODEL",
+    })
+    if not configured:
+        return {
+            "status": "error",
+            "data": {"healthy": False, "checks": checks},
+            "message": "NIM operational config missing.",
+        }
+
+    healthy = True
+    served = []
+    try:
+        response = requests.get(
+            f"{base_url}/models", headers=_models_headers(), timeout=min(timeout, 15)
+        )
+        response.raise_for_status()
+        served = [m.get("id") for m in response.json().get("data", []) if m.get("id")]
+        checks.append({"check": "endpoint_reachable", "ok": True, "detail": base_url})
+    except Exception as e:
+        healthy = False
+        checks.append({"check": "endpoint_reachable", "ok": False, "detail": str(e)[:200]})
+
+    if healthy:
+        model_served = default_model in served
+        healthy = model_served
+        checks.append({
+            "check": "default_model_served",
+            "ok": model_served,
+            "detail": default_model if model_served
+            else f"'{default_model}' not among served models",
+        })
+
+    data = {
+        "healthy": healthy,
+        "endpoint": base_url,
+        "default_model": default_model,
+        "allowed_models": list(allowed),
+        "checks": checks,
+    }
+    if healthy:
+        return {"status": True, "data": data, "message": "NIM healthy."}
+    return {"status": "error", "data": data, "message": "NIM health check failed."}

--- a/connectors/nvidia-nim/nvidia-nim.py
+++ b/connectors/nvidia-nim/nvidia-nim.py
@@ -92,22 +92,28 @@ def invoke_chat(params):
             "timeout": timeout,
         }
 
-        max_tokens = params.get("max_tokens")
-        if max_tokens is None:
-            max_tokens = params.get("params", {}).get("max_tokens")
-        cap = os.environ.get("NVIDIA_NIM_MAX_OUTPUT_TOKENS")
-        if max_tokens is not None and cap:
-            kwargs["max_tokens"] = min(int(max_tokens), int(cap))
-        elif max_tokens is not None:
-            kwargs["max_tokens"] = int(max_tokens)
-        elif cap:
-            kwargs["max_tokens"] = int(cap)
+        try:
+            max_tokens = params.get("max_tokens")
+            if max_tokens is None:
+                max_tokens = params.get("params", {}).get("max_tokens")
+            cap = os.environ.get("NVIDIA_NIM_MAX_OUTPUT_TOKENS")
+            if max_tokens is not None and cap:
+                kwargs["max_tokens"] = min(int(max_tokens), int(cap))
+            elif max_tokens is not None:
+                kwargs["max_tokens"] = int(max_tokens)
+            elif cap:
+                kwargs["max_tokens"] = int(cap)
 
-        temperature = params.get("temperature")
-        if temperature is None:
-            temperature = params.get("params", {}).get("temperature")
-        if temperature is not None:
-            kwargs["temperature"] = float(temperature)
+            temperature = params.get("temperature")
+            if temperature is None:
+                temperature = params.get("params", {}).get("temperature")
+            if temperature is not None:
+                kwargs["temperature"] = float(temperature)
+        except (TypeError, ValueError) as e:
+            return {
+                "status": "error",
+                "message": f"Invalid generation params (max_tokens/temperature must be numeric): {e}",
+            }
 
         llm = ChatOpenAI(**kwargs)
 
@@ -157,6 +163,20 @@ def health(params):
             "status": "error",
             "data": {"healthy": False, "checks": checks},
             "message": "NIM operational config missing.",
+        }
+
+    default_allowed = default_model in allowed
+    checks.append({
+        "check": "default_model_allowlisted",
+        "ok": default_allowed,
+        "detail": default_model if default_allowed
+        else f"'{default_model}' missing from NVIDIA_NIM_ALLOWED_MODELS",
+    })
+    if not default_allowed:
+        return {
+            "status": "error",
+            "data": {"healthy": False, "checks": checks},
+            "message": "Default model is not in the allowlist.",
         }
 
     healthy = True

--- a/connectors/nvidia-nim/nvidia-nim.yml
+++ b/connectors/nvidia-nim/nvidia-nim.yml
@@ -1,6 +1,6 @@
 connector:
   name: "nvidia-nim"
-  description: "NVIDIA NIM chat (OpenAI-compatible). Endpoint and model allowlist resolved from NVIDIA_NIM_* operational config — never from workflow YAML."
+  description: "NVIDIA NIM chat (OpenAI-compatible). Endpoint and model allowlist resolved from NVIDIA_NIM_CHAT_* operational config — never from workflow YAML."
   filename: "nvidia-nim.py"
   filetype: "pyscript"
   commands:
@@ -10,3 +10,5 @@ connector:
       value: "list_models"
     - name: "Health"
       value: "health"
+    - name: "Completion Receipt"
+      value: "completion_receipt"

--- a/connectors/nvidia-nim/nvidia-nim.yml
+++ b/connectors/nvidia-nim/nvidia-nim.yml
@@ -1,0 +1,12 @@
+connector:
+  name: "nvidia-nim"
+  description: "NVIDIA NIM chat (OpenAI-compatible). Endpoint and model allowlist resolved from NVIDIA_NIM_* operational config — never from workflow YAML."
+  filename: "nvidia-nim.py"
+  filetype: "pyscript"
+  commands:
+    - name: "Prompt"
+      value: "invoke_chat"
+    - name: "List Models"
+      value: "list_models"
+    - name: "Health"
+      value: "health"

--- a/connectors/nvidia-nim/test-credentials.yml
+++ b/connectors/nvidia-nim/test-credentials.yml
@@ -1,0 +1,31 @@
+workflow:
+  name: "nvidia-nim-test-credentials"
+  title: "NVIDIA NIM - Test Credentials"
+  description: "Private-runtime receipt: NIM operational config present, endpoint reachable, default model served, allowlist in place."
+  context-variables:
+    debugger:
+      enabled: true
+  outputs:
+    health: "$.get('health', {})"
+    models: "$.get('models', [])"
+    workflow-status: "$.get('workflow-status', 'skipped')"
+  tasks:
+
+    - type: connector
+      name: nvidia-nim-health-task
+      description: Health receipt (operational config + endpoint + default model).
+      connector:
+        name: nvidia-nim
+        command: health
+      outputs:
+        health: "$.get('data', {})"
+
+    - type: connector
+      name: nvidia-nim-list-models-task
+      description: List served models alongside the allowlist.
+      connector:
+        name: nvidia-nim
+        command: list_models
+      outputs:
+        models: "$.get('data', {}).get('models', [])"
+        workflow-status: "'executed'"

--- a/connectors/nvidia-nim/test-credentials.yml
+++ b/connectors/nvidia-nim/test-credentials.yml
@@ -1,12 +1,13 @@
 workflow:
   name: "nvidia-nim-test-credentials"
   title: "NVIDIA NIM - Test Credentials"
-  description: "Private-runtime receipt: NIM operational config present, endpoint reachable, default model served, allowlist in place."
+  description: "Private-runtime receipt: config and allowlist valid, default model served, and a real chat completion succeeds."
   context-variables:
     debugger:
       enabled: true
   outputs:
     health: "$.get('health', {})"
+    completion: "$.get('completion', {})"
     models: "$.get('models', [])"
     workflow-status: "$.get('workflow-status', 'skipped')"
   tasks:
@@ -21,6 +22,16 @@ workflow:
         health: "$.get('data', {})"
 
     - type: connector
+      name: nvidia-nim-completion-receipt-task
+      description: Execute one small chat completion to prove inference, not only model discovery.
+      connector:
+        name: nvidia-nim
+        command: completion_receipt
+      outputs:
+        completion: "$.get('data', {})"
+        workflow-status: "'executed' if $.get('data', {}).get('completed', False) else 'failed'"
+
+    - type: connector
       name: nvidia-nim-list-models-task
       description: List served models alongside the allowlist.
       connector:
@@ -28,4 +39,3 @@ workflow:
         command: list_models
       outputs:
         models: "$.get('data', {}).get('models', [])"
-        workflow-status: "'executed'"

--- a/connectors/nvidia-nim/tests/test_nvidia_nim.py
+++ b/connectors/nvidia-nim/tests/test_nvidia_nim.py
@@ -6,6 +6,9 @@ Requires: langchain-openai, requests (same deps the client-api runtime has).
 
 import importlib.util
 import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,10 +20,17 @@ _SPEC = importlib.util.spec_from_file_location(
 nim = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(nim)
 
+CONNECTOR_DIR = Path(__file__).resolve().parents[1]
+
 
 ENVS = (
     "NVIDIA_NIM_CHAT_BASE_URL",
     "NVIDIA_NIM_CHAT_MODEL",
+    "NVIDIA_NIM_CHAT_ALLOWED_MODELS",
+    "NVIDIA_NIM_CHAT_TIMEOUT_SECONDS",
+    "NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS",
+    "NVIDIA_NIM_CHAT_API_KEY",
+    # Legacy mixed-family names must not affect the chat connector.
     "NVIDIA_NIM_ALLOWED_MODELS",
     "NVIDIA_NIM_TIMEOUT_SECONDS",
     "NVIDIA_NIM_MAX_OUTPUT_TOKENS",
@@ -59,8 +69,16 @@ class TestOperationalConfigGates:
 
 class TestInvokeChat:
     def test_happy_path_builds_chat_openai(self, nim_env, monkeypatch):
-        monkeypatch.setenv("NVIDIA_NIM_MAX_OUTPUT_TOKENS", "2000")
-        result = nim.invoke_chat({"params": {"max_tokens": 4000, "temperature": 0}})
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS", "2000")
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        fake_module = SimpleNamespace(ChatOpenAI=FakeChatOpenAI)
+        with patch.dict(sys.modules, {"langchain_openai": fake_module}):
+            result = nim.invoke_chat({"params": {"max_tokens": 4000, "temperature": 0}})
+
         assert result["status"] is True
         llm = result["data"]
         assert llm.max_tokens == 2000  # capped by env
@@ -71,10 +89,16 @@ class TestInvokeChat:
         assert result["status"] == "error"
         assert "max_tokens" in result["message"]
 
+    def test_invalid_operational_timeout_error_cleanly(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS", "eventually")
+        result = nim.invoke_chat({})
+        assert result["status"] == "error"
+        assert "operational config" in result["message"]
+
 
 class TestHealth:
     def test_default_model_missing_from_allowlist_is_unhealthy(self, nim_env, monkeypatch):
-        monkeypatch.setenv("NVIDIA_NIM_ALLOWED_MODELS", "nvidia/nemotron-nano")
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_ALLOWED_MODELS", "nvidia/nemotron-nano")
         result = nim.health({})
         assert result["status"] == "error"
         assert result["data"]["healthy"] is False
@@ -108,3 +132,63 @@ class TestListModels:
         assert result["status"] is True
         assert result["data"]["models"] == ["a", "b"]
         assert result["data"]["default"] == "nvidia/nemotron-3-super-120b-a12b"
+
+
+class TestCompletionReceipt:
+    def test_executes_real_completion_with_chat_contract(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_API_KEY", "demo-secret")
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS", "12")
+        response = MagicMock()
+        response.json.return_value = {
+            "id": "chatcmpl-receipt",
+            "model": "nvidia/nemotron-3-super-120b-a12b",
+            "choices": [{"message": {"content": "MACHINA_NIM_OK"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+        }
+        response.raise_for_status.return_value = None
+
+        with patch.object(nim.requests, "post", return_value=response) as post:
+            result = nim.completion_receipt({})
+
+        assert result["status"] is True
+        assert result["data"]["completed"] is True
+        assert result["data"]["output"] == "MACHINA_NIM_OK"
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        assert post.call_args.args[0] == "http://nim:8001/v1/chat/completions"
+        assert kwargs["headers"]["Authorization"] == "Bearer demo-secret"
+        assert kwargs["json"]["model"] == "nvidia/nemotron-3-super-120b-a12b"
+        assert kwargs["json"]["max_tokens"] == 12
+        assert kwargs["json"]["stream"] is False
+
+    def test_legacy_api_key_is_not_used(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_API_KEY", "legacy-secret")
+        response = MagicMock()
+        response.json.return_value = {
+            "choices": [{"message": {"content": "MACHINA_NIM_OK"}}]
+        }
+        response.raise_for_status.return_value = None
+
+        with patch.object(nim.requests, "post", return_value=response) as post:
+            result = nim.completion_receipt({})
+
+        assert result["status"] is True
+        assert "Authorization" not in post.call_args.kwargs["headers"]
+
+    def test_empty_completion_fails_receipt(self, nim_env):
+        response = MagicMock()
+        response.json.return_value = {"choices": [{"message": {"content": ""}}]}
+        response.raise_for_status.return_value = None
+        with patch.object(nim.requests, "post", return_value=response):
+            result = nim.completion_receipt({})
+        assert result["status"] == "error"
+        assert result["data"]["completed"] is False
+
+
+class TestConnectorWiring:
+    def test_completion_receipt_is_registered_and_run_by_credentials_workflow(self):
+        manifest = (CONNECTOR_DIR / "nvidia-nim.yml").read_text()
+        workflow = (CONNECTOR_DIR / "test-credentials.yml").read_text()
+        assert 'value: "completion_receipt"' in manifest
+        assert "command: completion_receipt" in workflow
+        assert "workflow-status" in workflow

--- a/connectors/nvidia-nim/tests/test_nvidia_nim.py
+++ b/connectors/nvidia-nim/tests/test_nvidia_nim.py
@@ -1,0 +1,110 @@
+"""Versioned tests for the nvidia-nim connector (no network, no NIM).
+
+Run: pytest connectors/nvidia-nim/tests/ -q
+Requires: langchain-openai, requests (same deps the client-api runtime has).
+"""
+
+import importlib.util
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "nvidia_nim",
+    os.path.join(os.path.dirname(__file__), "..", "nvidia-nim.py"),
+)
+nim = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(nim)
+
+
+ENVS = (
+    "NVIDIA_NIM_CHAT_BASE_URL",
+    "NVIDIA_NIM_CHAT_MODEL",
+    "NVIDIA_NIM_ALLOWED_MODELS",
+    "NVIDIA_NIM_TIMEOUT_SECONDS",
+    "NVIDIA_NIM_MAX_OUTPUT_TOKENS",
+    "NVIDIA_NIM_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in ENVS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def nim_env(monkeypatch):
+    monkeypatch.setenv("NVIDIA_NIM_CHAT_BASE_URL", "http://nim:8001/v1")
+    monkeypatch.setenv("NVIDIA_NIM_CHAT_MODEL", "nvidia/nemotron-3-super-120b-a12b")
+
+
+class TestOperationalConfigGates:
+    def test_missing_config_fails_closed(self):
+        result = nim.invoke_chat({"value": "hi"})
+        assert result["status"] == "error"
+        assert "NVIDIA_NIM_CHAT_BASE_URL" in result["message"]
+
+    def test_workflow_supplied_base_url_fails_closed(self, nim_env):
+        result = nim.invoke_chat({"params": {"base_url": "http://evil:9/v1"}})
+        assert result["status"] == "error"
+        assert "operational config" in result["message"]
+
+    def test_model_outside_allowlist_rejected(self, nim_env):
+        result = nim.invoke_chat({"model_name": "some-other-model"})
+        assert result["status"] == "error"
+        assert "ALLOWED_MODELS" in result["message"]
+
+
+class TestInvokeChat:
+    def test_happy_path_builds_chat_openai(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_MAX_OUTPUT_TOKENS", "2000")
+        result = nim.invoke_chat({"params": {"max_tokens": 4000, "temperature": 0}})
+        assert result["status"] is True
+        llm = result["data"]
+        assert llm.max_tokens == 2000  # capped by env
+        assert llm.temperature == 0.0
+
+    def test_invalid_params_error_cleanly(self, nim_env):
+        result = nim.invoke_chat({"params": {"max_tokens": "quatro mil"}})
+        assert result["status"] == "error"
+        assert "max_tokens" in result["message"]
+
+
+class TestHealth:
+    def test_default_model_missing_from_allowlist_is_unhealthy(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_ALLOWED_MODELS", "nvidia/nemotron-nano")
+        result = nim.health({})
+        assert result["status"] == "error"
+        assert result["data"]["healthy"] is False
+        failed = [c for c in result["data"]["checks"] if c["check"] == "default_model_allowlisted"]
+        assert failed and failed[0]["ok"] is False
+
+    def test_endpoint_timeout_is_a_failed_check_not_an_exception(self, nim_env):
+        with patch.object(nim.requests, "get", side_effect=Exception("timed out")):
+            result = nim.health({})
+        assert result["status"] == "error"
+        reach = [c for c in result["data"]["checks"] if c["check"] == "endpoint_reachable"]
+        assert reach and reach[0]["ok"] is False
+
+    def test_healthy_when_default_model_served(self, nim_env):
+        response = MagicMock()
+        response.json.return_value = {"data": [{"id": "nvidia/nemotron-3-super-120b-a12b"}]}
+        response.raise_for_status.return_value = None
+        with patch.object(nim.requests, "get", return_value=response):
+            result = nim.health({})
+        assert result["status"] is True
+        assert result["data"]["healthy"] is True
+
+
+class TestListModels:
+    def test_lists_served_and_allowlist(self, nim_env):
+        response = MagicMock()
+        response.json.return_value = {"data": [{"id": "a"}, {"id": "b"}]}
+        response.raise_for_status.return_value = None
+        with patch.object(nim.requests, "get", return_value=response):
+            result = nim.list_models({})
+        assert result["status"] is True
+        assert result["data"]["models"] == ["a", "b"]
+        assert result["data"]["default"] == "nvidia/nemotron-3-super-120b-a12b"


### PR DESCRIPTION
## Summary

NVIDIA NIM surface for the **private runtime** ([review](https://machina-private-runtime-review.antonelli.chatgpt.site/), machina-templates item): chat inference on an OpenAI-compatible NIM endpoint, with the endpoint and model allowlist resolved from **operational config only**:

```
NVIDIA_NIM_CHAT_BASE_URL=http://nemotron-nim:8001/v1
NVIDIA_NIM_CHAT_MODEL=nvidia/nemotron-3-super-120b-a12b
NVIDIA_NIM_ALLOWED_MODELS=nvidia/nemotron-3-super-120b-a12b,nvidia/nemotron-nano
NVIDIA_NIM_TIMEOUT_SECONDS=70
NVIDIA_NIM_MAX_OUTPUT_TOKENS=…   # optional hard cap
NVIDIA_NIM_API_KEY=…             # optional, local NIMs don't validate
```

**No free endpoint enters agent YAML**: a workflow may pick a model *within* the allowlist; any `base_url` coming from a template fails closed. `max_tokens` is capped by the env. Embeddings stay deliberately separate under `RETRIEVAL_NIM_*` (client-api retrieval facade, machina-client-api#301) — this connector is chat only.

- `invoke_chat` returns a LangChain `ChatOpenAI` (same contract as `machina-ai`, the reference implementation — note: deliberately not copied from `azure-foundry`, whose `ChatAzureOpenAI` import doesn't exist in `langchain_openai`).
- `list_models` — served models vs allowlist.
- `health` — private-runtime receipt (config present / endpoint reachable / default model served), wired into `nvidia-nim-test-credentials`.
- `_install.yml` (ai-models category) + README documenting the env contract.

## Test plan
- Smoke (module-level, no network): config missing → error; model outside allowlist → error; template-supplied `base_url` → fail-closed error (same-URL echo tolerated); happy path builds `ChatOpenAI` with right base_url/model/temperature and **max_tokens capped by env** (4000→2000). All passing.
- YAMLs validated; `scripts/check-no-openai.sh` clean (no banned names/models/env vars).
- Live `health`/`list_models`/streaming/structured-output receipts against a real NIM land with the P1 box proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)