### PR TITLE
feat(nvidia-nim): add executable completion receipt

### DIFF
--- a/.github/workflows/test-nvidia-nim.yml
+++ b/.github/workflows/test-nvidia-nim.yml
@@ -1,0 +1,28 @@
+name: Test NVIDIA NIM connector
+
+on:
+  pull_request:
+    paths:
+      - "connectors/nvidia-nim/**"
+      - ".github/workflows/test-nvidia-nim.yml"
+  push:
+    branches: [main]
+    paths:
+      - "connectors/nvidia-nim/**"
+      - ".github/workflows/test-nvidia-nim.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  connector-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install hermetic test dependencies
+        run: python -m pip install pytest requests
+      - name: Run NVIDIA NIM connector tests
+        run: python -m pytest connectors/nvidia-nim/tests -q

--- a/connectors/nvidia-nim/README.md
+++ b/connectors/nvidia-nim/README.md
@@ -13,10 +13,10 @@ fails closed on any `base_url` coming from a workflow).
 |---|---|---|
 | `NVIDIA_NIM_CHAT_BASE_URL` | yes | NIM endpoint, e.g. `http://nemotron-nim:8001/v1` |
 | `NVIDIA_NIM_CHAT_MODEL` | yes | Default model, e.g. `nvidia/nemotron-3-super-120b-a12b` |
-| `NVIDIA_NIM_ALLOWED_MODELS` | no | CSV allowlist; defaults to just the default model |
-| `NVIDIA_NIM_TIMEOUT_SECONDS` | no | Request timeout (default 70 — Nemotron with reasoning needs >18s for structured answers) |
-| `NVIDIA_NIM_MAX_OUTPUT_TOKENS` | no | Hard cap applied to `max_tokens` |
-| `NVIDIA_NIM_API_KEY` | no | Local NIMs don't validate it |
+| `NVIDIA_NIM_CHAT_ALLOWED_MODELS` | no | CSV allowlist; defaults to just the default model |
+| `NVIDIA_NIM_CHAT_TIMEOUT_SECONDS` | no | Request timeout (default 70 — Nemotron with reasoning needs >18s for structured answers) |
+| `NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS` | no | Hard cap applied to `max_tokens` |
+| `NVIDIA_NIM_CHAT_API_KEY` | no | Local NIMs don't validate it |
 
 Embeddings are deliberately **separate**: the retrieval facade on
 machina-client-api owns them under the `RETRIEVAL_NIM_*` envs. This
@@ -27,10 +27,12 @@ connector is chat only.
 - `invoke_chat` (Prompt) — returns a LangChain `ChatOpenAI` wired to the NIM
   endpoint; the engine runs the prompt against it. Honors `model_name`
   (allowlist-checked), `temperature`, `max_tokens` (capped by
-  `NVIDIA_NIM_MAX_OUTPUT_TOKENS`).
+  `NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS`).
 - `list_models` — models served by the endpoint alongside the allowlist.
-- `health` — private-runtime receipt: operational config present, endpoint
-  reachable, default model served. Used by the
+- `health` — operational config present, endpoint reachable, default model served.
+- `completion_receipt` — sends a small, non-streaming chat completion and
+  records the served model, response ID, output, and token usage. Together
+  with `health`, this is the executable private-runtime receipt used by the
   `nvidia-nim-test-credentials` workflow.
 
 ## Usage in a workflow prompt task

--- a/connectors/nvidia-nim/_install.yml
+++ b/connectors/nvidia-nim/_install.yml
@@ -6,14 +6,14 @@ setup:
   estimatedTime: 5 minutes
   features:
     - Chat completions on Nemotron and other NIM-served models
-    - Endpoint and model allowlist from NVIDIA_NIM_* operational config (never workflow YAML)
-    - Health and list-models commands for private-runtime receipts
+    - Endpoint and model allowlist from NVIDIA_NIM_CHAT_* operational config (never workflow YAML)
+    - Health, completion, and list-models commands for private-runtime receipts
   requirements:
     - NVIDIA-NIM-Chat-Base-URL
     - NVIDIA-NIM-Chat-Model
   status: available
   value: connectors/nvidia-nim
-  version: 1.0.0
+  version: 1.1.0
 
 datasets:
   - type: "connector"

--- a/connectors/nvidia-nim/nvidia-nim.py
+++ b/connectors/nvidia-nim/nvidia-nim.py
@@ -3,7 +3,7 @@ NVIDIA NIM chat connector — OpenAI-compatible /v1 endpoint resolved from
 OPERATIONAL CONFIG ONLY (private-runtime requirement).
 
 The endpoint and the model allowlist come from the runtime environment
-(NVIDIA_NIM_* envs injected by the deployment), never from workflow YAML:
+(NVIDIA_NIM_CHAT_* envs injected by the deployment), never from workflow YAML:
 a template can pick a model within the allowlist, but cannot point the
 runtime at an arbitrary URL. Embeddings are deliberately separate
 (RETRIEVAL_NIM_* on the client-api retrieval facade).
@@ -11,11 +11,11 @@ runtime at an arbitrary URL. Embeddings are deliberately separate
 Env contract:
   NVIDIA_NIM_CHAT_BASE_URL      e.g. http://nemotron-nim:8001/v1 (required)
   NVIDIA_NIM_CHAT_MODEL         default model, e.g. nvidia/nemotron-3-super-120b-a12b (required)
-  NVIDIA_NIM_ALLOWED_MODELS     csv allowlist (default: just the default model)
-  NVIDIA_NIM_TIMEOUT_SECONDS    request timeout (default 70 — Nemotron with
-                                reasoning needs >18s for structured answers)
-  NVIDIA_NIM_MAX_OUTPUT_TOKENS  optional hard cap on max_tokens
-  NVIDIA_NIM_API_KEY            optional; local NIMs don't validate it
+  NVIDIA_NIM_CHAT_ALLOWED_MODELS     csv allowlist (default: just the default model)
+  NVIDIA_NIM_CHAT_TIMEOUT_SECONDS    request timeout (default 70 — Nemotron with
+                                     reasoning needs >18s for structured answers)
+  NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS  optional hard cap on max_tokens
+  NVIDIA_NIM_CHAT_API_KEY            optional; local NIMs don't validate it
 """
 
 import os
@@ -26,18 +26,37 @@ import requests
 def _operational_config():
     base_url = (os.environ.get("NVIDIA_NIM_CHAT_BASE_URL") or "").strip().rstrip("/")
     default_model = (os.environ.get("NVIDIA_NIM_CHAT_MODEL") or "").strip()
-    allowed_raw = os.environ.get("NVIDIA_NIM_ALLOWED_MODELS") or default_model
+    allowed_raw = os.environ.get("NVIDIA_NIM_CHAT_ALLOWED_MODELS") or default_model
     allowed = tuple(m.strip() for m in allowed_raw.split(",") if m.strip())
-    timeout = float(os.environ.get("NVIDIA_NIM_TIMEOUT_SECONDS") or 70)
+    timeout = float(os.environ.get("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS") or 70)
+    if timeout <= 0:
+        raise ValueError("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS must be greater than zero")
     return base_url, default_model, allowed, timeout
 
 
 def _models_headers():
     headers = {}
-    api_key = os.environ.get("NVIDIA_NIM_API_KEY")
+    api_key = os.environ.get("NVIDIA_NIM_CHAT_API_KEY")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     return headers
+
+
+def _config_value_error(error):
+    return {
+        "status": "error",
+        "message": f"Invalid NVIDIA NIM chat operational config: {error}",
+    }
+
+
+def _output_token_cap():
+    raw = os.environ.get("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS")
+    if not raw:
+        return None
+    value = int(raw)
+    if value <= 0:
+        raise ValueError("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS must be greater than zero")
+    return value
 
 
 def _config_error():
@@ -51,7 +70,11 @@ def _config_error():
 
 def invoke_chat(params):
     """Build a ChatOpenAI wired to the NIM endpoint (the engine runs the prompt)."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    params = params or {}
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     if not base_url or not default_model:
         return _config_error()
@@ -78,17 +101,15 @@ def invoke_chat(params):
     if model not in allowed:
         return {
             "status": "error",
-            "message": f"Model '{model}' is not in NVIDIA_NIM_ALLOWED_MODELS "
+            "message": f"Model '{model}' is not in NVIDIA_NIM_CHAT_ALLOWED_MODELS "
                        f"({', '.join(allowed)}).",
         }
 
     try:
-        from langchain_openai import ChatOpenAI
-
         kwargs = {
             "base_url": base_url,
             "model": model,
-            "api_key": os.environ.get("NVIDIA_NIM_API_KEY") or "not-needed",
+            "api_key": os.environ.get("NVIDIA_NIM_CHAT_API_KEY") or "not-needed",
             "timeout": timeout,
         }
 
@@ -96,13 +117,13 @@ def invoke_chat(params):
             max_tokens = params.get("max_tokens")
             if max_tokens is None:
                 max_tokens = params.get("params", {}).get("max_tokens")
-            cap = os.environ.get("NVIDIA_NIM_MAX_OUTPUT_TOKENS")
+            cap = _output_token_cap()
             if max_tokens is not None and cap:
-                kwargs["max_tokens"] = min(int(max_tokens), int(cap))
+                kwargs["max_tokens"] = min(int(max_tokens), cap)
             elif max_tokens is not None:
                 kwargs["max_tokens"] = int(max_tokens)
             elif cap:
-                kwargs["max_tokens"] = int(cap)
+                kwargs["max_tokens"] = cap
 
             temperature = params.get("temperature")
             if temperature is None:
@@ -115,6 +136,8 @@ def invoke_chat(params):
                 "message": f"Invalid generation params (max_tokens/temperature must be numeric): {e}",
             }
 
+        from langchain_openai import ChatOpenAI
+
         llm = ChatOpenAI(**kwargs)
 
         return {"status": True, "data": llm, "message": "Model loaded."}
@@ -124,7 +147,10 @@ def invoke_chat(params):
 
 def list_models(params):
     """List models served by the NIM endpoint, alongside the allowlist."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     if not base_url:
         return _config_error()
@@ -145,9 +171,94 @@ def list_models(params):
         return {"status": "error", "message": f"Error listing NIM models: {str(e)}"}
 
 
+def completion_receipt(params):
+    """Execute one small chat completion to prove the configured NIM serves inference."""
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+        cap = _output_token_cap()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
+
+    if not base_url or not default_model:
+        return _config_error()
+    if default_model not in allowed:
+        return {
+            "status": "error",
+            "message": f"Default model '{default_model}' is not in "
+                       "NVIDIA_NIM_CHAT_ALLOWED_MODELS.",
+        }
+
+    max_tokens = min(32, cap) if cap else 32
+    body = {
+        "model": default_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "/no_think Reply with exactly MACHINA_NIM_OK.",
+            }
+        ],
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+    headers = {"Content-Type": "application/json", **_models_headers()}
+
+    try:
+        response = requests.post(
+            f"{base_url}/chat/completions",
+            headers=headers,
+            json=body,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        choices = payload.get("choices") or []
+        message = choices[0].get("message", {}) if choices else {}
+        content = message.get("content")
+        if isinstance(content, list):
+            content = "".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+        content = str(content or "").strip()
+        if not content:
+            raise ValueError("completion response did not contain message content")
+
+        usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+        return {
+            "status": True,
+            "data": {
+                "completed": True,
+                "endpoint": base_url,
+                "requested_model": default_model,
+                "response_model": payload.get("model") or default_model,
+                "response_id": payload.get("id") or "",
+                "output": content[:200],
+                "usage": {
+                    key: usage[key]
+                    for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+                    if key in usage
+                },
+            },
+            "message": "NIM completion receipt succeeded.",
+        }
+    except Exception as error:
+        return {
+            "status": "error",
+            "data": {
+                "completed": False,
+                "endpoint": base_url,
+                "requested_model": default_model,
+            },
+            "message": f"NIM completion receipt failed: {str(error)}",
+        }
+
+
 def health(params):
     """Private-runtime receipt: config present, endpoint reachable, default model served."""
-    base_url, default_model, allowed, timeout = _operational_config()
+    try:
+        base_url, default_model, allowed, timeout = _operational_config()
+    except (TypeError, ValueError) as error:
+        return _config_value_error(error)
 
     checks = []
 
@@ -170,7 +281,7 @@ def health(params):
         "check": "default_model_allowlisted",
         "ok": default_allowed,
         "detail": default_model if default_allowed
-        else f"'{default_model}' missing from NVIDIA_NIM_ALLOWED_MODELS",
+        else f"'{default_model}' missing from NVIDIA_NIM_CHAT_ALLOWED_MODELS",
     })
     if not default_allowed:
         return {

--- a/connectors/nvidia-nim/nvidia-nim.yml
+++ b/connectors/nvidia-nim/nvidia-nim.yml
@@ -1,6 +1,6 @@
 connector:
   name: "nvidia-nim"
-  description: "NVIDIA NIM chat (OpenAI-compatible). Endpoint and model allowlist resolved from NVIDIA_NIM_* operational config — never from workflow YAML."
+  description: "NVIDIA NIM chat (OpenAI-compatible). Endpoint and model allowlist resolved from NVIDIA_NIM_CHAT_* operational config — never from workflow YAML."
   filename: "nvidia-nim.py"
   filetype: "pyscript"
   commands:
@@ -10,3 +10,5 @@ connector:
       value: "list_models"
     - name: "Health"
       value: "health"
+    - name: "Completion Receipt"
+      value: "completion_receipt"

--- a/connectors/nvidia-nim/test-credentials.yml
+++ b/connectors/nvidia-nim/test-credentials.yml
@@ -1,12 +1,13 @@
 workflow:
   name: "nvidia-nim-test-credentials"
   title: "NVIDIA NIM - Test Credentials"
-  description: "Private-runtime receipt: NIM operational config present, endpoint reachable, default model served, allowlist in place."
+  description: "Private-runtime receipt: config and allowlist valid, default model served, and a real chat completion succeeds."
   context-variables:
     debugger:
       enabled: true
   outputs:
     health: "$.get('health', {})"
+    completion: "$.get('completion', {})"
     models: "$.get('models', [])"
     workflow-status: "$.get('workflow-status', 'skipped')"
   tasks:
@@ -21,6 +22,16 @@ workflow:
         health: "$.get('data', {})"
 
     - type: connector
+      name: nvidia-nim-completion-receipt-task
+      description: Execute one small chat completion to prove inference, not only model discovery.
+      connector:
+        name: nvidia-nim
+        command: completion_receipt
+      outputs:
+        completion: "$.get('data', {})"
+        workflow-status: "'executed' if $.get('data', {}).get('completed', False) else 'failed'"
+
+    - type: connector
       name: nvidia-nim-list-models-task
       description: List served models alongside the allowlist.
       connector:
@@ -28,4 +39,3 @@ workflow:
         command: list_models
       outputs:
         models: "$.get('data', {}).get('models', [])"
-        workflow-status: "'executed'"

--- a/connectors/nvidia-nim/tests/test_nvidia_nim.py
+++ b/connectors/nvidia-nim/tests/test_nvidia_nim.py
@@ -6,6 +6,9 @@ Requires: langchain-openai, requests (same deps the client-api runtime has).
 
 import importlib.util
 import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,10 +20,17 @@ _SPEC = importlib.util.spec_from_file_location(
 nim = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(nim)
 
+CONNECTOR_DIR = Path(__file__).resolve().parents[1]
+
 
 ENVS = (
     "NVIDIA_NIM_CHAT_BASE_URL",
     "NVIDIA_NIM_CHAT_MODEL",
+    "NVIDIA_NIM_CHAT_ALLOWED_MODELS",
+    "NVIDIA_NIM_CHAT_TIMEOUT_SECONDS",
+    "NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS",
+    "NVIDIA_NIM_CHAT_API_KEY",
+    # Legacy mixed-family names must not affect the chat connector.
     "NVIDIA_NIM_ALLOWED_MODELS",
     "NVIDIA_NIM_TIMEOUT_SECONDS",
     "NVIDIA_NIM_MAX_OUTPUT_TOKENS",
@@ -59,8 +69,16 @@ class TestOperationalConfigGates:
 
 class TestInvokeChat:
     def test_happy_path_builds_chat_openai(self, nim_env, monkeypatch):
-        monkeypatch.setenv("NVIDIA_NIM_MAX_OUTPUT_TOKENS", "2000")
-        result = nim.invoke_chat({"params": {"max_tokens": 4000, "temperature": 0}})
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS", "2000")
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        fake_module = SimpleNamespace(ChatOpenAI=FakeChatOpenAI)
+        with patch.dict(sys.modules, {"langchain_openai": fake_module}):
+            result = nim.invoke_chat({"params": {"max_tokens": 4000, "temperature": 0}})
+
         assert result["status"] is True
         llm = result["data"]
         assert llm.max_tokens == 2000  # capped by env
@@ -71,10 +89,16 @@ class TestInvokeChat:
         assert result["status"] == "error"
         assert "max_tokens" in result["message"]
 
+    def test_invalid_operational_timeout_error_cleanly(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_TIMEOUT_SECONDS", "eventually")
+        result = nim.invoke_chat({})
+        assert result["status"] == "error"
+        assert "operational config" in result["message"]
+
 
 class TestHealth:
     def test_default_model_missing_from_allowlist_is_unhealthy(self, nim_env, monkeypatch):
-        monkeypatch.setenv("NVIDIA_NIM_ALLOWED_MODELS", "nvidia/nemotron-nano")
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_ALLOWED_MODELS", "nvidia/nemotron-nano")
         result = nim.health({})
         assert result["status"] == "error"
         assert result["data"]["healthy"] is False
@@ -108,3 +132,63 @@ class TestListModels:
         assert result["status"] is True
         assert result["data"]["models"] == ["a", "b"]
         assert result["data"]["default"] == "nvidia/nemotron-3-super-120b-a12b"
+
+
+class TestCompletionReceipt:
+    def test_executes_real_completion_with_chat_contract(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_API_KEY", "demo-secret")
+        monkeypatch.setenv("NVIDIA_NIM_CHAT_MAX_OUTPUT_TOKENS", "12")
+        response = MagicMock()
+        response.json.return_value = {
+            "id": "chatcmpl-receipt",
+            "model": "nvidia/nemotron-3-super-120b-a12b",
+            "choices": [{"message": {"content": "MACHINA_NIM_OK"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+        }
+        response.raise_for_status.return_value = None
+
+        with patch.object(nim.requests, "post", return_value=response) as post:
+            result = nim.completion_receipt({})
+
+        assert result["status"] is True
+        assert result["data"]["completed"] is True
+        assert result["data"]["output"] == "MACHINA_NIM_OK"
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        assert post.call_args.args[0] == "http://nim:8001/v1/chat/completions"
+        assert kwargs["headers"]["Authorization"] == "Bearer demo-secret"
+        assert kwargs["json"]["model"] == "nvidia/nemotron-3-super-120b-a12b"
+        assert kwargs["json"]["max_tokens"] == 12
+        assert kwargs["json"]["stream"] is False
+
+    def test_legacy_api_key_is_not_used(self, nim_env, monkeypatch):
+        monkeypatch.setenv("NVIDIA_NIM_API_KEY", "legacy-secret")
+        response = MagicMock()
+        response.json.return_value = {
+            "choices": [{"message": {"content": "MACHINA_NIM_OK"}}]
+        }
+        response.raise_for_status.return_value = None
+
+        with patch.object(nim.requests, "post", return_value=response) as post:
+            result = nim.completion_receipt({})
+
+        assert result["status"] is True
+        assert "Authorization" not in post.call_args.kwargs["headers"]
+
+    def test_empty_completion_fails_receipt(self, nim_env):
+        response = MagicMock()
+        response.json.return_value = {"choices": [{"message": {"content": ""}}]}
+        response.raise_for_status.return_value = None
+        with patch.object(nim.requests, "post", return_value=response):
+            result = nim.completion_receipt({})
+        assert result["status"] == "error"
+        assert result["data"]["completed"] is False
+
+
+class TestConnectorWiring:
+    def test_completion_receipt_is_registered_and_run_by_credentials_workflow(self):
+        manifest = (CONNECTOR_DIR / "nvidia-nim.yml").read_text()
+        workflow = (CONNECTOR_DIR / "test-credentials.yml").read_text()
+        assert 'value: "completion_receipt"' in manifest
+        assert "command: completion_receipt" in workflow
+        assert "workflow-status" in workflow


### PR DESCRIPTION
Stacked on #287. This turns the connector's chat contract into an executable receipt for the private-runtime RC.

## What changed

- Uses the governed `NVIDIA_NIM_CHAT_*` operational configuration and allowlist.
- Exercises a real OpenAI-compatible `POST /v1/chat/completions` request.
- Adds an importable receipt workflow and CI coverage.
- Keeps endpoint/model selection out of workflow YAML.

## Evidence

- Connector suite: **14 passed**.
- Python compilation passed.

## Intentionally pending

The live receipt against the selected NVIDIA NIM will run during box acceptance after the runtime images are approved.
