### PR TITLE
fix(world-cup): surface schedule scores and stages

### DIFF
--- a/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
+++ b/agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py
@@ -876,6 +876,49 @@ class TestNormalizeSchedule:
         r2 = normalize_schedule({"params": {"events": [], "team": "nobody"}})
         assert r2["data"]["events"] == [] and r2["data"]["warnings"]
 
+    def test_finished_semifinal_carries_score_and_stage(self):
+        # A completed knockout fixture must surface its result (live_score) and
+        # its round/stage so schedule consumers can show "Semi-finals · 2-0".
+        ev = _event_doc("urn:x:sf", "Spain vs France", "2026-07-14T18:00:00+00:00",
+                        status="FT", home="Spain", away="France")
+        ev["round"] = "Semi-finals"
+        ev["stage"] = "Semi-finals"
+        ev["live_score"] = {"home": 2, "away": 0, "elapsed": 90}
+        out = normalize_schedule({"params": {"events": [ev]}})["data"]["events"][0]
+        assert out["score"] == {"home": 2, "away": 0, "elapsed": 90}
+        assert out["round"] == "Semi-finals"
+        assert out["stage"] == "Semi-finals"
+
+    def test_upcoming_final_carries_round_and_stage(self):
+        # An unplayed fixture has no score, but round/stage still flow through —
+        # here from a sport:round dict ({name}), the IPTC-derived shape.
+        ev = _event_doc("urn:x:final", "TBD vs TBD", "2026-07-19T18:00:00+00:00",
+                        status="NS", home="Winner SF1", away="Winner SF2")
+        ev["sport:round"] = {"name": "Final"}
+        out = normalize_schedule({"params": {"events": [ev]}})["data"]["events"][0]
+        assert out["round"] == "Final"
+        assert out["stage"] == "Final"
+        assert out["score"] is None
+
+    def test_event_without_score_or_round_is_backward_compatible(self):
+        # Docs minted before this change carry no score/round/stage; the fields
+        # must resolve to null rather than break the schedule shape.
+        out = normalize_schedule({"params": {"events": self._events()}})["data"]["events"][0]
+        assert out["score"] is None
+        assert out["round"] is None
+        assert out["stage"] is None
+
+    def test_plain_score_fallback_preserves_zero_and_omits_null_elapsed(self):
+        # No live_score block: fall back to a plain `score` object. A 0-0 result
+        # must survive (0 is a real score, not "missing"), while a null elapsed
+        # is dropped rather than emitted as an explicit None.
+        ev = _event_doc("urn:x:draw", "Japan vs Egypt", "2026-06-20T18:00:00+00:00",
+                        status="FT", home="Japan", away="Egypt")
+        ev["score"] = {"home": 0, "away": 0, "elapsed": None}
+        out = normalize_schedule({"params": {"events": [ev]}})["data"]["events"][0]
+        assert out["score"] == {"home": 0, "away": 0}
+        assert "elapsed" not in out["score"]
+
 
 # -- Identity resolution: player ----------------------------------------------
 
@@ -1069,6 +1112,18 @@ class TestMintEventIdentity:
         assert d["provider_ids"]["entain"] == "7722030"
         # Ingest still owns the api_football (fixture) id.
         assert d["provider_ids"]["api_football"] == "1489417"
+
+    def test_carries_league_round_as_round_and_stage(self):
+        # API-Football labels knockout fixtures via league.round; persist it as
+        # top-level round/stage so the schedule view can read it back.
+        fx = _af_fixture()
+        fx["league"] = {"id": 1, "name": "World Cup", "round": "Semi-finals"}
+        d = mint_event_identity({"params": {"fixtures": [fx]}})["data"]["events"][0]
+        assert d["round"] == "Semi-finals"
+        assert d["stage"] == "Semi-finals"
+        # When league.round is absent, no null round/stage keys are added.
+        d2 = mint_event_identity({"params": {"fixtures": [_af_fixture()]}})["data"]["events"][0]
+        assert "round" not in d2 and "stage" not in d2
 
 
 # -- Provider entity merge (identity crosswalk producer) ---------------------

--- a/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
+++ b/agent-templates/world-cup-intelligence/worldcup-market-intelligence.py
@@ -1367,12 +1367,30 @@ def normalize_schedule(request_data: dict[str, Any]) -> dict[str, Any]:
         venue = ev.get("venue") if isinstance(ev.get("venue"), dict) else (
             ev.get("sport:venue") if isinstance(ev.get("sport:venue"), dict) else {})
         competition = ev.get("sport:competition") if isinstance(ev.get("sport:competition"), dict) else {}
+        # Score: prefer the live_score block, then a plain score object; keep only
+        # the home/away/elapsed fields that are actually present (null otherwise).
+        score_src = ev.get("live_score") if isinstance(ev.get("live_score"), dict) else (
+            ev.get("score") if isinstance(ev.get("score"), dict) else None)
+        score: dict[str, Any] | None = None
+        if score_src is not None:
+            score = {k: score_src[k] for k in ("home", "away", "elapsed") if score_src.get(k) is not None}
+            score = score or None
+        # Round/stage: accept the top-level round/stage/competition_stage or the
+        # IPTC sport:round (string or {name|label} dict); resolve one label and
+        # expose it as both round and stage (null when the doc predates this).
+        round_raw = _first(ev, "round", "stage", "competition_stage", "sport:round")
+        if isinstance(round_raw, dict):
+            round_raw = _first(round_raw, "name", "label")
+        round_label = _text(round_raw) or None
         out.append({
             "event_urn": _first(ev, "_id", "id", "event_urn"),
             "name": _text(ev.get("name")),
             "start_date": start,
             "status": st,
             "competition": _text(ev.get("competition")) or _text(competition.get("name")) or "World Cup",
+            "score": score,
+            "round": round_label,
+            "stage": round_label,
             "teams": [
                 {
                     "name": _text(t.get("name")),
@@ -2147,6 +2165,15 @@ def mint_event_identity(request_data: dict[str, Any]) -> dict[str, Any]:
                 "away": ga,
                 "elapsed": (fixture.get("status") or {}).get("elapsed"),
             }
+        # API-Football tags knockout fixtures via league.round (e.g. "Semi-finals",
+        # "Final"). Carry it into the canonical doc as top-level round/stage so the
+        # schedule view can read it back — but never add null keys for group games
+        # where the round label is absent.
+        league = f.get("league") if isinstance(f.get("league"), dict) else {}
+        round_name = _text(league.get("round"))
+        if round_name:
+            doc["round"] = round_name
+            doc["stage"] = round_name
         for k, v in carry.get(fixture_id, {}).items():
             doc["provider_ids"].setdefault(k, v)
         events.append(doc)


### PR DESCRIPTION
## Summary
- return score, round, and stage from the World Cup schedule normalizer
- persist API-Football league.round as round/stage during event ingestion
- preserve backward compatibility for existing events without these fields

## Verification
- [x] `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py -q` — 204 passed
- [x] `python3 -m py_compile agent-templates/world-cup-intelligence/worldcup-market-intelligence.py`
- [x] parsed 60 template YAML files with `yaml.safe_load`
- [x] `git diff --check`
- [x] independent review passed with no security or logic findings

## Production context
Completes the durable source fix behind the guarded World Cup final-stage document backfill and enables live schedule consumers to receive semifinal scores and stage labels.