### PR TITLE
fix(machina-ai): don't inject a default temperature on the Claude route

### DIFF
--- a/connectors/machina-ai/machina-ai.py
+++ b/connectors/machina-ai/machina-ai.py
@@ -1372,7 +1372,6 @@ class VertexAnthropicAdapter(ProviderAdapter):
                 "model_name": route.model,
                 "project": route.credentials.get("project"),
                 "location": route.credentials.get("location") or "global",
-                "temperature": request.options.get("temperature", 0.2),
                 "max_tokens": _safe_int(
                     request.options.get("max_tokens"),
                     self.default_max_tokens,
@@ -1380,6 +1379,11 @@ class VertexAnthropicAdapter(ProviderAdapter):
                     maximum=64000,
                 ),
             }
+            # Claude 4.6+ (Sonnet 5, Opus 4.7/4.8, …) reject sampling params with
+            # a 400 ("temperature is deprecated for this model"), so no default is
+            # applied — only an explicit workflow-provided temperature is forwarded.
+            if request.options.get("temperature") is not None:
+                kwargs["temperature"] = request.options["temperature"]
             credentials = self._credentials(route)
             if credentials is not None:
                 kwargs["credentials"] = credentials

--- a/connectors/machina-ai/tests/test_router.py
+++ b/connectors/machina-ai/tests/test_router.py
@@ -527,6 +527,22 @@ class TestProviderAdapters:
             policy.route(request)
         assert unsupported.value.error_class == "unsupported_capability"
 
+    def test_vertex_anthropic_omits_default_temperature(self):
+        # Sonnet 5 / Opus 4.8-class models reject sampling params (400
+        # "temperature is deprecated"); the adapter must not inject a default.
+        fake_chat = MagicMock(return_value="claude-chat")
+        mg_module = SimpleNamespace(ChatAnthropicVertex=fake_chat)
+        adapter = router.VertexAnthropicAdapter(router.RuntimeFacade(), router.MediaSecurity({"media": {"allowed_roots": [os.getcwd()]}}))
+        route = self.route("vertex_anthropic", "vertex_anthropic", model="claude-sonnet-5")
+        with patch.dict(sys.modules, {"langchain_google_vertexai.model_garden": mg_module}):
+            result = adapter.create_chat_model(route, self.request())
+        assert result.data == "claude-chat"
+        assert "temperature" not in fake_chat.call_args.kwargs
+        assert fake_chat.call_args.kwargs["max_tokens"] == adapter.default_max_tokens
+        with patch.dict(sys.modules, {"langchain_google_vertexai.model_garden": mg_module}):
+            adapter.create_chat_model(route, self.request(temperature=0.7))
+        assert fake_chat.call_args.kwargs["temperature"] == 0.7
+
     def test_vertex_and_google_media_can_delegate_without_provider_imports(self):
         class DelegateRuntime:
             def delegate(self, connector, command, payload):


### PR DESCRIPTION
Sonnet 5 / Opus 4.8-class models reject sampling params on Vertex (`400 temperature is deprecated for this model`) — caught live by the Stage 0 staging smoke on `enrichment-st` (Haiku green, Sonnet 5 400'd). The adapter now forwards `temperature` only when the workflow sets it explicitly; no default. +1 adapter test (omission + explicit forwarding), suite 103 passing.

Refs ClickUp [86ajmxm3u](https://app.clickup.com/t/86ajmxm3u) · follow-up to #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)