### PR TITLE
feat(exa-search): add systemPrompt to /search request schema

### DIFF
--- a/connectors/exa-search/exa-search.json
+++ b/connectors/exa-search/exa-search.json
@@ -145,6 +145,11 @@
                         "description": "JSON schema for deep search structured output mode. When provided, the output.content field is returned as structured JSON matching this schema.",
                         "additionalProperties": {}
                       },
+                      "systemPrompt": {
+                        "type": "string",
+                        "description": "Instructions that steer the synthesized output.content (used with deep search structured output / outputSchema). Guides tone, focus, and structure of the generated content.",
+                        "example": "Extract concise, factual structured analysis grounded strictly in the retrieved sources."
+                      },
                       "category": {
                         "type": "string",
                         "enum": [


### PR DESCRIPTION
## Why

Evaluating Exa as a replacement for the google-genai (Gemini) grounding in `entain-enrichment`. Reviewed Exa's current [Search API guide](https://exa.ai/docs/reference/search-api-guide-for-coding-agents) against our `exa-search.json` connector spec.

**Finding: the connector is already ~current** — it has the modern `/search` shape (`type` incl. `deep`/`deep-reasoning`/`instant`, `outputSchema`, `contents{text,highlights,summary,maxAgeHours}`, `startPublishedDate`, response `output.content` + `output.grounding[]`, `costDollars`). The one missing field is **`systemPrompt`**.

## What

Adds `systemPrompt` (optional string) to the `POST /search` request schema. Per Exa's docs it "guides synthesized output" — it steers `output.content` when using deep-search structured output (`outputSchema`).

Additive only; no behavior change for existing callers. JSON validated.

## Why it matters for the enrich migration

Exa's `/search` now does grounded structured synthesis natively. With `outputSchema` (the research JSON) + `systemPrompt` (the extraction instructions) + `startPublishedDate` (from `recency_days`), **one `/search` call can replace both the current `invoke_search` AND the Gemini `extract` prompt**, returning `output.content` (structured research) and `output.grounding[]` (per-field citations → `sources[]`). `systemPrompt` is the missing lever to steer that synthesis.

## Not included (noted follow-ups)
- Deprecated params still declared (`numSentences`, `highlightsPerUrl`) — Exa ignores them; cosmetic cleanup deferred.
- Still open before any prod migration: **source-language quality** (does Exa return pt/es sources for pt/es queries) and **cost** (`costDollars` per-request vs ~12k tokens/fixture on Gemini) — to be settled by an enrich-stg prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)