### PR TITLE
fix(machina-ai): treat temperature 0/None as unset on the Claude route

### DIFF
--- a/connectors/machina-ai/machina-ai.py
+++ b/connectors/machina-ai/machina-ai.py
@@ -1381,8 +1381,11 @@ class VertexAnthropicAdapter(ProviderAdapter):
             }
             # Claude 4.6+ (Sonnet 5, Opus 4.7/4.8, …) reject sampling params with
             # a 400 ("temperature is deprecated for this model"), so no default is
-            # applied — only an explicit workflow-provided temperature is forwarded.
-            if request.options.get("temperature") is not None:
+            # applied. The platform workflow prompt runner also injects
+            # ``temperature: 0`` into every prompt task regardless of author
+            # intent, so 0/None are treated as "unset" — only an explicit
+            # non-zero temperature is forwarded on this route.
+            if request.options.get("temperature"):
                 kwargs["temperature"] = request.options["temperature"]
             credentials = self._credentials(route)
             if credentials is not None:

--- a/connectors/machina-ai/tests/test_router.py
+++ b/connectors/machina-ai/tests/test_router.py
@@ -542,6 +542,11 @@ class TestProviderAdapters:
         with patch.dict(sys.modules, {"langchain_google_vertexai.model_garden": mg_module}):
             adapter.create_chat_model(route, self.request(temperature=0.7))
         assert fake_chat.call_args.kwargs["temperature"] == 0.7
+        # The platform prompt runner injects temperature: 0 into every prompt
+        # task; 0 must be treated as unset on this route (Claude rejects it).
+        with patch.dict(sys.modules, {"langchain_google_vertexai.model_garden": mg_module}):
+            adapter.create_chat_model(route, self.request(temperature=0))
+        assert "temperature" not in fake_chat.call_args.kwargs
 
     def test_vertex_and_google_media_can_delegate_without_provider_imports(self):
         class DelegateRuntime:


### PR DESCRIPTION
The platform prompt runner injects `temperature: 0` into every prompt task; the Claude route forwarded it as explicit and Claude 4.6+ 400s on sampling params. Caught by the Entain widgets server-path smoke (Sonnet 5). Zero/None now = unset on `vertex_anthropic` only; explicit non-zero still forwarded. Suite 103 passing. Refs [86ajmxm3u](https://app.clickup.com/t/86ajmxm3u) · follow-up to #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)