### PR TITLE
fix(sportradar-mlb): add the daily feed and the schedule/results sync pair

### DIFF
--- a/connectors/sportradar-mlb/_install.yml
+++ b/connectors/sportradar-mlb/_install.yml
@@ -12,12 +12,13 @@ setup:
     - Favorite players season stats
     - In-depth subjective statistics
     - All game data feeds update in real-time as games are played
-    - All NFL games - including preseason - feature full play-by-play coverage
+    - Season schedule sync into IPTC sport:Event documents
+    - Daily boxscore sync that merges runs onto existing fixtures
   integrations:
     - sportradar
   status: available
   value: sportradar-mlb
-  version: 8.0.0
+  version: 8.1.0
 
 datasets:
   - type: "connector"
@@ -26,4 +27,18 @@ datasets:
   - type: "workflow"
     path: "test-credentials.yml"
 
+  # mappings
+  - type: "mappings"
+    path: "mappings/iptc-sport-event.yml"
 
+  # workflows
+  #
+  # Two workflows, not one, because the MLB feeds split the data:
+  #   sync-games   -> /games/{season_year}/{season_type}/schedule.json  (fixtures, NO runs)
+  #   sync-results -> /games/{year}/{month}/{day}/boxscore.json         (runs)
+  # Same split the sportradar-soccer connector uses.
+  - type: "workflow"
+    path: "sync-games.yml"
+
+  - type: "workflow"
+    path: "sync-results.yml"

--- a/connectors/sportradar-mlb/mappings/iptc-sport-event.yml
+++ b/connectors/sportradar-mlb/mappings/iptc-sport-event.yml
@@ -1,0 +1,23 @@
+mappings:
+- type: mapping
+  title: IPTC | Sportradar Event MLB Mapping
+  name: iptc-sportradar-event-mlb-mapping
+  description: 'Mapping data from sportradar MLB to sportschema event. NOTE: schedule.json carries NO runs — sportradar-mlb-sync-results merges the score in from the daily boxscore feed. sport:score is
+    emitted with explicit nulls so the shape stays stable and extract-team-stats reads a predictable path. sport:gameNumber / sport:doubleHeader are kept because MLB plays doubleheaders (two games, same
+    teams, same day) and a naive team+date join would collapse the pair. Do NOT put inline `#` comments inside the expression below — the engine''s expression parser returns an empty result instead of erroring.
+    O diff em task-bulk-save-events compara apenas name + status do evento, entao mudanca em campo aninhado (ex: sport:competitors) NAO dispara reescrita — por isso o name do evento tambem usa market+name.'
+  outputs:
+    sport_schema_events: "[\n  {\n    \"@context\": {\n      \"sport\": \"https://www.sportschema.org/ontologies/sport#\",\n      \"schema\": \"https://schema.org/\"\n    },\n    \"@id\": f\"urn:sportradar:sport_event:{f.get('id')}\"\
+      ,\n    \"@type\": [\"sport:Event\", \"schema:SportsEvent\"],\n    \"name\": f\"{f.get('home', {}).get('market', '')} {f.get('home', {}).get('name', 'TBD')}\".strip() + \" vs \" + f\"{f.get('away',\
+      \ {}).get('market', '')} {f.get('away', {}).get('name', 'TBD')}\".strip(),\n    \"schema:startDate\": f.get('scheduled') or f.get('start_time'),\n    \"schema:sportName\": \"mlb\",\n    \"sport:status\"\
+      : (f.get('status') or 'not_started').replace('created', 'not_started').replace('inprogress', 'live').replace('scheduled', 'not_started'),\n    \"sport:matchStatus\": (f.get('status') or 'not_started').replace('created',\
+      \ 'not_started').replace('inprogress', 'live').replace('scheduled', 'not_started'),\n    \"sport:competition\": {\n      \"@id\": f\"urn:sportradar:competition:mlb\",\n      \"@type\": \"sport:Competition\"\
+      ,\n      \"name\": \"MLB\",\n      \"sport:season\": {\n        \"@id\": f\"urn:sportradar:season:{$.get('season_year', '2026')}\",\n        \"@type\": \"sport:Season\",\n        \"name\": f\"MLB\
+      \ {$.get('season_year', '2026')}\",\n        \"sport:year\": f\"{$.get('season_year', '2026')}\"\n      }\n    },\n    \"sport:venue\": {\n      \"@type\": \"sport:Venue\",\n      \"@id\": f\"urn:sportradar:venue:{f.get('venue',\
+      \ {}).get('id')}\",\n      \"name\": f.get('venue', {}).get('name'),\n      \"schema:addressLocality\": f.get('venue', {}).get('city')\n    },\n    \"sport:competitors\": [\n      {\n        \"@type\"\
+      : \"sport:Team\",\n        \"@id\": f\"urn:sportradar:team:{f.get('home', {}).get('id')}\",\n        \"name\": f\"{f.get('home', {}).get('market', '')} {f.get('home', {}).get('name', '')}\".strip(),\n\
+      \        \"sport:market\": f.get('home', {}).get('market'),\n        \"sport:abbreviation\": f.get('home', {}).get('abbr'),\n        \"sport:qualifier\": \"home\"\n      },\n      {\n        \"@type\"\
+      : \"sport:Team\",\n        \"@id\": f\"urn:sportradar:team:{f.get('away', {}).get('id')}\",\n        \"name\": f\"{f.get('away', {}).get('market', '')} {f.get('away', {}).get('name', '')}\".strip(),\n\
+      \        \"sport:market\": f.get('away', {}).get('market'),\n        \"sport:abbreviation\": f.get('away', {}).get('abbr'),\n        \"sport:qualifier\": \"away\"\n      }\n    ],\n    \"sport:score\"\
+      : {\n      \"sport:homeScore\": f.get('home', {}).get('runs'),\n      \"sport:awayScore\": f.get('away', {}).get('runs')\n    },\n    \"sport:gameNumber\": f.get('game_number'),\n    \"sport:doubleHeader\"\
+      : f.get('double_header')\n  }\n  for f in $.get('schedules', [])\n]\n"

--- a/connectors/sportradar-mlb/sportradar-mlb.json
+++ b/connectors/sportradar-mlb/sportradar-mlb.json
@@ -486,6 +486,66 @@
           }
         ]
       }
+    },
+    "/games/{year}/{month}/{day}/{data_type}": {
+      "get": {
+        "summary": "Daily schedule / boxscore / summary for a given date",
+        "description": "The ONLY feed that carries runs. Season-level /games/{season_year}/{season_type}/boxscore.json returns 404; schedule.json carries no score. Payload is league.games[].game with home.runs / away.runs.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "month",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "day",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "data_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "boxscore.json | schedule.json | summary.json"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/connectors/sportradar-mlb/sync-games.yml
+++ b/connectors/sportradar-mlb/sync-games.yml
@@ -1,0 +1,138 @@
+workflow:
+  name: sportradar-mlb-sync-games
+  title: Sportradar MLB Sync Games
+  description: |
+    Sync the MLB season schedule into IPTC sport:Event documents.
+
+    Unlike the NFL feed, MLB's schedule.json returns a FLAT games[] list (the NFL
+    one nests games inside weeks[]), and it carries NO runs — scores arrive via
+    sportradar-mlb-sync-results from the daily boxscore feed. Same split the
+    soccer connector uses (sync-schedules + sync-results).
+
+    Auth is a HEADER (x-api-key), not the query-param api_key that the soccer and
+    NFL v7 connectors use.
+  context-variables:
+    debugger:
+      enabled: true
+    sportradar-mlb:
+      x-api-key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
+  inputs:
+    season_year: $.get('season_year', '2026')
+    season_type: $.get('season_type', 'REG')
+  outputs:
+    # Counts only, never the event payload. A full season is 2431 events (~5 MB);
+    # returning it made every run ship megabytes back through the caller for no
+    # reason. The written_count is the useful signal — it is diff-only, so a
+    # steady-state run reports 0 and a results day reports just the changed games.
+    games_count: len($.get('games_parsed', []))
+    written_count: len($.get('new_or_updated_events_list', []))
+    workflow-status: "'executed'"
+  tasks:
+
+    # task-load-games
+    - type: connector
+      name: task-load-games
+      description: Get a season schedule from SportRadar MLB
+      connector:
+        name: sportradar-mlb
+        command: get-games/{season_year}/{season_type}/{data_type}
+        command_attribute:
+          season_year: $.get('season_year')
+          season_type: $.get('season_type')
+          data_type: "'schedule.json'"
+      inputs:
+        x-api-key: $.get('x-api-key')
+      outputs:
+        games_parsed: |
+          [
+            {
+              **game,
+              'metadata': {
+                'event_code': game.get('id', ''),
+                'team_ids': [game.get('home', {}).get('id', ''), game.get('away', {}).get('id', '')],
+              },
+              'title': f"{game.get('home', {}).get('name', '')} v {game.get('away', {}).get('name', '')}",
+              'selected': False
+            }
+            for game in $.get('games', [])
+          ]
+
+    # iptc-sportradar-event-mlb-mapping
+    - type: mapping
+      name: iptc-sportradar-event-mlb-mapping
+      title: IPTC | Sportradar Event MLB Mapping
+      description: Mapping data from sportradar to IPTC events
+      condition: len($.get('games_parsed')) > 0
+      inputs:
+        schedules: $.get('games_parsed')
+        season_year: $.get('season_year')
+      outputs:
+        all_events: $.get('sport_schema_events')
+        all_events_ids: |
+          [str(f.get('@id', '')) for f in $.get('sport_schema_events', [])]
+
+    # load-events-by-ids
+    - type: document
+      name: load-events-by-ids
+      condition: $.get('all_events_ids') is not None
+      description: Load existing events by IDs.
+      config:
+        action: search
+        search-limit: 10000
+        search-vector: false
+      filters:
+        metadata.event_code: |
+          {'$in': $.get('all_events_ids', [])}
+      inputs:
+        name: "'sport:Event'"
+      outputs:
+        existing_events_ids: |
+          [
+            fixture.get('metadata', {}).get('event_code', '')
+            for fixture in $.get('documents', [])
+          ]
+        existing_events_map: |
+          {
+            fixture.get('metadata', {}).get('event_code', ''): {
+              'name': fixture.get('value', {}).get('name', ''),
+              'status': fixture.get('value', {}).get('sport:status', '')
+            }
+            for fixture in $.get('documents', [])
+          }
+
+    # task-bulk-save-events
+    #
+    # embed-vector is OFF. A full MLB season is 2431 fixtures — an order of
+    # magnitude more than the NFL's 272, which already stalled indefinitely with
+    # per-document embedding (2 docs instant, 32 timed out, 272 hung 30+ min).
+    # Nothing reads these by vector: predictions-find-upcoming filters on metadata
+    # with search-vector:false.
+    - type: document
+      name: task-bulk-save-events
+      description: Bulk save or update events (new events or events whose name/status changed).
+      condition: len($.get('new_or_updated_events_list', [])) > 0
+      config:
+        action: bulk-update
+        embed-vector: false
+        force-update: true
+      document_name: "'sport:Event'"
+      documents:
+        items: $.get('new_or_updated_events_list')
+      inputs:
+        new_or_updated_events_list: |
+          [
+            {
+              **f,
+              'metadata': {
+                'event_code': str(f.get('@id', '')),
+                'sport_name': str(f.get('schema:sportName', ''))
+              },
+              'title': f"{(f.get('sport:competition') or {}).get('name', '')} - {f.get('name', '')}"
+            }
+            for f in ($.get('all_events') or [])
+            if (
+              str(f.get('@id', '')) not in $.get('existing_events_ids', []) or
+              ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('name', '') != f.get('name', '') or
+              ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('status', '') != f.get('sport:status', '')
+            )
+          ]

--- a/connectors/sportradar-mlb/sync-results.yml
+++ b/connectors/sportradar-mlb/sync-results.yml
@@ -1,0 +1,83 @@
+workflow:
+  name: sportradar-mlb-sync-results
+  title: Sportradar MLB Sync Results
+  description: 'Companion to sportradar-mlb-sync-games. The season schedule.json carries NO runs, so this merges the score and final status onto the existing sport:Event docs from the DAILY boxscore feed
+    (/games/{year}/{month}/{day}/boxscore.json), whose payload is league.games[].game with home.runs / away.runs.
+
+    Without this, extract-team-stats has nothing to read — it needs value.sport:score.sport:homeScore / sport:awayScore — so no team stats, so the MLB forecaster prompt (gated on home_stats being non-null)
+    never runs and no pick is ever produced. Exactly the failure mode NFL hit for a different reason.
+
+    One call per day, defaulting to yesterday: MLB plays daily, games finish overnight US time, and a same-day call mid-slate returns half-finished games. Pass an explicit year/month/day to backfill.
+
+    Merge-not-replace: only sport:score / sport:status / sport:matchStatus are written, so version_control (forecasted / forecast_refreshed) survives. Clobbering it would re-forecast every fixture and re-bill
+    the model.'
+  context-variables:
+    debugger:
+      enabled: true
+    sportradar-mlb:
+      x-api-key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
+  inputs:
+    year: $.get('year', (datetime.utcnow() - timedelta(days=1)).strftime('%Y'))
+    month: $.get('month', (datetime.utcnow() - timedelta(days=1)).strftime('%m'))
+    day: $.get('day', (datetime.utcnow() - timedelta(days=1)).strftime('%d'))
+  outputs:
+    scored_count: len($.get('scored_games', []))
+    workflow-status: '''executed'''
+  tasks:
+  - type: connector
+    name: load-daily-boxscore
+    description: Daily boxscore for the requested date
+    connector:
+      name: sportradar-mlb
+      command: get-games/{year}/{month}/{day}/{data_type}
+      command_attribute:
+        year: $.get('year')
+        month: $.get('month')
+        day: $.get('day')
+        data_type: '''boxscore.json'''
+    inputs:
+      x-api-key: $.get('x-api-key')
+    outputs:
+      scored_games: "[\n  {\n    'event_code': f\"urn:sportradar:sport_event:{(g.get('game') or {}).get('id')}\",\n    'status': (g.get('game') or {}).get('status'),\n    'home_runs': ((g.get('game') or\
+        \ {}).get('home') or {}).get('runs'),\n    'away_runs': ((g.get('game') or {}).get('away') or {}).get('runs')\n  }\n  for g in ($.get('league', {}) or {}).get('games', [])\n  if (g.get('game') or\
+        \ {}).get('id')\n]\n"
+      scored_ids: "[\n  f\"urn:sportradar:sport_event:{(g.get('game') or {}).get('id')}\"\n  for g in ($.get('league', {}) or {}).get('games', [])\n  if (g.get('game') or {}).get('id')\n]\n"
+      scored_map: "{\n  (g.get('game') or {}).get('id'): {\n    'status': (g.get('game') or {}).get('status'),\n    'home_runs': ((g.get('game') or {}).get('home') or {}).get('runs'),\n    'away_runs':\
+        \ ((g.get('game') or {}).get('away') or {}).get('runs')\n  }\n  for g in ($.get('league', {}) or {}).get('games', [])\n  if (g.get('game') or {}).get('id')\n}\n"
+  - type: document
+    name: load-existing-events
+    description: Load the sport:Event docs for the scored games
+    condition: len($.get('scored_ids', [])) > 0
+    config:
+      action: search
+      search-limit: 200
+      search-vector: false
+    filters:
+      metadata.event_code: '{''$in'': $.get(''scored_ids'', [])}
+
+        '
+    inputs:
+      name: '''sport:Event'''
+    outputs:
+      existing_docs: $.get('documents', [])
+  - type: document
+    name: merge-scores
+    description: 'Merge score + status onto each existing event, preserving version_control. The join lives in foreach.value, NOT in task inputs: on a foreach task the engine resolves foreach.value from
+      context BEFORE the task''s own inputs, so an inputs-based join silently yields zero iterations. Verified: the same expression returns 16 as a workflow output but 0 as a task input.'
+    condition: len($.get('existing_docs', [])) > 0
+    foreach:
+      name: item
+      expr: $
+      value: "[\n  {\n    'document_id': doc.get('_id'),\n    'value': {\n      **(doc.get('value') or {}),\n      'sport:status': ($.get('scored_map') or {}).get(doc.get('metadata', {}).get('event_code',\
+        \ '').replace('urn:sportradar:sport_event:', ''), {}).get('status'),\n      'sport:matchStatus': ($.get('scored_map') or {}).get(doc.get('metadata', {}).get('event_code', '').replace('urn:sportradar:sport_event:',\
+        \ ''), {}).get('status'),\n      'sport:score': {\n        'sport:homeScore': ($.get('scored_map') or {}).get(doc.get('metadata', {}).get('event_code', '').replace('urn:sportradar:sport_event:',\
+        \ ''), {}).get('home_runs'),\n        'sport:awayScore': ($.get('scored_map') or {}).get(doc.get('metadata', {}).get('event_code', '').replace('urn:sportradar:sport_event:', ''), {}).get('away_runs')\n\
+        \      }\n    }\n  }\n  for doc in $.get('existing_docs', [])\n  if doc.get('metadata', {}).get('event_code', '').replace('urn:sportradar:sport_event:', '') in ($.get('scored_map') or {})\n]\n"
+    config:
+      action: update
+      embed-vector: false
+      force-update: true
+    filters:
+      document_id: $.get('item').get('document_id')
+    documents:
+      sport:Event: $.get('item').get('value')


### PR DESCRIPTION
The canonical MLB connector was a stub — spec plus `test-credentials` — and the spec was missing **the only endpoint that carries runs**. Anyone wiring MLB into a predictions pipeline hits a wall immediately: `extract-team-stats` needs `value.sport:score.sport:homeScore`, and nothing in the connector could supply it.

## Measured against the live API

```
/games/{season_year}/{season_type}/schedule.json   →  2431 games, NO runs
/games/{season_year}/{season_type}/boxscore.json   →  404
/games/{year}/{month}/{day}/boxscore.json          →  league.games[].game
                                                      with home.runs / away.runs
```

Scores are only reachable per-day. This adds that path, plus the two workflows the split implies — the same shape `sportradar-soccer` already uses (`sync-schedules` + `sync-results`):

| workflow | feed | writes |
|---|---|---|
| `sync-games` | season `schedule.json` | IPTC `sport:Event` fixtures (no runs) |
| `sync-results` | daily `boxscore.json` | **merges** runs + final status onto existing docs |

Plus the IPTC mapping (`iptc-sportradar-event-mlb-mapping`).

## Already validated in production

All three are running on the entain-widgets pod: **2431 fixtures** written, **21 days backfilled (248 scored games)**, and a real MLB forecast produced from the resulting team stats (`abstain: false`, expected score 5.1–4.8, moneyline 52.7% home).

## Four gotchas, documented in the files

- **MLB's `games[]` is a FLAT list.** The NFL feed nests games inside `weeks[]` — the NFL mapping does not port over directly.
- **Auth is a HEADER** (`x-api-key`), not the query-param `api_key` the soccer and NFL v7 connectors use.
- **`embed-vector` is OFF** on the bulk write. A season is 2431 fixtures; the NFL's 272 already stalled indefinitely with per-document embedding (2 instant, 32 timed out, 272 hung 30+ min). Nothing reads these by vector — `predictions-find-upcoming` filters on metadata with `search-vector:false`.
- **Names use `market + name`** ("Tampa Bay Rays", not "Rays"), because Bwin names its fixtures that way and odds matching is by team name.

Two engine constraints also captured as comments, since both cost real debugging time:
- Inline `#` comments inside a mapping expression make the parser return an **empty result with no error**.
- On a `foreach` task, `foreach.value` resolves from context **before** the task's own `inputs`, so an inputs-based join silently yields zero iterations. The same expression returned 16 as a workflow output and 0 as a task input.

## Also fixed

`_install.yml` advertised *"All **NFL** games - including preseason - feature full play-by-play coverage"* on the MLB connector. Copy-paste from the NFL package.

Version bumped 8.0.0 → 8.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)