### PR TITLE
fix(sportradar-mlb): stop the schedule sync from wiping scores

### DIFF
--- a/connectors/sportradar-mlb/sync-games.yml
+++ b/connectors/sportradar-mlb/sync-games.yml
@@ -95,7 +95,9 @@ workflow:
           {
             fixture.get('metadata', {}).get('event_code', ''): {
               'name': fixture.get('value', {}).get('name', ''),
-              'status': fixture.get('value', {}).get('sport:status', '')
+              'status': fixture.get('value', {}).get('sport:status', ''),
+              'score': fixture.get('value', {}).get('sport:score'),
+              'version_control': fixture.get('value', {}).get('version_control')
             }
             for fixture in $.get('documents', [])
           }
@@ -107,9 +109,17 @@ workflow:
     # per-document embedding (2 docs instant, 32 timed out, 272 hung 30+ min).
     # Nothing reads these by vector: predictions-find-upcoming filters on metadata
     # with search-vector:false.
+    #
+    # sport:score and version_control are carried over from the existing document.
+    # bulk-update REPLACES the whole value, and schedule.json carries no runs, so
+    # without this a schedule re-sync rewrites every score with null. Measured:
+    # one re-sync took 242 scored games to 0, which dropped games_played below
+    # min_games_played and made every MLB forecast abstain. version_control is
+    # preserved for the same reason sync-results preserves it — losing it
+    # re-forecasts the whole slate and re-bills the model.
     - type: document
       name: task-bulk-save-events
-      description: Bulk save or update events (new events or events whose name/status changed).
+      description: Bulk save or update events (new events or events whose name/status changed), preserving score and version_control.
       condition: len($.get('new_or_updated_events_list', [])) > 0
       config:
         action: bulk-update
@@ -123,6 +133,16 @@ workflow:
           [
             {
               **f,
+              **(
+                {'sport:score': ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('score')}
+                if (($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('score') or {}).get('sport:homeScore') is not None
+                else {}
+              ),
+              **(
+                {'version_control': ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('version_control')}
+                if ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('version_control')
+                else {}
+              ),
               'metadata': {
                 'event_code': str(f.get('@id', '')),
                 'sport_name': str(f.get('schema:sportName', ''))


### PR DESCRIPTION
## Problem

`sync-games` saves `sport:Event` with `action: bulk-update`, which replaces the entire document value. MLB's `schedule.json` carries **no runs** — scores only arrive through the daily boxscore feed that `sync-results` reads.

So every schedule re-sync overwrote `sport:score` with nulls, destroying whatever `sync-results` had merged in.

## Impact (measured on the widgets pod)

| | scored MLB games |
|---|---|
| after the 21-day boxscore backfill | 242 |
| after one `sync-games` re-run | **0** |

`extract-team-stats` reads `value.sport:score.sport:homeScore`, so `games_played` collapsed to 0, fell below `min_games_played`, and **every MLB forecast abstained**. The two sync workflows were fighting each other on every tick.

## Fix

Carry `sport:score` and `version_control` over from the existing document when rewriting it.

`version_control` is preserved for the same reason `sync-results` already preserves it — clobbering it re-forecasts the whole slate and re-bills the model.

## Verification

```
antes:  242
re-sync -> reescritos: 1
depois: 242
```

And `predictions-forecast` on an upcoming MLB game returns `abstain: false` again, with a stored prediction document.

## Note

Follow-up to #297, which shipped this file before the bug was found. NFL is unaffected — its `schedule.json` does carry scores.