### PR TITLE
fix(sportradar-nfl): emit sport:abbreviation, and make the diff notice mapping changes

### DIFF
--- a/connectors/sportradar-nfl/mappings/iptc-sport-event.yml
+++ b/connectors/sportradar-nfl/mappings/iptc-sport-event.yml
@@ -42,12 +42,14 @@ mappings:
                 "@type": "sport:Team",
                 "@id": f"urn:sportradar:team:{f.get('home', {}).get('id')}",
                 "name": f.get('home', {}).get('name'),
+                "sport:abbreviation": f.get('home', {}).get('alias'),
                 "sport:qualifier": "home"
               },
               {
                 "@type": "sport:Team",
                 "@id": f"urn:sportradar:team:{f.get('away', {}).get('id')}",
                 "name": f.get('away', {}).get('name'),
+                "sport:abbreviation": f.get('away', {}).get('alias'),
                 "sport:qualifier": "away"
               }
             ],

--- a/connectors/sportradar-nfl/sync-games.yml
+++ b/connectors/sportradar-nfl/sync-games.yml
@@ -101,7 +101,12 @@ workflow:
           {
             fixture.get('metadata', {}).get('event_code', ''): {
               'name': fixture.get('value', {}).get('name', ''),
-              'status': fixture.get('value', {}).get('sport:status', '')
+              'status': fixture.get('value', {}).get('sport:status', ''),
+              'abbrs': [
+                (c or {}).get('sport:abbreviation')
+                for c in (fixture.get('value', {}).get('sport:competitors') or [])
+              ],
+              'version_control': fixture.get('value', {}).get('version_control')
             }
             for fixture in $.get('documents', [])
           }
@@ -130,6 +135,15 @@ workflow:
           [
             {
               **f,
+              # Full-value replace: without carrying version_control over, a re-sync
+              # clears the forecast flags and the whole slate is re-forecast and
+              # re-billed. Latent while NFL has no forecasts. Same fix MLB needed,
+              # where the equivalent replace wiped 242 scores.
+              **(
+                {'version_control': ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('version_control')}
+                if ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('version_control')
+                else {}
+              ),
               'metadata': {
                 'event_code': str(f.get('@id', '')),
                 'sport_name': str(f.get('schema:sportName', ''))
@@ -142,6 +156,11 @@ workflow:
               ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('name', '') != f.get('name', '') or
               ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('status', '') != f.get('sport:status', '') or
               '(win)' in ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('name', '') or
-              'TBD' in ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('name', '')
+              'TBD' in ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('name', '') or
+              # The diff compared only name and status, so a mapping change rewrote
+              # NOTHING: stored fixtures keep both, so none looked changed.
+              ($.get('existing_events_map') or {}).get(str(f.get('@id', '')), {}).get('abbrs', []) != [
+                (c or {}).get('sport:abbreviation') for c in (f.get('sport:competitors') or [])
+              ]
             )
           ]


### PR DESCRIPTION
The NFL schedule mapping emitted only `name` and `qualifier` per competitor, while the MLB one emits `sport:abbreviation`. That asymmetry is why the picks feed needs a hardcoded 32-club map to label NFL teams — the stored prediction documents keep only the name, and the nickname heuristic gave `Kansas City Chiefs` the abbreviation `CHI`, colliding with Chicago.

## Three changes, because the first alone is a no-op

**1.** The mapping emits `sport:abbreviation` from the feed's `team.alias`.

**2.** The bulk-save diff now includes the competitors' abbreviations. It compared only name and status (plus the `(win)`/`TBD` placeholder checks) — so adding a field to the mapping would have rewritten **nothing**: stored fixtures keep their name and status, so none would look changed and the new field would only appear on genuinely new games.

**3.** `version_control` is carried over. This is a full-value replace, so a re-sync clears the forecast flags and the whole slate is re-forecast and re-billed. Latent while NFL has no forecasts; it bites the moment the season starts — the same fix `sync-games` needed for MLB, where the equivalent replace wiped 242 scores.

## Verified on the widgets pod

which runs the equivalent change (entain-widgets#54). Re-syncing PRE and REG:

| check | result |
|---|---|
| fixtures before / after | 321 / **321** — no duplicates |
| carrying an abbreviation | 0 → **321** |
| distinct clubs | **32** |
| left without one | **0** |
| divergences vs the feed's alias | **none** |

```
Kansas City Chiefs    -> KC     (heuristic gave CHI, colliding with Chicago)
Arizona Cardinals     -> ARI    (heuristic gave CAR, which is Carolina)
```

## Note for reviewers

This repo's `sync-games.yml` had **already diverged** from the entain-widgets copy — it carries extra `(win)`/`TBD` placeholder conditions the other lacks. These edits are applied to *this* repo's own structure rather than copied over, so that pre-existing divergence is preserved rather than silently resolved in one direction. Worth deciding deliberately which version is authoritative.

## Still does not remove the hardcoded club map

`format-picks` reads the stored `*-prediction` documents, whose team fields are plain strings, so the abbreviation does not reach it. Carrying it from the event document into the prediction document is the remaining step — and it is what would let NBA and NHL skip a hardcoded map entirely.