### PR TITLE
fix(mlb): literal-friendly days_ago input on the sportradar-mlb sync workflows

### DIFF
--- a/connectors/sportradar-mlb/sync-games.yml
+++ b/connectors/sportradar-mlb/sync-games.yml
@@ -17,7 +17,11 @@ workflow:
     sportradar-mlb:
       x-api-key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
   inputs:
-    season_year: $.get('season_year', '2026')
+    # season_year defaults to the current UTC year, computed in the task's
+    # command_attribute — not here and not as a '2026' literal. The enrichment
+    # pod's AGENT-leg input context cannot evaluate datetime, so scheduler legs
+    # pass no season_year at all and the task computes it where datetime works.
+    season_year: $.get('season_year')
     season_type: $.get('season_type', 'REG')
   outputs:
     # Counts only, never the event payload. A full season is 2431 events (~5 MB);
@@ -37,7 +41,7 @@ workflow:
         name: sportradar-mlb
         command: get-games/{season_year}/{season_type}/{data_type}
         command_attribute:
-          season_year: $.get('season_year')
+          season_year: $.get('season_year') or str(datetime.utcnow().year)
           season_type: $.get('season_type')
           data_type: "'schedule.json'"
       inputs:

--- a/connectors/sportradar-mlb/sync-pitchers.yml
+++ b/connectors/sportradar-mlb/sync-pitchers.yml
@@ -30,16 +30,20 @@ workflow:
 
     TWO DATES, because a Major League Baseball day begins at 4am ET (per Sportradar), so a
     UTC 'today' before ~08:00 UTC is still the previous MLB day. The agent runs yesterday
-    and today; re-reading a day is idempotent.
+    and today; re-reading a day is idempotent. Dates come from days_ago (integer, default 0
+    = today) computed in the task's command_attribute, or explicit year/month/day overrides:
+    the enrichment pod's AGENT-leg input context cannot evaluate datetime (dates resolved to
+    the literal error string and 404ed), so scheduler legs must pass literals.
   context-variables:
     debugger:
       enabled: true
     sportradar-mlb:
       x-api-key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
   inputs:
-    year: $.get('year', datetime.utcnow().strftime('%Y'))
-    month: $.get('month', datetime.utcnow().strftime('%m'))
-    day: $.get('day', datetime.utcnow().strftime('%d'))
+    days_ago: $.get('days_ago', 0)
+    year: $.get('year')
+    month: $.get('month')
+    day: $.get('day')
   outputs:
     pitcher_count: len($.get('pitcher_games', []))
     merged_count: len($.get('existing_docs', []))
@@ -53,9 +57,9 @@ workflow:
       name: sportradar-mlb
       command: get-games/{year}/{month}/{day}/{data_type}
       command_attribute:
-        year: $.get('year')
-        month: $.get('month')
-        day: $.get('day')
+        year: $.get('year') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 0)))).strftime('%Y')
+        month: $.get('month') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 0)))).strftime('%m')
+        day: $.get('day') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 0)))).strftime('%d')
         data_type: '''summary.json'''
     inputs:
       x-api-key: $.get('x-api-key')

--- a/connectors/sportradar-mlb/sync-results.yml
+++ b/connectors/sportradar-mlb/sync-results.yml
@@ -7,7 +7,9 @@ workflow:
     Without this, extract-team-stats has nothing to read — it needs value.sport:score.sport:homeScore / sport:awayScore — so no team stats, so the MLB forecaster prompt (gated on home_stats being non-null)
     never runs and no pick is ever produced. Exactly the failure mode NFL hit for a different reason.
 
-    One call per day, defaulting to yesterday: MLB plays daily, games finish overnight US time, and a same-day call mid-slate returns half-finished games. Pass an explicit year/month/day to backfill.
+    One call per day, defaulting to yesterday: MLB plays daily, games finish overnight US time, and a same-day call mid-slate returns half-finished games. Pass an explicit year/month/day to backfill, or
+    days_ago (integer, default 1) to pick the day relative to now — added because the enrichment pod''s AGENT-leg input context cannot evaluate datetime (every date leg resolved to the literal string
+    "Error: name ''datetime'' is not defined" and 404ed for a week), so scheduler legs must pass literals; the date arithmetic lives in the task''s command_attribute, where datetime is proven on that pod.
 
     Merge-not-replace: only sport:score / sport:status / sport:matchStatus are written, so version_control (forecasted / forecast_refreshed) survives. Clobbering it would re-forecast every fixture and re-bill
     the model.'
@@ -17,9 +19,10 @@ workflow:
     sportradar-mlb:
       x-api-key: $TEMP_CONTEXT_VARIABLE_SPORTRADAR_SOCCER_V4_API_KEY
   inputs:
-    year: $.get('year', (datetime.utcnow() - timedelta(days=1)).strftime('%Y'))
-    month: $.get('month', (datetime.utcnow() - timedelta(days=1)).strftime('%m'))
-    day: $.get('day', (datetime.utcnow() - timedelta(days=1)).strftime('%d'))
+    days_ago: $.get('days_ago', 1)
+    year: $.get('year')
+    month: $.get('month')
+    day: $.get('day')
   outputs:
     scored_count: len($.get('scored_games', []))
     workflow-status: '''executed'''
@@ -31,9 +34,9 @@ workflow:
       name: sportradar-mlb
       command: get-games/{year}/{month}/{day}/{data_type}
       command_attribute:
-        year: $.get('year')
-        month: $.get('month')
-        day: $.get('day')
+        year: $.get('year') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 1)))).strftime('%Y')
+        month: $.get('month') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 1)))).strftime('%m')
+        day: $.get('day') or (datetime.utcnow() - timedelta(days=int($.get('days_ago', 1)))).strftime('%d')
         data_type: '''boxscore.json'''
     inputs:
       x-api-key: $.get('x-api-key')


### PR DESCRIPTION
Canonical-copy twin of machina-sports/entain-widgets#64 — identical patch, same three files.

The enrichment pod's **agent-leg input context cannot evaluate `datetime`** — every date expression in `entain-coverage-mlb-results`'s legs resolved to the literal string `Error: name 'datetime' is not defined`, so the Sportradar URL 404ed and all five legs failed every 15 minutes since install (~1,860 consecutive failures; MLB enrichment frozen at Jul 30).

- `sync-results.yml` / `sync-pitchers.yml`: new integer input `days_ago` (results default 1 = yesterday, pitchers default 0 = today); date arithmetic moves into the task `command_attribute` where `datetime` is proven to work on that pod. Explicit `year/month/day` still override — backfill unchanged.
- `sync-games.yml`: `season_year` falls back to the current UTC year instead of a `'2026'` literal.

Companion: literal-only legs in `entain-enrichment:coverage/mlb/agent.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)