### PR TITLE
fix(sports-skills): require version 0.30.1

### DIFF
--- a/connectors/sports-skills/sports-skills.py
+++ b/connectors/sports-skills/sports-skills.py
@@ -15,7 +15,7 @@ Design:
 
 Runtime requirement:
 - The pod's Python env must have `sports-skills` importable. The
-  preferred path is adding `sports-skills>=0.21` to
+  preferred path is adding `sports-skills>=0.30.1` to
   `machina-client-api/requirements.txt` and rebuilding the pod image.
 - As a fallback this module attempts a one-time `pip install
   sports-skills` on first ImportError so customers can use the
@@ -30,8 +30,8 @@ import subprocess
 import sys
 
 
-_MIN_VERSION = (0, 28, 0)
-_PIP_PACKAGE = "sports-skills>=0.28.0,<1.0"
+_MIN_VERSION = (0, 30, 1)
+_PIP_PACKAGE = "sports-skills>=0.30.1,<1.0"
 # Writable install target for in-place upgrades. The pod runs as a non-root
 # user whose home dir is read-only (`pip install --user` fails with EACCES on
 # /home/machina), and system site-packages is root-owned — /tmp is the one

--- a/connectors/sports-skills/tests/test_version_floor.py
+++ b/connectors/sports-skills/tests/test_version_floor.py
@@ -1,0 +1,36 @@
+"""Regression tests for the sports-skills connector dependency floor.
+
+Pods bake a pinned sports-skills into system site-packages; the connector
+only hot-upgrades when the baked copy is older than the floor declared here.
+"""
+import importlib.util
+import os
+import re
+
+# Load module with hyphenated filename using importlib
+_parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "sports_skills_connector",
+    os.path.join(_parent_dir, "sports-skills.py")
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+
+def test_min_version_is_0_30_1():
+    assert _module._MIN_VERSION == (0, 30, 1)
+
+
+def test_pip_package_pins_the_same_floor():
+    assert _module._PIP_PACKAGE == "sports-skills>=0.30.1,<1.0"
+
+
+def test_runtime_requirement_docs_recommend_no_older_floor():
+    """The docstring must not tell operators to pin below _MIN_VERSION."""
+    floors = re.findall(r"sports-skills>=([0-9][0-9.]*)", _module.__doc__)
+    assert floors, "runtime requirement docs must state a sports-skills floor"
+    assert all(f == "0.30.1" for f in floors), floors
+
+
+def test_upgrade_target_stays_in_tmp():
+    assert _module._TARGET_DIR == "/tmp/sports-skills-site"


### PR DESCRIPTION
## Summary
- raise the sports-skills connector runtime floor to 0.30.1
- keep the existing `/tmp/sports-skills-site` hot-upgrade path unchanged
- add regression tests for the version floor and install spec

## Test plan
- `python3 -m pytest connectors/sports-skills/tests -q`
- `ruff check connectors/sports-skills/sports-skills.py connectors/sports-skills/tests/test_version_floor.py`