### PR TITLE
refactor(iptc): harden consumer inventory and review ledger

### DIFF
--- a/docs/iptc/PR3-CONSUMER-INVENTORY.md
+++ b/docs/iptc/PR3-CONSUMER-INVENTORY.md
@@ -7,7 +7,8 @@ a **migration order**, and the **seam** every migrated consumer will call.
 
 Nothing here changes production code, mapping YAML, workflows, connectors, install
 manifests, tests, or the generated inventory. This is the classification gate that
-Design Log #027 and `.claude/tasks/CURRENT.md` require before any PR 3 refactor starts.
+the internal design-decision record and `.claude/tasks/CURRENT.md` require before any
+PR 3 refactor starts.
 
 ---
 
@@ -248,7 +249,7 @@ found. The lane exists so PR 3 can state what would break, not so PR 3 can chang
 
 | Surface | Why excluded | Proof |
 |---|---|---|
-| `machina-templates-iptc-1.1-foundation`, `machina-templates-iptc-1.1-mappings`, and this worktree | All three share one `.git` common dir with `machina-templates`. They are PR 1 / PR 2 / PR 3 worktrees of **one** repository | `git worktree list` in `machina-templates` |
+| The two sibling local worktree checkouts for the PR 1 and PR 2 lanes, and this worktree | All three share one `.git` common dir with `machina-templates`. They are PR 1 / PR 2 / PR 3 worktrees of **one** repository | `git worktree list` in `machina-templates` |
 | `sportsclaw-pr136`, `sportsclaw-pr137`, `sportsclaw-pr138`, `sportsclaw-v0292` | Registered worktrees of the single `sportsclaw` repo (plus two `prunable` temp worktrees) | `git worktree list` in `sportsclaw` |
 | `sports-skills-machina-schema` | Checkout of the `sports-skills` PR 2 branch, superseded by `origin/main` @ `944c14e` | branch `feat/machina-sports-schema` |
 | `agent-templates/world-cup-intelligence/**/__pycache__/*.pyc` | Byte-compiled output of a file already counted | matched only by content |
@@ -375,7 +376,7 @@ fails-closed gate into an outage.
 Every candidate directory was resolved to a repository before being counted:
 `git rev-parse --git-common-dir` for shared worktrees, `git worktree list` for
 registrations, and branch/ref inspection for stale checkouts. The result is §3.7. Four
-`sportsclaw-*` directories, two `machina-templates-iptc-*` directories, this worktree, and
+`sportsclaw-*` directories, two sibling PR-lane worktree directories, this worktree, and
 `sports-skills-machina-schema` collapse to **three** repositories: `sportsclaw`,
 `machina-templates`, `sports-skills`. Generated JS, `.d.ts`, `.map` and `__pycache__`
 artefacts are excluded on the same principle: they are a second copy of a counted source.
@@ -502,9 +503,9 @@ made one.
 PR 3 does **not**:
 
 - change the canonical schema, its terms, its capability names, its envelope, or the
-  rights model — the canonical layer is frozen per Design Log #027, except bugs and
-  standards/provider corrections;
-- touch Sports Moment, Experience, or Coach Mode;
+  rights model — the canonical layer is frozen per the internal design-decision record,
+  except bugs and standards/provider corrections;
+- touch Experience or any other adjacent product surface;
 - rewrite customer repositories for purity — `dazn-templates`, `entain-templates`,
   `SINCH`, `sportingbot-web` and `sportsclaw-machina` get a plan, not a refactor;
 - change any frontend;

--- a/docs/iptc/PR3-CONSUMER-INVENTORY.md
+++ b/docs/iptc/PR3-CONSUMER-INVENTORY.md
@@ -1,0 +1,513 @@
+# PR 3 — consumer inventory and classification
+
+Hand-authored. Companion to the generated `docs/iptc/INVENTORY.md` / `inventory.json`,
+which stay authoritative for *what reads an IPTC field path inside this repository*.
+This document adds the thing a generator cannot produce: a per-surface **classification**,
+a **migration order**, and the **seam** every migrated consumer will call.
+
+Nothing here changes production code, mapping YAML, workflows, connectors, install
+manifests, tests, or the generated inventory. This is the classification gate that
+Design Log #027 and `.claude/tasks/CURRENT.md` require before any PR 3 refactor starts.
+
+---
+
+## 1. Scope and methodology
+
+**In scope.** Every surface that consumes a sports *event* shape produced by Machina —
+whether that shape is the legacy `sport:`-prefixed document, a provider payload, or a
+hand-rolled normalized model. Both this repository and the cross-repo consumers named
+in the PR 3 brief.
+
+**Method, in order of authority:**
+
+1. **Generated inventory first.** `docs/iptc/inventory.json` lists **75** consumer
+   files. That list is re-runnable (`python3 -m tools.iptc`) and is the authority for
+   in-repo legacy dependencies. This document extends it with categories; it does not
+   re-scan and does not restate its rows as if independently discovered.
+2. **Targeted verification** of each grounded finding in the PR 3 brief, by reading the
+   exact file and symbol named, and by running scoped greps whose patterns are recorded
+   below so the result is reproducible.
+3. **Bounded cross-repo reads.** Sibling repositories were read at their current checked-out
+   ref, read-only, limited to the files needed to classify the surface.
+4. **Worktree de-duplication** before counting anything (§7).
+
+**Reproducibility of the scoped greps.** Where this document states a count that is not
+from the generated inventory, it came from one of two patterns run over a named directory:
+
+- *legacy-shape pattern* — `worldcup:event|sport:competitors|schema:startDate|sport:competition|sport:venue|sport:status`
+- *canonical-key pattern* — `machina_sports_schema|event_view|sport_schema_graph|check_compatibility`
+
+Both are substring matches over file text. They are a floor, not a ceiling: a consumer
+that builds a field path at runtime is missed, exactly as the generated inventory's own
+"known gaps" section warns. **A consumer either pattern misses is an inventory defect to
+fix, not a tolerance to widen.**
+
+**Deliberately not attempted.** No exhaustive manual enumeration of every YAML in every
+customer repository is claimed. Where a repository was searched and returned nothing, that
+is stated as "searched, no match", not as "has no coupling".
+
+---
+
+## 2. Headline counts and observations
+
+| Fact | Count | Source |
+|---|---|---|
+| Generated in-repo consumer rows | **75** | `docs/iptc/inventory.json` → `totals.consumer_files` |
+| …of which are test scaffolds | 4 | 3 `*-test.yml` under `agent-templates/iptc-mappings/`, 1 `tests/test_worldcup_market_intelligence.py` |
+| Emitting mappings / files | 25 / 16 | `totals.emitting_mappings`, `totals.emitting_files` |
+| **Production YAML consumers of the canonical contract** | **0** | canonical-key pattern over `agent-templates/` + `connectors/` — no match |
+| Corrected canonical envelopes checked in | 8 | `tools/iptc/fixtures/corrected/*-envelope.json` |
+| Corrected canonical graphs checked in | 8 | `tools/iptc/fixtures/corrected/*-graph.json` |
+| In-repo canonical provider adapters | 6 | `tools/iptc/canonical/adapters/` (api_football, sportradar_{soccer,nfl,mlb,tennis}, stats_perform_opta) |
+| Capability names in the contract | 19 | `ALL_CAPABILITIES` in `tools/iptc/canonical/capabilities.py` |
+| …with a presence predicate | 15 | `_PRESENCE` |
+| …reported `not_expressible` | 4 | `NOT_EXPRESSIBLE` (derived: `ALL_CAPABILITIES − _PRESENCE`) |
+
+### The generated inventory's 75 rows, grouped
+
+| Group | Rows |
+|---|---|
+| `agent-templates/world-cup-intelligence` | 14 |
+| `agent-templates/assistant-tools` | 9 |
+| `agent-templates/iptc-mappings` | 6 |
+| `agent-templates/kalshi-market-agent` | 5 |
+| `agent-templates/coverage-tools` | 4 |
+| `agent-templates/chat-completion` | 1 |
+| `connectors/api-football` | 9 |
+| `connectors/stats-perform` | 9 |
+| `connectors/sportradar-soccer` | 8 |
+| `connectors/sportradar-nfl` | 4 |
+| `connectors/sportradar-mlb` | 3 |
+| `connectors/sportradar-tennis` | 2 |
+| `connectors/american-football` | 1 |
+| **Total** | **75** |
+
+### Observation 1 — the canonical contract has zero production consumers today
+
+The canonical-key pattern over `agent-templates/` and `connectors/` returns **no match**.
+Every hit for `machina_sports_schema`, `event_view`, `sport_schema_graph` and
+`check_compatibility` in this repository is in `tools/iptc/**`, `tests/**`,
+`docs/rfcs/00{1,2}-*.md`, or one comment line in
+`agent-templates/iptc-mappings/contexts/iptc-sport-schema-1.1.context.jsonld`.
+Two near-hits for the words *capabilities* / *rights* in production YAML —
+`agent-templates/machina-media/prompts/storyline-ranking-prompt.yml` (editorial prose about
+"rights-dependent video") and `connectors/google-speech-to-text/google-speech-to-text.yml`
+("speech-to-text capabilities") — are English, not contract fields.
+
+So: corrected canonical output exists (8 envelopes, 8 graphs, 6 adapters), `sports-skills`
+ships a canonical CLI mode, and **not one Machina workflow reads any of it.** The producer
+side is finished and the consumer side has not started. That is why the first
+implementation step in PR 3 is the **shared access seam** (§5), not a consumer rewrite:
+without a seam, each of the surfaces below would invent its own way to reach the envelope,
+and PR 3 would end with several new dialects instead of one contract.
+
+### Observation 2 — the generated inventory undercounts World Cup Intelligence by 13 workflows
+
+The generated scan keys on **IPTC field paths and payload state keys**. World Cup
+Intelligence also couples to the legacy shape through the *document name*
+`'worldcup:event'` in `filters:` blocks, which is not a field path. Running the
+legacy-shape pattern over `agent-templates/world-cup-intelligence/` returns 13 workflow
+files that carry legacy coupling and are **not** among the 14 generated rows:
+
+`worldcup-get-iptc-event-context.yml`, `worldcup-match-preview.yml`,
+`worldcup-get-event-context.yml`, `worldcup-get-schedule.yml`, `worldcup-get-signal.yml`,
+`worldcup-resolve.yml`, `worldcup-refresh-live-status.yml`,
+`worldcup-refresh-prematch-enrichment.yml`, `worldcup-sync-event-crosswalk.yml`,
+`worldcup-generate-market-brief.yml`, `worldcup-get-player-performance-context.yml`,
+`worldcup-fan-pulse.yml`, `worldcup-fan-sentiment-context.yml`.
+
+Per the generated inventory's own rule, this is an inventory defect. **Proposed PR 3
+action:** extend `tools/iptc/inventory.py` to also record document-name coupling, and
+re-generate. Not done in this commit — the generated inventory is out of scope here.
+
+### Observation 3 — Machina Media is invisible to the inventory because it never used IPTC at all
+
+`agent-templates/machina-media/` contributes **0** of the 75 rows. It is not conformant and
+not exempt; it is a **parallel event model** that the IPTC-shaped scan cannot see.
+`mappings/map-normalize-event.yml` describes itself as mapping "to the canonical 'event'
+data model" — a second thing calling itself canonical is the exact duplication PR 3 exists
+to remove.
+
+### Observation 4 — a documentation/code discrepancy consumers will hit
+
+RFC 002 §8 states "Five capabilities have no predicate". `NOT_EXPRESSIBLE` in
+`tools/iptc/canonical/capabilities.py` derives to **four** names
+(`event.coordinates`, `event.tracking`, `event.expected_metrics`, `event.formations`);
+the RFC's fifth is the prose placeholder "anything a later version adds", not a name.
+Consumers authoring `requires`/`optional` lists should read the code constant, which is
+also the vendored one. Recorded as an evidence gap (§10), not fixed here.
+
+---
+
+## 3. Classification
+
+Buckets, as defined for PR 3:
+
+- **canonical already** — reads the `machina_sports_schema` envelope.
+- **legacy canonical** — reads the pre-1.1 `sport:`-prefixed Machina document shape.
+- **provider-coupled** — reads a provider payload (API-Football fixture, Sportradar,
+  Opta) directly, above what should be the boundary.
+- **projection-only** — reads only to render/summarize; owns no model and would be
+  satisfied by `event_view`.
+- **customer-specific** — lives in a customer/product repo, migrates on the customer's
+  schedule.
+- **dead/unused/test/docs-only** — test scaffolds, docs, generated artefacts, stale worktrees.
+
+Proof confidence: **high** = exact file and symbol read in this session; **medium** =
+pattern match over the named directory with at least one file read; **low** = search
+result only.
+
+### 3.1 World Cup Intelligence — priority 1
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| WCI (this repo) | `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` → `mint_event_identity` (l. 2053) | Mints the obsolete shape itself: `@context.sport = https://www.sportschema.org/ontologies/sport#`, `@type: ["sport:Event","schema:SportsEvent"]`, `schema:startDate`, `sport:status`, `sport:competition`, `sport:venue` (`@type: sport:Venue`), `sport:competitors` (`sport:qualifier`), plus `live_score`, `round`, `stage`, `provider_ids` | legacy canonical (**producer**, not just consumer) | **1** | Replace body with a call to the canonical API-Football adapter + `canonical_envelope`; keep the `worldcup:event` doc as a persisted projection during transition | high |
+| WCI | `workflows/worldcup-ingest-fixtures.yml` | `api-football get-fixtures` → `mint_event_identity` → `bulk-update` into `'worldcup:event'`; separately crosswalks Sportradar (`get-seasons/{season_id}/schedules.json`), Entain/bwin, Opta into `build_event_crosswalk` | provider-coupled + legacy canonical | **1** | Single ingest that emits one envelope per fixture; crosswalk feeds `provider_ids`, not a side table | high |
+| WCI | `workflows/worldcup-get-iptc-event-context.yml` | `document.search` on `name: 'worldcup:event'`, `value._id` / `value.provider_ids.api_football`, then applies the response mapping | legacy canonical | **1** | Becomes the first caller of `resolve-canonical-event` (§5) | high |
+| WCI | `mappings/worldcup-iptc-event-to-api-response.yml` | Hand-rolled projection: `event_urn`, `provider_ids`, `iptc` (whole doc), `name`, `competition` ← `sport:competition.name`, `start_date` ← `schema:startDate`, `status` ← `sport:status`, `teams` ← `sport:competitors`, `venue` ← `sport:venue` | projection-only | **1** | Delete and serve `event_view` — this mapping *is* an ad-hoc `event_view`, field for field | high |
+| WCI | `workflows/worldcup-match-preview.yml` | `load-event` searches `'worldcup:event'` by `value._id`, passes the raw doc to `worldcup-match-preview` prompt; also `worldcup:model-forecast`, `worldcup:market-cache`, caches to `worldcup:skill-match-preview` | legacy canonical | **1** | **Representative flow for the substitution proof** (§8) | high |
+| WCI | `workflows/worldcup-match-recap.yml`, `prompts/worldcup-match-recap.yml` | Same doc read, recap prompt | legacy canonical | 1 | Migrate with preview | high (generated row) |
+| WCI | `workflows/worldcup-get-schedule.yml`, `worldcup-resolve.yml`, `worldcup-get-event-context.yml`, `worldcup-get-signal.yml`, `worldcup-refresh-live-status.yml`, `worldcup-refresh-prematch-enrichment.yml`, `worldcup-sync-event-crosswalk.yml`, `worldcup-generate-market-brief.yml`, `worldcup-get-player-performance-context.yml`, `worldcup-fan-pulse.yml`, `worldcup-fan-sentiment-context.yml` | `'worldcup:event'` document reads / `sport:*` field reads | legacy canonical | 1 | Migrate behind the seam; **also add to the generated inventory** (Observation 2) | medium |
+| WCI | `workflows/worldcup-get-standings.yml`, `worldcup-get-injuries.yml`, `worldcup-get-squads.yml` | Generated rows; event-adjacent reads | legacy canonical | 2 | Migrate after the event path lands | high (generated rows) |
+| WCI | `workflows/wcbracket-enrich-teams.yml`, `wcbracket-simulate.yml` | Generated rows; bracket sim over event docs | legacy canonical | 2 | Migrate after the event path lands | high (generated rows) |
+| WCI | `workflows/worldcup-sync-market-sources.yml`, `worldcup-sync-model-forecasts.yml`, `worldcup-coverage-gateway.yml` | Generated rows | legacy canonical | 2 | Migrate after the event path lands | high (generated rows) |
+| WCI | `tests/test_worldcup_market_intelligence.py` | Asserts the legacy mint shape | test | 1 | Update in lockstep with `mint_event_identity` | high |
+| WCI | `__pycache__/*.pyc`, `docs/api-contracts.md`, `docs/worldcup-bracket-sim-design.md`, `_folders.yml` | Byte-compiled output and prose that mention the shape | dead / docs-only | — | No code change; refresh docs when the shape changes | high |
+
+### 3.2 Machina Media — priority 2
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| Machina Media (this repo) | `agent-templates/machina-media/mappings/map-normalize-event.yml` | Independent event model: `sport`, `league`, `home_team{name,score}`, `away_team{name,score}`, `score` as the string `"h-a"`, `clock`, `status`, `start_time`, `external_ids`. Self-described "canonical 'event' data model" | **legacy canonical (duplicate model)** | **2** | **Delete the model.** Replace with `event_view`. Do not preserve as a second canonical shape | high |
+| Machina Media | `workflows/sync-sports-state.yml` | Three separate connector pulls — `machina-media-football-data get-matches`, `machina-media-nfl-data get-games`, `machina-media-nba-data get-games` — concatenated and fed to `map-normalize-event` | provider-coupled | **2** | One canonical fan-in; per-sport connectors become adapter inputs below the boundary | high |
+| Machina Media | `workflows/detect-storylines.yml` → `prompts/storyline-detection-prompt.yml` (`- Live Events: {normalized_events}`) | Consumes `normalized_events` directly | projection-only | 2 | Repoint to `event_view`; prompt text needs the field names updated once | high |
+| Machina Media | `workflows/rank-storylines.yml` | Consumes `candidate_storylines`, not events | projection-only (no event coupling) | 4 | No change | high |
+| Machina Media | `workflows/generate-postgame-recap.yml` (`final_event`), `generate-morning-briefing.yml` (`overnight_results`, `todays_schedule`), `generate-live-desk-update.yml` (`live_context`) | Typed as bare `object`; shape supplied by the caller, i.e. the normalized model in practice | projection-only | 2 | Document the input as `event_view` and declare capabilities (§6). Low code delta, real contract delta | high |
+| Machina Media | `mappings/map-normalize-news-item.yml`, `map-normalize-market-signal.yml` | News and market signals, not events | out of scope | — | No change | high |
+| Machina Media | `connectors/machina-media-{football,nfl,nba}-data.{yml,json}` | Provider surfaces | provider-coupled | 2 | Stay, but below the boundary | high |
+| Machina Media | `_install.yml` | Manifest listing the mappings above | — | 2 | Update only when the mapping is removed | high |
+
+### 3.3 Shared in-repo consumers — priority 3
+
+Cited from the generated inventory. Counts are its rows; the characterizations below come
+from reading one or two representative files per group.
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| assistant-tools (9 rows) | `tools/find-upcoming.yml`, `find-odds.yml`, `find-historical.yml`, `event-matcher.yml`; `scripts/event-processor.py`, `event-summarizer.py`, `market-event-matcher.py`, `market-extractor.py`, `message-data-transformer.py` | Document search on `name: 'sport:Event'`, sorted by `value.schema:startDate`, then `iptc-events-summary`. `event-processor.py` reads `schema:startDate`, `sport:competitor(s)`, `sport:homeScore`, `sport:score`, `sport:status` | legacy canonical + projection-only | **3** | Repoint to the seam. **Note the filter coupling**: `value.schema:startDate` and `value.sport:status` are *storage* predicates, so migration needs either a stored canonical projection or an index-compatible alias — this is the hardest part of group 3 | high |
+| IPTC any-selectors / summaries (6 rows) | `iptc-mappings/any-selector/event-selector.yml`, `events-selector.yml`, `events-summary.yml` (`iptc-events-summary`, `iptc-events-summary-statistics`) | Pure readers: `@id`, `name`, `schema:startDate`, `schema:sportName`, `sport:score.{homeScore,awayScore}`, `sport:status`, `sport:venue`, `sport:channels`, `sport:statParticipant`/`sport:statLabel`/`sport:statValue` | **projection-only** | **3** | The single highest-leverage migration in group 3: these are the shared selectors most other surfaces route through. Rewrite against `event_view` once | high |
+| coverage-tools (4 rows) | `mappings/selectors.yml` (`coverage-iptc-events-summary`, `coverage-mapping-search-date-interval`), `scripts/past_events.py`, `tools/find-images.yml`, `tools/soccer/tallysight-widgets.yml` | Same legacy reads plus timezone formatting (BRT/CET) | projection-only | 3 | Repoint to `event_view`; timezone logic is presentation and stays | high |
+| Kalshi matcher / market (5 rows) | `kalshi-market-agent/workflows/event-matcher.yml`, `market-analysis/{consumer,executor}.yml`, `combo-analysis/executor.yml`, `scripts/market-event-matcher.py` | Filters `'sport:Event'` by `value.sport:competition.sport:season.@id`, `value.sport:status: {$nin: [Played, closed, ended, FT]}`, `value.schema:startDate` | legacy canonical | 3 | Same storage-predicate problem as assistant-tools. **The `$nin` status list is a provider-vocabulary leak** (`FT` is API-Football, `closed` is Sportradar) — canonical `status` fixes it | high |
+| chat-completion (1 row) | `workflows/chat-moderator.yml` | Incidental event read | projection-only | 4 | Repoint with group 3 | high (generated row) |
+| Provider connector sync/consumer workflows (36 rows) | `connectors/api-football/**` (9), `stats-perform/**` (9), `sportradar-soccer/**` (8), `sportradar-nfl/**` (4), `sportradar-mlb/**` (3), `sportradar-tennis/**` (2), `american-football/**` (1) | Provider payload → legacy IPTC mapping → document store. These are the **producers** that the 6 in-repo canonical adapters already replace at the library level | provider-coupled | 3 | Route through the corresponding `tools/iptc/canonical/adapters/*` and emit the envelope. **Highest row count and lowest risk per row** — each is a mechanical producer swap once the seam exists | high (generated rows) |
+| Test scaffolds (4 rows) | `iptc-mappings/any-source/custom-event-test.yml`, `iptc-mappings/api-football/event-mapping-test.yml`, `iptc-mappings/sportradar/event-mapping-test.yml`, WCI `tests/test_worldcup_market_intelligence.py` | Exercise the legacy emitters | test | with their subject | Update alongside the mapping they test; never ahead of it | high |
+
+### 3.4 SportsClaw — priority 4
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| `sportsclaw` | `src/tools/sports_query.ts` → `executePythonBridge(input.sport, input.command, input.args, …)`, returns `JSON.stringify(result.data)` | Raw native `sports-skills` payload, passed through untouched | provider-coupled (pass-through) | **4** | Add a canonical event tool that requests canonical mode and **validates the envelope before returning it** | high |
+| `sportsclaw` | `src/bridge.ts` → `buildArgs(sport, command, args)` builds `["-m","sports_skills",sport,command, "--k=v"…]` | Already forwards arbitrary CLI args, so `--format=machina-canonical` / `--observed-at` / `--consumer-tier` are reachable **today with no bridge change** | enabler | 4 | No change needed to `buildArgs` — this is the cheapest part | high |
+| `sportsclaw` | Whole `src/` tree | Canonical-key pattern returns **no** match for `machina_sports_schema`, `event_view`, `sport_schema_graph`, `check_compatibility`. (Hits for the *word* "canonical" are cache keys, entity resolution and guardrail hashing — unrelated.) | **gap** | 4 | SportsClaw does not validate the envelope, does not enforce capabilities or rights, and exposes no stable canonical event tool | high |
+| `sports-skills` (`origin/main` @ `944c14e`) | `src/sports_skills/canonical/_cli.py`: `CANONICAL_FORMAT = "machina-canonical"`, `EVENT_COMMANDS = {("football","get_event_summary"), ("football","get_daily_schedule")}`, `DEFAULT_CONSUMER_TIER = "prototype"`, `_vendored/{capabilities,rights,ids,observation,serialize,vocab}.py` | Canonical mode exists and is byte-vendored from this repo | **canonical already** (producer) | — | Consume it. **Do not copy canonical terms into SportsClaw** — SportsClaw consumes the schema, it does not own it | high |
+
+**Constraint to design around, not around which to design.** `_cli.py` states every
+envelope it emits is `open-public` / `prototype_only`, and the rights gate refuses a
+`production` consumer tier *before* the provider is called. So SportsClaw-over-sports-skills
+can prove canonical **shape and behavior** at prototype tier and can never prove production
+rights. That is the gate working, not a defect (§8).
+
+### 3.5 Machina Sports TV — priority 5
+
+Provider-coupled and high value, but sequenced **after** WCI, Machina Media, shared
+selectors and SportsClaw. Nothing found forces it earlier: it reads the WCI pod's
+`worldcup:event` docs, so it inherits whatever WCI migrates to.
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| `machina-sports-tv` | `agent-templates/machina-sports-tv/mappings/api-football-event-mapping.yml` (`iptc-api-football-event-mapping`) | Its **own** copy of the API-Football → legacy IPTC mapping, `@id: urn:apifootball:sport_event:{id}`, non-official `sport:` IRI, `schema:startDate`, `sport:status`, `sport:competition`/`sport:season` | provider-coupled + legacy canonical | **5** | Replace with the shared canonical adapter; stop maintaining a fork of the mapping | high |
+| `machina-sports-tv` | `mappings/api-football-event-teams-stats.yml`, `mappings/events-summary.yml` | Fork of the shared summary selector, with its own live-vs-full-time score precedence comment | projection-only (forked) | 5 | Collapse into the shared `event_view` selector | high |
+| `machina-sports-tv` | `operator-sink/src/worldcup.ts` → `interface WcLiveMatch`, `mapPodEventDoc(d)` (l. 635), and the sibling mapper at l. ~597 | TypeScript model built straight off legacy keys: `v["sport:status"]`, `v["sport:competitors"]` filtered on `c["sport:qualifier"]`, `v["sport:score"]["sport:liveHomeScore"] ?? ["sport:homeScore"]`, `v["sport:venue"].name`, `v["sport:minutesElapsed"]` | legacy canonical (typed) | 5 | Regenerate the interface from `event_view`; the live/full-time score precedence becomes a canonical `event.score` concern | high |
+| `machina-sports-tv` | `operator-sink/src/football.ts` → `FootballResult`, shells `python -m sports_skills football …` | Native `sports-skills` payload as a *correction* source for missing pod scores | provider-coupled | 5 | Once both sides are canonical this fallback becomes a same-shape merge instead of a second parser | high |
+| `machina-sports-tv` | `workflows/ingest-*.yml` (10 ingest workflows incl. `ingest-sport-events.yml`, `ingest-football-state.yml`), `connectors/api-football.{yml,json}` | Independent API-Football ingest path | provider-coupled | 5 | Adapter swap, same pattern as the in-repo connectors | medium |
+
+### 3.6 Customer-specific — later lane, evidence-gated
+
+**These are not rewritten for purity.** Each row records only coupling that was actually
+found. The lane exists so PR 3 can state what would break, not so PR 3 can change it.
+
+| System / repo | Files / symbols | Current shape / producer | Category | Prio | PR 3 action | Proof |
+|---|---|---|---|---|---|---|
+| `dazn-templates` | 23 code files (`.yml`/`.py`) match the legacy-shape pattern — incl. `agent-templates/dazn-coverage/event-{preview,recap,narration}/workflows/{selector,update,executor}.yml`, `dazn-predictions/workflows/{generate-by-round,auto-settle-checkin,test-player-selection}.yml`, `dazn-predictions/scripts/{format-event-summary,format-prediction-package}.py`, `dazn-coverage/event-preview/scripts/format_slack_messages.py`, plus `docs/examples/sport-event.json` | Legacy `sport:` event reads: run-of-show, predictions, coverage | customer-specific (legacy canonical) | **later lane** | Migration/removal plan only. No code change in PR 3 | medium |
+| `entain-templates` | 17 code files match — incl. `agent-templates/blog-br/soccer-preview/workflows/{dispatch,consumer,preview,stories,reasoning,player}.yml`, `blog-br/tools/soccer/tallysight-widgets.yml`, `entain-predictions/workflows/{predictions-find-upcoming,predictions-forecast}.yml`, `entain-predictions/agents/predictions-scheduler-{nba,nfl,mlb,wc}.yml`, `entain-predictions/scripts/{extract-event-data,extract-team-stats}.py`, `configs/setup-{dev,prd}.yml` | Legacy `sport:` event reads; SportingBOT surfaces | customer-specific (legacy canonical) | later lane | Migration/removal plan only | medium |
+| `SINCH` (Globo World Cup) | `sinch-templates/globo/mappings/worldcup-match.yml` (`worldcup-match`, `worldcup-fixture-resolver`), `workflows/worldcup-postmatch-dispatch.yml`, `workflows/worldcup-chat.yml`, `prompts/worldcup-{postmatch-summary,match-reasoning,match-response,audio-rewriter}.yml` | **Raw API-Football**, not IPTC at all: `event.fixture.{id,status.short,status.elapsed,date,venue.*}`, `event.league.{id,name,season,round}`, `event.teams.{home,away}.{id,name}`, `event.goals.{home,away}`; then `get-fixtures/events` | customer-specific (**provider-coupled**) | later lane | Migration/removal plan only. Note: this is *direct* provider coupling, so it is the customer surface a provider change would break first | high |
+| `sportingbot-web` | Legacy-shape pattern over code: **0 matches**. Provider coupling exists in `lib/types/fixtures.ts`, `lib/api/competition-season.ts`, `components/competition/upcoming-fixtures.tsx`, `app/copa-mundo/wc-teams.ts`, `public/copa-rumo-ao-hexa/lib/api.js`, plus `fan-engagement-agent/connectors/sportradar-nfl-v7.yml` and `agent-templates/nba-grok-chat/connectors/sportradar-nba-v8.yml`. One docs hit: `docs/troubleshooting/preview-parser-fix.md` | customer-specific; the typed surfaces are **frontend**, an explicit non-goal (§11) | later lane | Record only. The two agent-template connectors are the only non-frontend rows | medium |
+| `ADIDAS` | Legacy-shape pattern: **0 matches**. Searched, nothing found | no coupling on current evidence | — | **No PR 3 change** | medium |
+
+### 3.7 Dead / unused / stale — excluded from all counts
+
+| Surface | Why excluded | Proof |
+|---|---|---|
+| `machina-templates-iptc-1.1-foundation`, `machina-templates-iptc-1.1-mappings`, and this worktree | All three share one `.git` common dir with `machina-templates`. They are PR 1 / PR 2 / PR 3 worktrees of **one** repository | `git worktree list` in `machina-templates` |
+| `sportsclaw-pr136`, `sportsclaw-pr137`, `sportsclaw-pr138`, `sportsclaw-v0292` | Registered worktrees of the single `sportsclaw` repo (plus two `prunable` temp worktrees) | `git worktree list` in `sportsclaw` |
+| `sports-skills-machina-schema` | Checkout of the `sports-skills` PR 2 branch, superseded by `origin/main` @ `944c14e` | branch `feat/machina-sports-schema` |
+| `agent-templates/world-cup-intelligence/**/__pycache__/*.pyc` | Byte-compiled output of a file already counted | matched only by content |
+| Generated JS / `.d.ts` / `.js.map` under `sportsclaw` | Build output of already-counted TypeScript | 11 files, none in `src/` |
+| Prose hits — WCI `docs/*.md`, `_folders.yml`, `machina-sports-tv/docs/**`, `.superpowers/**`, `dazn-templates/*.md`, `entain-templates/.claude/**` and `commands/*.md` | Documentation describing the shape, not code reading it | inspected |
+
+**No surface is counted twice.** Cross-repo rows are attributed to the source-of-truth
+repository only.
+
+---
+
+## 4. Core PR 3 migration order
+
+1. **World Cup Intelligence.** Largest single concentration of legacy coupling (14
+   generated rows + 13 uncounted workflows), and the only place that *mints* the obsolete
+   shape in Python (`mint_event_identity`). It also owns the docs that
+   `sportsclaw-machina` and `machina-sports-tv` both read, so migrating it unblocks two
+   downstream systems.
+2. **Machina Media.** A second self-described canonical model. It must be **removed**, not
+   reconciled, and it is small enough (1 mapping, 1 sync workflow, 1 direct consumer) that
+   removing it early prevents anyone building on it during PR 3.
+3. **Shared selectors and summaries.** `iptc-events-summary` and friends, then
+   assistant-tools, coverage-tools, Kalshi, and the 36 provider connector workflows. Highest
+   row count, most mechanical, but blocked on the storage-predicate question (§10).
+4. **SportsClaw.** Consumes the contract. Cheapest code change (the bridge already forwards
+   args) and the clearest statement of the boundary: a consumer that validates and gates but
+   owns nothing.
+5. **Machina Sports TV**, then **proven customer-specific consumers** as a separate,
+   deferred lane.
+
+Ordering rationale: **producers before readers, shared before local, owners before
+consumers.** Nothing in the evidence forces a different order — Machina Sports TV reads
+WCI's output, so it cannot lead; SportsClaw reads `sports-skills`, which is already
+canonical, so it can move at any time and is placed where its proof is most useful.
+
+---
+
+## 5. Shared canonical access seam — requirements
+
+One seam, built first, before any consumer is touched.
+
+1. **A stable resolver.** `resolve-canonical-event` (name provisional) taking
+   `{event_urn | provider + provider_event_id}` and returning the
+   `machina_sports_schema` envelope. Every consumer in §3 reaches canonical data through
+   this and only this. `worldcup-get-iptc-event-context.yml` is its first caller and
+   already has the right signature (`event_urn` / `provider_event_id` / `provider`).
+2. **Envelope validation at the seam, not at each consumer.** Reject anything that is not
+   `schema_version: machina-sports-schema/1` + `profile: machina-iptc-profile/1.1`.
+   RFC 002 §9: `canonical_envelope` raises `ValueError` on an invalid observation, so an
+   envelope that reaches a consumer has already been validated once; the seam must not
+   weaken that by constructing envelopes by hand.
+3. **`event_view` is the default.** Application-facing consumers get `event_view`. This is
+   what almost every row in §3 actually needs — `worldcup-iptc-event-to-api-response.yml`
+   and `iptc-events-summary` are both hand-rolled `event_view`s already.
+4. **`sport_schema_graph` is opt-in.** Requested only by graph/interchange consumers.
+   No consumer in §3 needs it today.
+5. **Capabilities, rights and provenance travel with either path.** They are envelope
+   siblings of `event_view` and `sport_schema_graph`, so serving a projection must not
+   strip them. A projection without its rights block is an unlicensed payload wearing a
+   licensed one's shape.
+6. **Fail closed on required capabilities.** The seam calls
+   `check_compatibility(capabilities, requires=…, optional=…)` with the consumer's own
+   declaration and refuses when `compatible` is false — including on `unknown_capabilities`,
+   which is the whole point of the fails-closed rule in RFC 002 §8.
+7. **Rights gate at the seam.** `rights_findings(envelope, consumer_tier=…)` runs before the
+   consumer sees anything. A `production` consumer served a `prototype_only` envelope is
+   refused, never downgraded.
+8. **No provider field crosses the boundary.** Above the seam there is no `fixture.id`, no
+   `sport:qualifier`, no `FT`/`NS`/`closed` status string. Provider identity survives only
+   as `provider_ids` and `provenance`. The Kalshi `$nin: ['Played','closed','ended','FT']`
+   filter is the current best example of what this rule deletes.
+
+---
+
+## 6. Consumer capability declarations
+
+Using the **existing** dotted names from `ALL_CAPABILITIES` — PR 3 declares, it does not
+extend.
+
+**WCI match preview** — needs the fixture, both sides and a kickoff time; a score is
+optional because a preview runs pre-match; a forecast and market snapshot are separate
+documents, not capabilities.
+
+```yaml
+requires:
+  - event.identity
+  - event.competition
+  - event.participants
+  - event.start_time
+  - event.status
+  - provenance
+optional:
+  - event.score
+  - event.lineups
+```
+
+**Machina Media postgame recap** — a recap is meaningless without a final score and result,
+so those are required, not optional; player statistics and play-by-play enrich it.
+
+```yaml
+requires:
+  - event.identity
+  - event.participants
+  - event.status
+  - event.score
+  - event.result
+  - provenance
+optional:
+  - event.actions
+  - event.play_by_play
+  - participant.player_statistics
+```
+
+Two rules for every other declaration: **`provenance` is always required** (an
+unattributed fact is not usable editorially), and a capability goes in `requires` only if
+the consumer would produce something *wrong* without it — a consumer that would merely
+produce something *thinner* declares it `optional`. Over-declaring `requires` turns the
+fails-closed gate into an outage.
+
+---
+
+## 7. Source-of-truth vs. stale — how double counting was avoided
+
+Every candidate directory was resolved to a repository before being counted:
+`git rev-parse --git-common-dir` for shared worktrees, `git worktree list` for
+registrations, and branch/ref inspection for stale checkouts. The result is §3.7. Four
+`sportsclaw-*` directories, two `machina-templates-iptc-*` directories, this worktree, and
+`sports-skills-machina-schema` collapse to **three** repositories: `sportsclaw`,
+`machina-templates`, `sports-skills`. Generated JS, `.d.ts`, `.map` and `__pycache__`
+artefacts are excluded on the same principle: they are a second copy of a counted source.
+
+---
+
+## 8. Provider substitution acceptance path
+
+**Representative flow: `agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml`.**
+
+Chosen on evidence, not convenience. It is a real production workflow; it reads exactly one
+event document (`load-event`, filtering `name: 'worldcup:event'` on `value._id`); its
+downstream — grounded research, the `worldcup-match-preview` prompt, and the
+`worldcup:skill-match-preview` cache write — never touches a provider field. So the
+provider dependency is concentrated in one task, which is what makes substitution
+demonstrable rather than asserted. The alternative candidates were rejected:
+`worldcup-get-iptc-event-context.yml` is a thin lookup with no downstream to hold constant,
+and `worldcup-match-recap.yml` needs a completed match and therefore a narrower fixture set.
+
+**Acceptance criteria.**
+
+1. **Downstream workflow code is identical across providers.** After the one-time change
+   that repoints `load-event` at the seam, the prompt task, the cache write, the outputs
+   block and the freshness logic are byte-identical for every provider run. The only
+   difference between runs is configuration: which provider the seam resolves.
+2. **Same sanitized fixture, three providers.** One equivalent match resolved via
+   `sports-skills` (ESPN), API-Football, and Sportradar, each through its adapter —
+   `sports_skills.canonical.adapters.football`, `tools/iptc/canonical/adapters/api_football.py`,
+   `tools/iptc/canonical/adapters/sportradar_soccer.py`.
+3. **Configuration-only changes.** Provider selection is a parameter. No task added,
+   removed or reordered; no field path edited per provider.
+4. **Capability report drives behavior, not a provider name.** Where providers differ, the
+   workflow reacts to `capabilities`, never to `provenance.provider`.
+5. **Rights gate observed.** The run records the tier it asked for and what the gate
+   answered.
+
+**What this proves, stated precisely.** The corrected fixtures under
+`tools/iptc/fixtures/corrected/` are synthetic. They prove **substitution of shape and
+behavior**: that three providers produce one envelope a single consumer reads unchanged.
+They do **not** prove live provider parity — no live API is called — and they do **not**
+prove rights. On rights the evidence points the other way and should be reported that way:
+`sports-skills` `_cli.py` documents that every envelope it emits is `open-public` /
+`prototype_only`, and the gate refuses a `production` consumer *before* the provider call.
+So the `sports-skills` leg of the proof is valid at **prototype** tier only. A production-tier
+substitution claim requires the licensed adapters and a live authorized sandbox (§10).
+Saying otherwise would be the exact false conformance claim the rights block exists to stop.
+
+---
+
+## 9. Legacy removal plan — grouping
+
+**Group A — mint and store (blocking).** `mint_event_identity` and
+`worldcup-ingest-fixtures.yml`. Until the producer emits canonical, every reader migration
+is a translation layer. Removal target: the obsolete `@context` binding
+`https://www.sportschema.org/ontologies/sport#` and the hand-built `sport:Venue` /
+`sport:competitors` blocks.
+
+**Group B — duplicate models.** `map-normalize-event.yml` (Machina Media) and
+`iptc-api-football-event-mapping` + `events-summary.yml` (Machina Sports TV's forks).
+Delete, do not reconcile.
+
+**Group C — hand-rolled projections.** `worldcup-iptc-event-to-api-response.yml`,
+`iptc-event-selector`, `iptc-events-summary`, `coverage-iptc-events-summary`,
+`mapPodEventDoc`. Each is an `event_view` someone wrote by hand; each collapses into one.
+
+**Group D — provider producers.** The 36 connector rows. Mechanical adapter swaps, done
+last within the core lane because they are the least risky and benefit from the seam being
+settled.
+
+**Group E — storage predicates.** `value.schema:startDate`, `value.sport:status`,
+`value.sport:competition.sport:season.@id`, `name: 'sport:Event'`,
+`name: 'worldcup:event'`. **Not a code change** — a document-store migration. Sequenced
+explicitly because it is the one item in §9 that can strand a half-migrated system.
+
+### Deferred / customer lane — explicitly out of the core PR 3 sequence
+
+`dazn-templates` (23 files), `entain-templates` (17 files), `SINCH` Globo (7 files),
+`sportingbot-web` (2 non-frontend connector files). This lane produces a **migration and
+removal plan** with per-customer sequencing, not code changes. `ADIDAS` has no entry: the
+search returned nothing, and no PR 3 change is recommended on current evidence.
+`sportsclaw-machina` sits here too — `src/prompt-builder.ts` names legacy `worldcup:event`,
+`value.sport:venue.name`, `value.schema:startDate` and `value.name` in its MCP routing
+guidance, and routes World Cup traffic to pod workflows/documents while sending all other
+sports to native `sports-skills`. It is a **customer/product-specific bridge consumer** of
+the pod contract. It follows WCI's migration; it is not a canonical owner and must not be
+made one.
+
+---
+
+## 10. Open questions and blockers
+
+1. **Full authorized live sandbox import.** Every substitution artefact available today is
+   synthetic. A production-tier parity claim needs an authorized sandbox with real
+   API-Football and Sportradar credentials and an explicit rights decision per provider.
+   **Blocker for §8 criterion 5 at production tier.** Not a blocker for the shape proof.
+2. **Runtime packaging and access for the canonical adapters.** `tools/iptc/canonical/**`
+   is repository tooling. Workflow tasks cannot import `tools.*` — RFC 002 §10 already
+   states the vendoring constraint and `sports-skills` already vendors byte-exact. How the
+   Machina workflow runtime reaches the adapters (a pyscript connector, a vendored package,
+   a service) is **undecided and blocks the seam**, which blocks everything in §4.
+3. **Storage predicates (Group E).** Consumers filter on `value.schema:startDate`,
+   `value.sport:status` and `name: 'sport:Event'` at the document store. Does the stored
+   document become canonical, or does an alias/index layer keep legacy predicates working
+   during migration? Different answers give different migration orders inside group 3.
+4. **`worldcup:event` document name.** WCI's coupling is as much to the *document name* as
+   to field paths. Renaming breaks `sportsclaw-machina` prompt guidance and Machina Sports
+   TV's `mapPodEventDoc` simultaneously. Keep the name and change the value shape, or
+   version the name?
+5. **Canonical coverage of non-event surfaces.** `sports-skills` canonical mode allowlists
+   exactly two commands (`football get_event_summary`, `football get_daily_schedule`).
+   WCI standings, injuries, squads and bracket workflows have no canonical counterpart.
+   Do they stay legacy through PR 3, or does PR 3 scope grow?
+6. **Inventory generator gap (Observation 2).** 13 WCI workflows are legacy-coupled and
+   uncounted. Fixing `tools/iptc/inventory.py` changes the headline 75. Decide whether the
+   "zero known legacy consumer breakages" claim is scoped to 75 or to the corrected number
+   before the claim is made.
+7. **RFC 002 §8 vs. `NOT_EXPRESSIBLE` (Observation 4).** Prose says five, the constant
+   derives four. Cosmetic, but consumers read the RFC to author `requires`.
+
+---
+
+## 11. Explicit non-goals
+
+PR 3 does **not**:
+
+- change the canonical schema, its terms, its capability names, its envelope, or the
+  rights model — the canonical layer is frozen per Design Log #027, except bugs and
+  standards/provider corrections;
+- touch Sports Moment, Experience, or Coach Mode;
+- rewrite customer repositories for purity — `dazn-templates`, `entain-templates`,
+  `SINCH`, `sportingbot-web` and `sportsclaw-machina` get a plan, not a refactor;
+- change any frontend;
+- introduce a graph database, or make `sport_schema_graph` a default output;
+- make SportsClaw or any other consumer an owner of canonical terms;
+- assert live provider parity or production rights from synthetic fixtures.

--- a/docs/iptc/consumer-review.json
+++ b/docs/iptc/consumer-review.json
@@ -1,0 +1,2576 @@
+{
+  "schema": "machina.iptc.consumer-review/v1",
+  "version": "1",
+  "entries": [
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/_folders.yml",
+      "category": "document-name",
+      "literal": "season:Schedule",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `season:Schedule` at agent-templates/assistant-tools/_folders.yml:144. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/_folders.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/_folders.yml:122. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/_folders.yml",
+      "category": "document-name",
+      "literal": "sport:Team",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:Team` at agent-templates/assistant-tools/_folders.yml:133. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/scripts/event-processor.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors`, `sport:homeScore`, \u2026 (6 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/scripts/event-summarizer.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:awayScore`, `sport:channelName`, `sport:channels`, \u2026 (11 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/scripts/market-event-matcher.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/scripts/market-extractor.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `sport:competitor`, `sport:competitors` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/scripts/message-data-transformer.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:awayScore`, `sport:channelName`, `sport:channels`, \u2026 (18 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/tools/event-matcher.yml:88. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:season`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/assistant-tools/tools/event-matcher.yml:77, 82. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at agent-templates/assistant-tools/tools/event-matcher.yml:79. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/assistant-tools/tools/event-matcher.yml:81. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/tools/find-historical.yml:93, 153. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/assistant-tools/tools/find-historical.yml:77, 87, 137, \u2026 (4 findings). PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/assistant-tools/tools/find-historical.yml:86, 146. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/tools/find-odds.yml:52, 72, 94. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/assistant-tools/tools/find-odds.yml:50, 70, 92. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/assistant-tools/tools/find-odds.yml:55, 73, 95. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/tools/find-upcoming.yml:92. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/assistant-tools/tools/find-upcoming.yml:77, 86. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/assistant-tools/workflows/chat-reasoning.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/assistant-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/assistant-tools/workflows/chat-reasoning.yml:85. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/chat-completion",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/chat-completion/workflows/chat-moderator.yml:64, 117, 177. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/chat-completion",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/chat-completion",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events`, `sport-schema-event`, `sport_schema_event` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/chat-completion",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/chat-completion/workflows/chat-moderator.yml:67. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/chat-completion/workflows/event-search.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/chat-completion",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/chat-completion/workflows/event-search.yml:39. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/mappings/selectors.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:awayScore`, `sport:competition`, \u2026 (11 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/mappings/selectors.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/scripts/past_events.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:awayScore`, `sport:competition`, \u2026 (13 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/tools/find-images.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/tools/soccer/preview-boxes.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/coverage-tools/tools/soccer/preview-boxes.yml:38. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/coverage-tools/tools/soccer/tallysight-widgets.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/coverage-tools",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:competitor`, `sport:competitors` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-selector/event-selector.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:score` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-selector/events-selector.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:score` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-selector/events-selector.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-selector/events-summary.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:actionType`, `sport:awayScore`, \u2026 (23 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-selector/events-summary.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-source/custom-event-mapping.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-custom-event-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-source/custom-event-test.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/iptc-mappings/any-source/custom-event-test.yml:67. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/any-source/custom-event-test.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport-schema-event`, `sport_schema_event` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/api-football/event-mapping-test.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport-schema-event`, `sport_schema_event` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/api-football/event-mapping.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-api-football-event-mapping`, `iptc-api-football-events-mapping`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/api-football/event-players-stats.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-api-football-event-players-stats`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/api-football/event-teams-stats.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-api-football-event-teams-stats`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/sportradar-tennis/event-mapping.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-tennis-event-hierarchy-mapping`, `iptc-sportradar-tennis-event-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/sportradar/event-mapping-test.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport-schema-event`, `sport_schema_event` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/sportradar/event-players-stats.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-event-players-stats`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/iptc-mappings/sportradar/event-teams-stats.yml",
+      "category": "emitter",
+      "owner": "machina-templates:agent-templates/iptc-mappings",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-event-teams-stats`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/_folders.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/kalshi-market-agent/_folders.yml:56. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/scripts/market-event-matcher.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml:35. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:status` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml:30. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml:32. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml:33. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/kalshi-market-agent/workflows/event-matcher.yml:81. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:season`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/kalshi-market-agent/workflows/event-matcher.yml:71, 75. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at agent-templates/kalshi-market-agent/workflows/event-matcher.yml:73. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/kalshi-market-agent/workflows/event-matcher.yml:74. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml:31, 57. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:competition`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml:51. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml:53. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml:59. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml:54. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competitors",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competitors` at agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml:56. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:agent-templates/kalshi-market-agent",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml:57. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/_folders.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/_folders.yml:34. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/_folders.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/_folders.yml:45. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/_folders.yml",
+      "category": "document-name",
+      "literal": "worldcup:social-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:social-cache` at agent-templates/world-cup-intelligence/_folders.yml:56. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/mappings/worldcup-iptc-event-to-api-response.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:competitor`, `sport:competitors`, \u2026 (6 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/prompts/worldcup-match-recap.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:status` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=test].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:competitor`, `sport:competitors`, \u2026 (8 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements). PR3-CONSUMER-INVENTORY.md \u00a73.1/\u00a73.3: a test scaffold migrates in lockstep with the subject it exercises, never ahead of it."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "category": "document-name",
+      "literal": "worldcup:bracket-simulation",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:bracket-simulation` at agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml:34. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml:52. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "category": "document-name",
+      "literal": "worldcup:team-adjustment",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:team-adjustment` at agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml:93. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:competitor`, `sport:competitors`, `sport:qualifier` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-get-bracket.yml",
+      "category": "document-name",
+      "literal": "worldcup:bracket-simulation",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:bracket-simulation` at agent-templates/world-cup-intelligence/workflows/wcbracket-get-bracket.yml:26. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "document-name",
+      "literal": "worldcup:bracket-simulation",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:bracket-simulation` at agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml:211. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml:89. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "document-name",
+      "literal": "worldcup:fifa-ranking",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:fifa-ranking` at agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml:59. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml:120. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "document-name",
+      "literal": "worldcup:team-adjustment",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:team-adjustment` at agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml:149. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors`, `sport:qualifier`, \u2026 (5 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:clv-report",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:clv-report` at agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml:190. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:forecast-audit",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:forecast-audit` at agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml:77, 106. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-snapshot",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-snapshot` at agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml:135. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml:51. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:signal-ledger",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:signal-ledger` at agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml:122, 162. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml:30. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml:31. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:status` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-explain-market-move.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-explain-market-move.yml:37. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml:48, 96. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "category": "document-name",
+      "literal": "worldcup:skill-fan-pulse",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:skill-fan-pulse` at agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml:79, 175. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml:30. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml",
+      "category": "document-name",
+      "literal": "worldcup:social-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:social-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml:120. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml:31. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml:57. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml:32. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml:45. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml:34, 66. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml:29. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml:48. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors`, `sport:qualifier` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml:26. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-market-state.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-get-market-state.yml:43, 214. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml:51. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml:36. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml:30. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-schedule.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-schedule.yml:28. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml:46. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml:92. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml:77. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml:29. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml:47. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:competitor`, `sport:competitors`, `sport:qualifier` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml:29. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml:56, 172. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml:83. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_events`, `sport_schema_event`, `sport_schema_events` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml:41. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml:29. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "category": "document-name",
+      "literal": "worldcup:signal-ledger",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:signal-ledger` at agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml:53, 80. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml:28. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-snapshot",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-snapshot` at agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml:40. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml:46. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-snapshot",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-snapshot` at agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml:60. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml:75. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "category": "document-name",
+      "literal": "worldcup:skill-market-watch",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:skill-market-watch` at agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml:31, 135. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml:41, 87. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml:117. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml:102. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "category": "document-name",
+      "literal": "worldcup:skill-match-preview",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:skill-match-preview` at agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml:72, 167. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml:39, 85. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml:101. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "category": "document-name",
+      "literal": "worldcup:skill-match-recap",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:skill-match-recap` at agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml:70, 150. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:status` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml:38, 84. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "category": "document-name",
+      "literal": "worldcup:skill-player-spotlight",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:skill-player-spotlight` at agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml:69, 132. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml:44, 81. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml:28, 92. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml:32. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml:32. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-search-markets.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-search-markets.yml:38. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml",
+      "category": "document-name",
+      "literal": "worldcup:fifa-ranking",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:fifa-ranking` at agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml:92. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml:32. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml:39. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-snapshot",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-snapshot` at agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml:51. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml:51, 137. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml:38. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-identity-crosswalk.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-identity-crosswalk.yml:37. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml:84. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml:197. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-cache",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-cache` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml:224. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "category": "document-name",
+      "literal": "worldcup:market-snapshot",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:market-snapshot` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml:250. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competitor`, `sport:competitors` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:event",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `worldcup:event` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml:72. PR 3 architecture: WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` document name, so this document-name dependency is preserved rather than migrated (plan Architecture; PR3-CONSUMER-INVENTORY.md \u00a710.4)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:fifa-ranking",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:fifa-ranking` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml:46. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "category": "document-name",
+      "literal": "worldcup:model-forecast",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:model-forecast` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml:97. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:status` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml:36, 49, 184. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml",
+      "category": "document-name",
+      "literal": "worldcup:identity-crosswalk",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "no-change",
+      "evidence": "inventory.json couplings: document-name `worldcup:identity-crosswalk` at agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml:151. PR3-CONSUMER-INVENTORY.md \u00a73.1: a world-cup-intelligence side document (cache / ledger / crosswalk / skill output), not the event document. PR 3 changes the event envelope only, so this document name is unaffected."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/worldcup-market-intelligence.py",
+      "category": "field-path-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:competitor`, `sport:competitors`, \u2026 (8 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "agent-templates/world-cup-intelligence/worldcup-market-intelligence.py",
+      "category": "payload-key-read",
+      "owner": "machina-templates:agent-templates/world-cup-intelligence",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=script].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/american-football/mappings/iptc-american-football-event-mapping.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/american-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-american-football-event-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/american-football/workflows/sync-games.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/american-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/american-football/workflows/sync-games.yml:86. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/american-football/workflows/sync-games.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/american-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-events.yml",
+      "category": "document-name",
+      "literal": "sport:Action",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:Action` at connectors/api-football/sync-fixtures-events.yml:79. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-events.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:label` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-events.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_events`, `iptc_schema_events`, `iptc_schema_ids` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-players-statistics.yml",
+      "category": "document-name",
+      "literal": "sport:IndividualParticipation",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:IndividualParticipation` at connectors/api-football/sync-fixtures-players-statistics.yml:77. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-players-statistics.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_players`, `iptc_players_statistics`, `iptc_schema_events`, `iptc_schema_ids` (4 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-teams-statistics.yml",
+      "category": "document-name",
+      "literal": "sport:TeamParticipation",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:TeamParticipation` at connectors/api-football/sync-fixtures-teams-statistics.yml:77. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-teams-statistics.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:participation`, `sport:participationBy` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures-teams-statistics.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_schema_events`, `iptc_schema_ids`, `iptc_teams`, `iptc_teams_statistics` (4 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/api-football/sync-fixtures.yml:86. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/sync-fixtures.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-live.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/api-football/workflows/event-consumer-live.yml:34, 68, 93. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-live.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:status` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/api-football/workflows/event-consumer-live.yml:32, 66, 69. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/api-football/workflows/event-consumer-live.yml:74. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/api-football/workflows/event-consumer-live.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/api-football/workflows/event-consumer-prelive.yml:34, 68. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:status` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/api-football/workflows/event-consumer-prelive.yml:32, 66, 69. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/api-football/workflows/event-consumer-prelive.yml:74. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/api-football/workflows/event-consumer-prelive.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-sync-markets.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-sync-markets.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_schema_events` (1 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-sync-markets.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/api-football/workflows/event-sync-markets.yml:30. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-synchronize.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-synchronize.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_schema_events`, `sport_schema_event`, `sport_schema_events` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-synchronize.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/api-football/workflows/event-synchronize.yml:30. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-update.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/api-football/workflows/event-update.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/api-football",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/api-football/workflows/event-update.yml:31. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/mappings/iptc-sport-event.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-event-mlb-mapping`; sport namespace None (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-games.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-mlb/sync-games.yml:91, 132. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-games.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `sport:competition`, `sport:homeScore`, `sport:score`, \u2026 (5 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-games.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-pitchers.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-mlb/sync-pitchers.yml:115. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-pitchers.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:score`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-results.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-mlb/sync-results.yml:63. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-mlb/sync-results.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-mlb",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:awayScore`, `sport:homeScore`, `sport:matchStatus`, `sport:score`, \u2026 (5 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/mappings/iptc-sport-event.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-event-nfl-mapping`, `iptc-sportradar-event-update-mapping`, `iptc-sportradar-events-statistics-mapping`, `iptc-sportradar-events-timeline-mapping`, `iptc-sportradar-game-statistics-mapping`, `iptc-sportradar-player-statistics-mapping`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/sync-games.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-nfl/sync-games.yml:93, 130. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/sync-games.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `sport:abbreviation`, `sport:competition`, `sport:competitor`, \u2026 (6 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/sync-games.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-nfl/workflows/event-consumer-live.yml:35, 69, 95. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:competition`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:sportName",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:sportName` at connectors/sportradar-nfl/workflows/event-consumer-live.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-nfl/workflows/event-consumer-live.yml:67, 72. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/sportradar-nfl/workflows/event-consumer-live.yml:76. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/sportradar-nfl/workflows/event-consumer-live.yml:71. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-nfl/workflows/event-consumer-prelive.yml:35, 69. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `schema:startDate`, `sport:competition`, `sport:status` (4 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:sportName",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:sportName` at connectors/sportradar-nfl/workflows/event-consumer-prelive.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-nfl/workflows/event-consumer-prelive.yml:67, 71. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/sportradar-nfl/workflows/event-consumer-prelive.yml:76. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/sportradar-nfl/workflows/event-consumer-prelive.yml:72. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-nfl/workflows/event-sync-timeline.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-nfl",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_game_statistics`, `iptc_player_statistics`, `iptc_schema_events` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/mappings/iptc-sport-event.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-event-mapping`, `iptc-sportradar-events-statistics-mapping`, `iptc-sportradar-events-timeline-mapping`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/mappings/iptc-team.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-team-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-soccer/workflows/event-consumer-live.yml:34, 68, 93. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:status` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-soccer/workflows/event-consumer-live.yml:66, 69. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/sportradar-soccer/workflows/event-consumer-live.yml:74. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/sportradar-soccer/workflows/event-consumer-live.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-soccer/workflows/event-consumer-prelive.yml:34, 68. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:status` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-soccer/workflows/event-consumer-prelive.yml:66, 69. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/sportradar-soccer/workflows/event-consumer-prelive.yml:74. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/sportradar-soccer/workflows/event-consumer-prelive.yml:70. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-soccer/workflows/event-consumer.yml:34, 53, 76, \u2026 (6 findings). PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-soccer/workflows/event-consumer.yml:54, 77, 100, \u2026 (4 findings). PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/sportradar-soccer/workflows/event-consumer.yml:55, 78, 101, \u2026 (4 findings). PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/event-synchronize.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_events`, `iptc_events_statistics`, `iptc_events_timeline`, `iptc_schema_events`, `sport_schema_event`, `sport_schema_events` (6 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-soccer/workflows/load-round-events.yml:30. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition`, `sport:round` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/sportradar-soccer/workflows/load-round-events.yml:28. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:competition",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:competition` at connectors/sportradar-soccer/workflows/load-round-events.yml:32. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:round",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:round` at connectors/sportradar-soccer/workflows/load-round-events.yml:31. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-competitors.yml",
+      "category": "document-name",
+      "literal": "sport:Team",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:Team` at connectors/sportradar-soccer/workflows/sync-competitors.yml:100. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-competitors.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_teams`, `sport_schema_teams` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-events-stats.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_events`, `iptc_match_statistics`, `iptc_players`, `iptc_players_statistics`, `iptc_schema_events`, `iptc_schema_ids`, `iptc_teams`, `iptc_teams_statistics` (8 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-schedules.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-soccer/workflows/sync-schedules.yml:66, 90. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-schedules.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `sport:competition` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-schedules.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-soccer/workflows/sync-season-schedules.yml",
+      "category": "document-name",
+      "literal": "season:Schedule",
+      "owner": "machina-templates:connectors/sportradar-soccer",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `season:Schedule` at connectors/sportradar-soccer/workflows/sync-season-schedules.yml:63, 87. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-tennis/mappings/iptc-event-mapping.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/sportradar-tennis",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-sportradar-tennis-event-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-tennis/workflows/sync-season-info.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-tennis",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-tennis/workflows/sync-season-info.yml:77. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-tennis/workflows/sync-season-info.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/sportradar-tennis",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:competition`, `sport:season`, `sport:venue` (3 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-tennis/workflows/sync-season-summaries.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/sportradar-tennis",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/sportradar-tennis/workflows/sync-season-summaries.yml:59. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/sportradar-tennis/workflows/sync-season-summaries.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/sportradar-tennis",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc-events`, `sport_schema_event`, `sport_schema_events` (3 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/mappings/iptc-player.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-opta-player-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/mappings/iptc-sport-event.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-opta-event-mapping`; sport namespace https://sportschema.org/ontologies/main/ (official=True). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/mappings/iptc-team.yml",
+      "category": "emitter",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json emitters: mapping(s) `iptc-opta-team-mapping`; sport namespace https://www.sportschema.org/ontologies/sport# (official=False). PR3-CONSUMER-INVENTORY.md \u00a79 groups B/D: legacy emitters are replaced by `tools/iptc/canonical/adapters/*` emitting the canonical envelope."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml:32, 51, 74. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml:30, 49, 52, \u2026 (4 findings). PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml:53. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml:32, 51. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml:30, 49, 52. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml:53. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-sync-markets.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-sync-markets.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sp-opta-event-sync-markets.yml:31. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-synchronize.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:competition` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-synchronize.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-synchronize.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sp-opta-event-synchronize.yml:29. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-update.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sp-opta-event-update.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sp-opta-event-update.yml:29. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-players.yml",
+      "category": "document-name",
+      "literal": "sport:Player",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:Player` at connectors/stats-perform/workflows/sync-players.yml:127, 146. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-players.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `sport:competition`, `sport:season` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-players.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_players`, `sport_schema_players` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-schedules.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/stats-perform/workflows/sync-schedules.yml:88, 112. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-schedules.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName`, `sport:competition` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-schedules.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-teams.yml",
+      "category": "document-name",
+      "literal": "sport:Team",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "excluded",
+      "evidence": "inventory.json couplings: document-name `sport:Team` at connectors/stats-perform/workflows/sync-teams.yml:72, 96. PR3-CONSUMER-INVENTORY.md \u00a710.5 (open): canonical coverage of non-event surfaces is undecided, so no PR 3 disposition can be assigned to a non-event entity document name without inventing scope. Excluded with the owning surface recorded, to be re-reviewed when \u00a710.5 closes."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-teams.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:sportName` (1 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-teams.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `iptc_teams`, `sport_schema_teams` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "category": "document-name",
+      "literal": "sport:Event",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: document-name `sport:Event` at connectors/stats-perform/workflows/sync-update-live.yml:40, 68. PR3-CONSUMER-INVENTORY.md \u00a79 group E lists `name: 'sport:Event'` as a document-store concern preserved by an alias/index layer, not a consumer code change."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "category": "field-path-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_field_paths = `schema:startDate`, `sport:status` (2 paths). PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "category": "payload-key-read",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "migrate",
+      "evidence": "inventory.json consumers[kind=workflow-or-mapping].reads_payload_keys = `sport_schema_event`, `sport_schema_events` (2 keys) \u2014 legacy IPTC payload passed between workflow tasks. PR 3 action: repoint at the shared canonical seam and read `event_view` (PR3-CONSUMER-INVENTORY.md \u00a74 migration order, \u00a75 seam requirements)."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.schema:startDate",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.schema:startDate` at connectors/stats-perform/workflows/sync-update-live.yml:36, 63. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    },
+    {
+      "repo": "machina-templates",
+      "path": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "category": "storage-predicate",
+      "literal": "value.sport:status",
+      "owner": "machina-templates:connectors/stats-perform",
+      "disposition": "compat-alias",
+      "evidence": "inventory.json couplings: storage-predicate `value.sport:status` at connectors/stats-perform/workflows/sync-update-live.yml:62. PR3-CONSUMER-INVENTORY.md \u00a79 group E and \u00a710.3: a storage predicate binds the persisted document shape, and is preserved by an exact-path derived compatibility alias at the same path \u2014 a document-store migration, not a consumer edit. Task 1 evidence amendment: the surfaces welded to the persisted event shape are the provider connector workflows, so this row is owned here and not by world-cup-intelligence."
+    }
+  ]
+}

--- a/docs/iptc/inventory.json
+++ b/docs/iptc/inventory.json
@@ -882,6 +882,1884 @@
       ]
     }
   ],
+  "couplings": [
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/_folders.yml",
+      "line": 122,
+      "literal": "sport:Event",
+      "snippet": "\"name\": [\"sport:Event\"]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/_folders.yml",
+      "line": 133,
+      "literal": "sport:Team",
+      "snippet": "\"name\": [\"sport:Team\"]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/_folders.yml",
+      "line": 144,
+      "literal": "season:Schedule",
+      "snippet": "\"name\": [\"season:Schedule\"]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "line": 77,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "line": 79,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: $.get('externalCompetitionId')"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "line": 81,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$nin': ['Played', 'closed', 'ended']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "line": 82,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/event-matcher.yml",
+      "line": 88,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 77,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", -1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 86,
+      "path": "value.sport:status",
+      "snippet": "\"value.sport:status\": \"{'$in': ['Played', 'closed', 'ended']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 87,
+      "path": "value.schema:startDate",
+      "snippet": "\"value.schema:startDate\": |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 93,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 137,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", -1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 146,
+      "path": "value.sport:status",
+      "snippet": "\"value.sport:status\": \"{'$in': ['Played', 'closed', 'ended']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 147,
+      "path": "value.schema:startDate",
+      "snippet": "\"value.schema:startDate\": |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-historical.yml",
+      "line": 153,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 50,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 52,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 55,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$ne': 'closed'}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 70,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", -1]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 72,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 73,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$ne': 'closed'}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 92,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 94,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-odds.yml",
+      "line": 95,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$ne': 'closed'}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "line": 77,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "line": 86,
+      "path": "value.schema:startDate",
+      "snippet": "\"value.schema:startDate\": |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/tools/find-upcoming.yml",
+      "line": 92,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/assistant-tools/workflows/chat-reasoning.yml",
+      "line": 85,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "line": 64,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "line": 67,
+      "path": "value.schema:startDate",
+      "snippet": "\"value.schema:startDate\": |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "line": 117,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/chat-completion/workflows/chat-moderator.yml",
+      "line": 177,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/chat-completion/workflows/event-search.yml",
+      "line": 39,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/coverage-tools/tools/soccer/preview-boxes.yml",
+      "line": 38,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/iptc-mappings/any-source/custom-event-test.yml",
+      "line": 67,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/_folders.yml",
+      "line": 56,
+      "literal": "sport:Event",
+      "snippet": "\"name\": [\"sport:Event\"]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "line": 30,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "line": 32,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: \"{'$in': [$.get('seasonId')]}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "line": 33,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['NS']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/workflows/combo-analysis/executor.yml",
+      "line": 35,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "line": 71,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "line": 73,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.sport:season.@id: $.get('seasonId')"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "line": 74,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$nin': ['Played', 'closed', 'ended', 'FT']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "line": 75,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: |"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/workflows/event-matcher.yml",
+      "line": 81,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "line": 31,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "line": 51,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=60)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=60)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "line": 53,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/consumer.yml",
+      "line": 57,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "line": 54,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", -1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "line": 56,
+      "path": "value.sport:competitors",
+      "snippet": "value.sport:competitors.@id: \"{'$in': $.get('event_competititors')}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "line": 57,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['closed', 'ended', 'FT']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/kalshi-market-agent/workflows/market-analysis/executor.yml",
+      "line": 59,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/_folders.yml",
+      "line": 34,
+      "literal": "worldcup:event",
+      "snippet": "\"name\": [\"worldcup:event\"]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/_folders.yml",
+      "line": 45,
+      "literal": "worldcup:market-cache",
+      "snippet": "\"name\": [\"worldcup:market-cache\"]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/_folders.yml",
+      "line": 56,
+      "literal": "worldcup:social-cache",
+      "snippet": "\"name\": [\"worldcup:social-cache\"]"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "line": 34,
+      "literal": "worldcup:bracket-simulation",
+      "snippet": "name: \"'worldcup:bracket-simulation'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "line": 52,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-enrich-teams.yml",
+      "line": 93,
+      "literal": "worldcup:team-adjustment",
+      "snippet": "document_name: \"'worldcup:team-adjustment'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-get-bracket.yml",
+      "line": 26,
+      "literal": "worldcup:bracket-simulation",
+      "snippet": "name: \"'worldcup:bracket-simulation'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "line": 59,
+      "literal": "worldcup:fifa-ranking",
+      "snippet": "name: \"'worldcup:fifa-ranking'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "line": 89,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "line": 120,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "line": 149,
+      "literal": "worldcup:team-adjustment",
+      "snippet": "name: \"'worldcup:team-adjustment'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/wcbracket-simulate.yml",
+      "line": 211,
+      "literal": "worldcup:bracket-simulation",
+      "snippet": "name: \"'worldcup:bracket-simulation'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 51,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 77,
+      "literal": "worldcup:forecast-audit",
+      "snippet": "document_name: \"'worldcup:forecast-audit'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 106,
+      "literal": "worldcup:forecast-audit",
+      "snippet": "document_name: \"'worldcup:forecast-audit'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 122,
+      "literal": "worldcup:signal-ledger",
+      "snippet": "name: \"'worldcup:signal-ledger'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 135,
+      "literal": "worldcup:market-snapshot",
+      "snippet": "name: \"'worldcup:market-snapshot'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 162,
+      "literal": "worldcup:signal-ledger",
+      "snippet": "document_name: \"'worldcup:signal-ledger'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-backtest-forecasts.yml",
+      "line": 190,
+      "literal": "worldcup:clv-report",
+      "snippet": "document_name: \"'worldcup:clv-report'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-compare-market-sources.yml",
+      "line": 30,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-coverage-gateway.yml",
+      "line": 31,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-explain-market-move.yml",
+      "line": 37,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "line": 48,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "line": 79,
+      "literal": "worldcup:skill-fan-pulse",
+      "snippet": "name: \"'worldcup:skill-fan-pulse'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "line": 96,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-pulse.yml",
+      "line": 175,
+      "literal": "worldcup:skill-fan-pulse",
+      "snippet": "document_name: \"'worldcup:skill-fan-pulse'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml",
+      "line": 30,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-fan-sentiment-context.yml",
+      "line": 120,
+      "literal": "worldcup:social-cache",
+      "snippet": "name: \"'worldcup:social-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml",
+      "line": 31,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-find-market-edges.yml",
+      "line": 57,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml",
+      "line": 32,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-generate-market-brief.yml",
+      "line": 45,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml",
+      "line": 34,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-event-context.yml",
+      "line": 66,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml",
+      "line": 29,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-injuries.yml",
+      "line": 48,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml",
+      "line": 26,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-market-state.yml",
+      "line": 43,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-market-state.yml",
+      "line": 214,
+      "literal": "worldcup:market-cache",
+      "snippet": "document_name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml",
+      "line": 36,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-match-forecast.yml",
+      "line": 51,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-player-performance-context.yml",
+      "line": 30,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-schedule.yml",
+      "line": 28,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "line": 46,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "line": 77,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-signal.yml",
+      "line": 92,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml",
+      "line": 29,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-squads.yml",
+      "line": 47,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-get-standings.yml",
+      "line": 29,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "line": 56,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "line": 83,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml",
+      "line": 172,
+      "literal": "worldcup:event",
+      "snippet": "document_name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "line": 29,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "line": 41,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "line": 53,
+      "literal": "worldcup:signal-ledger",
+      "snippet": "name: \"'worldcup:signal-ledger'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-log-signals.yml",
+      "line": 80,
+      "literal": "worldcup:signal-ledger",
+      "snippet": "document_name: \"'worldcup:signal-ledger'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml",
+      "line": 28,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-movers.yml",
+      "line": 40,
+      "literal": "worldcup:market-snapshot",
+      "snippet": "name: \"'worldcup:market-snapshot'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "line": 31,
+      "literal": "worldcup:skill-market-watch",
+      "snippet": "name: \"'worldcup:skill-market-watch'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "line": 46,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "line": 60,
+      "literal": "worldcup:market-snapshot",
+      "snippet": "name: \"'worldcup:market-snapshot'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "line": 75,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-market-watch.yml",
+      "line": 135,
+      "literal": "worldcup:skill-market-watch",
+      "snippet": "document_name: \"'worldcup:skill-market-watch'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 41,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 72,
+      "literal": "worldcup:skill-match-preview",
+      "snippet": "name: \"'worldcup:skill-match-preview'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 87,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 102,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 117,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml",
+      "line": 167,
+      "literal": "worldcup:skill-match-preview",
+      "snippet": "document_name: \"'worldcup:skill-match-preview'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "line": 39,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "line": 70,
+      "literal": "worldcup:skill-match-recap",
+      "snippet": "name: \"'worldcup:skill-match-recap'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "line": 85,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "line": 101,
+      "literal": "worldcup:model-forecast",
+      "snippet": "name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-match-recap.yml",
+      "line": 150,
+      "literal": "worldcup:skill-match-recap",
+      "snippet": "document_name: \"'worldcup:skill-match-recap'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "line": 38,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "line": 69,
+      "literal": "worldcup:skill-player-spotlight",
+      "snippet": "name: \"'worldcup:skill-player-spotlight'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "line": 84,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-player-spotlight.yml",
+      "line": 132,
+      "literal": "worldcup:skill-player-spotlight",
+      "snippet": "document_name: \"'worldcup:skill-player-spotlight'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml",
+      "line": 44,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-live-status.yml",
+      "line": 81,
+      "literal": "worldcup:event",
+      "snippet": "document_name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml",
+      "line": 28,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-refresh-prematch-enrichment.yml",
+      "line": 92,
+      "literal": "worldcup:event",
+      "snippet": "document_name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml",
+      "line": 32,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: {\"$in\": [\"worldcup:identity-crosswalk\", \"worldcup:event\"]}"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-resolve.yml",
+      "line": 32,
+      "literal": "worldcup:event",
+      "snippet": "name: {\"$in\": [\"worldcup:identity-crosswalk\", \"worldcup:event\"]}"
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-search-markets.yml",
+      "line": 38,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml",
+      "line": 32,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-seed-fifa-ranking.yml",
+      "line": 92,
+      "literal": "worldcup:fifa-ranking",
+      "snippet": "document_name: \"'worldcup:fifa-ranking'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml",
+      "line": 39,
+      "literal": "worldcup:market-cache",
+      "snippet": "name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-stable-markets.yml",
+      "line": 51,
+      "literal": "worldcup:market-snapshot",
+      "snippet": "name: \"'worldcup:market-snapshot'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml",
+      "line": 38,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml",
+      "line": 51,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-event-crosswalk.yml",
+      "line": 137,
+      "literal": "worldcup:event",
+      "snippet": "document_name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-identity-crosswalk.yml",
+      "line": 37,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "document_name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "line": 84,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "line": 197,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "line": 224,
+      "literal": "worldcup:market-cache",
+      "snippet": "document_name: \"'worldcup:market-cache'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-market-sources.yml",
+      "line": 250,
+      "literal": "worldcup:market-snapshot",
+      "snippet": "document_name: \"'worldcup:market-snapshot'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "line": 46,
+      "literal": "worldcup:fifa-ranking",
+      "snippet": "name: \"'worldcup:fifa-ranking'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "line": 72,
+      "literal": "worldcup:event",
+      "snippet": "name: \"'worldcup:event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-model-forecasts.yml",
+      "line": 97,
+      "literal": "worldcup:model-forecast",
+      "snippet": "document_name: \"'worldcup:model-forecast'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml",
+      "line": 36,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml",
+      "line": 49,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-player-crosswalk.yml",
+      "line": 184,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "document_name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "agent-templates/world-cup-intelligence/workflows/worldcup-sync-team-crosswalk.yml",
+      "line": 151,
+      "literal": "worldcup:identity-crosswalk",
+      "snippet": "document_name: \"'worldcup:identity-crosswalk'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/american-football/workflows/sync-games.yml",
+      "line": 86,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/sync-fixtures-events.yml",
+      "line": 79,
+      "literal": "sport:Action",
+      "snippet": "document_name: \"'sport:Action'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/sync-fixtures-players-statistics.yml",
+      "line": 77,
+      "literal": "sport:IndividualParticipation",
+      "snippet": "document_name: \"'sport:IndividualParticipation'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/sync-fixtures-teams-statistics.yml",
+      "line": 77,
+      "literal": "sport:TeamParticipation",
+      "snippet": "document_name: \"'sport:TeamParticipation'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/sync-fixtures.yml",
+      "line": 86,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 32,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 34,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 66,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 68,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 69,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=6)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=6)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 70,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['1H', 'HT', '2H', 'ET', 'BT', 'P', 'SUSP', 'INT', 'LIVE', 'live']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 74,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/workflows/event-consumer-live.yml",
+      "line": 93,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 32,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 34,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 66,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 68,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 69,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=24)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=240)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 70,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['NS', 'TBD', 'not_started']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-consumer-prelive.yml",
+      "line": 74,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-sync-markets.yml",
+      "line": 30,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-synchronize.yml",
+      "line": 30,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/api-football/workflows/event-update.yml",
+      "line": 31,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-mlb/sync-games.yml",
+      "line": 91,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-mlb/sync-games.yml",
+      "line": 132,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-mlb/sync-pitchers.yml",
+      "line": 115,
+      "literal": "sport:Event",
+      "snippet": "name: '''sport:Event'''"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-mlb/sync-results.yml",
+      "line": 63,
+      "literal": "sport:Event",
+      "snippet": "name: '''sport:Event'''"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/sync-games.yml",
+      "line": 93,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/sync-games.yml",
+      "line": 130,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 35,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 67,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 69,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 70,
+      "path": "value.schema:sportName",
+      "snippet": "value.schema:sportName: \"{'$in': ['nfl']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 71,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started', 'scheduled', 'live', 'interrupted']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 72,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=2)).isoformat() + '+00:00', '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat() + '+00:00'}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 76,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-live.yml",
+      "line": 95,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 35,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 67,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 69,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 70,
+      "path": "value.schema:sportName",
+      "snippet": "value.schema:sportName: \"{'$in': ['nfl']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 71,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=80)).isoformat() + '+00:00', '$lt': (datetime.utcnow() + timedelta(hours=240)).isoformat() + '+00:00'}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 72,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started', 'scheduled']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-nfl/workflows/event-consumer-prelive.yml",
+      "line": 76,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 34,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 66,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [[\"value.version_control.consumer-update-timestamp\", 1], [\"value.schema:startDate\", 1]]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 68,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 69,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=1)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 70,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started', 'live', 'interrupted']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 74,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-live.yml",
+      "line": 93,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 34,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 66,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [[\"value.version_control.consumer-update-timestamp\", 1], [\"value.schema:startDate\", 1]]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 68,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 69,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=80)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=240)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 70,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer-prelive.yml",
+      "line": 74,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: |"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 34,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 53,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 54,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=24)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 55,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['live', 'interrupted']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 76,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 77,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=24)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=8)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 78,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 99,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 100,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=24)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 101,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['closed', 'ended']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 122,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 123,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() + timedelta(hours=8)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=72)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 124,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['not_started']}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/event-consumer.yml",
+      "line": 145,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "line": 28,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "line": 30,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "line": 31,
+      "path": "value.sport:round",
+      "snippet": "value.sport:round.sport:number: \"int($.get('round_number'))\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/sportradar-soccer/workflows/load-round-events.yml",
+      "line": 32,
+      "path": "value.sport:competition",
+      "snippet": "value.sport:competition.@id: \"$.get('competition_id') if $.get('competition_id') else None\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/sync-competitors.yml",
+      "line": 100,
+      "literal": "sport:Team",
+      "snippet": "document_name: 'sport:Team'"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/sync-schedules.yml",
+      "line": 66,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/sync-schedules.yml",
+      "line": 90,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/sync-season-schedules.yml",
+      "line": 63,
+      "literal": "season:Schedule",
+      "snippet": "name: \"'season:Schedule'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-soccer/workflows/sync-season-schedules.yml",
+      "line": 87,
+      "literal": "season:Schedule",
+      "snippet": "document_name: \"'season:Schedule'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-tennis/workflows/sync-season-info.yml",
+      "line": 77,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/sportradar-tennis/workflows/sync-season-summaries.yml",
+      "line": 59,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 30,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 32,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 49,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 51,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 52,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=2)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 53,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['Fixture', 'Playing']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 72,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-live.yml",
+      "line": 74,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 30,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 32,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 49,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.version_control.consumer-update-timestamp\", 1, \"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 51,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 52,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"{'$gt': (datetime.utcnow() - timedelta(hours=80)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=240)).isoformat()}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-consumer-prelive.yml",
+      "line": 53,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"{'$in': ['Fixture']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-sync-markets.yml",
+      "line": 31,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-synchronize.yml",
+      "line": 29,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sp-opta-event-update.yml",
+      "line": 29,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-players.yml",
+      "line": 127,
+      "literal": "sport:Player",
+      "snippet": "name: \"'sport:Player'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-players.yml",
+      "line": 146,
+      "literal": "sport:Player",
+      "snippet": "document_name: \"'sport:Player'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-schedules.yml",
+      "line": 88,
+      "literal": "sport:Event",
+      "snippet": "name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-schedules.yml",
+      "line": 112,
+      "literal": "sport:Event",
+      "snippet": "document_name: \"'sport:Event'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-teams.yml",
+      "line": 72,
+      "literal": "sport:Team",
+      "snippet": "name: \"'sport:Team'\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-teams.yml",
+      "line": 96,
+      "literal": "sport:Team",
+      "snippet": "document_name: \"'sport:Team'\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "line": 36,
+      "path": "value.schema:startDate",
+      "snippet": "search-sorters: [\"value.schema:startDate\", 1]"
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "line": 40,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "line": 62,
+      "path": "value.sport:status",
+      "snippet": "value.sport:status: \"$.get('sport_status') if $.get('sport_status') is not None else {'$in': ['Fixture', 'Playing']}\""
+    },
+    {
+      "category": "storage-predicate",
+      "file": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "line": 63,
+      "path": "value.schema:startDate",
+      "snippet": "value.schema:startDate: \"$.get('start_date') if $.get('start_date') is not None else {'$gt': (datetime.utcnow() - timedelta(hours=24)).isoformat(), '$lt': (datetime.utcnow() + timedelta(hours=24)).isoformat()}\""
+    },
+    {
+      "category": "document-name",
+      "file": "connectors/stats-perform/workflows/sync-update-live.yml",
+      "line": 68,
+      "literal": "sport:Event",
+      "snippet": "name: \"{'$in': ['sport:Event']}\""
+    }
+  ],
   "emitters": [
     {
       "declared_prefixes": {

--- a/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
+++ b/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
@@ -8,7 +8,7 @@
 
 ## Authority and scope
 
-The full approved architecture is **Chief of Staff Design Log #027 Amendment B**; treat it as authority. Where this plan and Amendment B disagree, Amendment B wins and this plan is amended before implementation continues.
+The full approved architecture is held in the **internal architecture decision record (revision B)** that governs this work; treat that record as authority. Where this plan and that record disagree, the record wins and this plan is amended before implementation continues.
 
 This plan contains **17 tasks** across four physical PRs (PR3-A .. PR3-D) plus a stop/review gate. Every task is **strict TDD**: the RED test is written and observed failing for the stated reason before any implementation line is written. A task is not complete until its GREEN commands pass and its commit is made.
 
@@ -820,7 +820,7 @@ Do not import to or execute in the Machina sandbox. Report: all command outputs,
 - **G** — Sports TV
 - Customer migration and alias-removal plans
 
-**Explicitly out of scope:** Sports Moment, Sports Experience, Coach Mode.
+**Explicitly out of scope:** Sports Experience, plus the other adjacent internal product surfaces that are not named in the later-work outline above.
 
 **Commit message:** `docs(iptc): record PR3 stop-and-review outcome`
 

--- a/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
+++ b/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
@@ -1,0 +1,853 @@
+# IPTC PR 3 Canonical Runtime and WCI Provider Substitution Implementation Plan
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+**Goal:** Publish and install the canonical Python runtime, then prove World Cup Intelligence provider substitution without provider branches above the seam.
+**Architecture:** `machina-templates` remains source authority. A pinned `machina-sports-canonical` wheel maps import namespace `machina_sports_canonical` to existing `tools/iptc/canonical` bytes without copying/moving logic. `machina-client-api` installs it; a thin shared pyscript connector imports it; WCI persists the canonical envelope plus exact-path derived compatibility aliases under the unchanged `worldcup:event` name.
+**Tech Stack:** Python 3.9+/3.11, stdlib-only canonical core, setuptools/build, pytest/unittest, Machina pyscript connectors/YAML workflows, Docker.
+
+---
+
+## Authority and scope
+
+The full approved architecture is **Chief of Staff Design Log #027 Amendment B**; treat it as authority. Where this plan and Amendment B disagree, Amendment B wins and this plan is amended before implementation continues.
+
+This plan contains **17 tasks** across four physical PRs (PR3-A .. PR3-D) plus a stop/review gate. Every task is **strict TDD**: the RED test is written and observed failing for the stated reason before any implementation line is written. A task is not complete until its GREEN commands pass and its commit is made.
+
+### Current package/runtime evidence
+
+These facts constrain the design and must not be re-litigated during implementation:
+
+- The `machina-client-api` template importer stores **one pyscript sidecar** per connector.
+- `core.connector.executor.connector_script` **execs that sidecar in-process** (same interpreter, same site-packages).
+- Therefore any `import machina_sports_canonical` inside a pyscript **requires the wheel to be installed in the image** — there is no per-template dependency install, no vendoring hook, and no sys.path injection at execution time.
+- **Production** images build from the **root `requirements.txt`**.
+- **Development** images build from **`docker/development/requirements.txt`**.
+- `requirements.prod.txt` is **not referenced** by either dockerfile and must not be touched.
+- PyPI name `machina-sports-canonical` returned **404/unclaimed on 2026-08-10**. Unclaimed is not owned. Ownership only exists after a successful release upload; any task depending on the installed distribution is blocked until then.
+
+### Global conventions
+
+- Repo root for PR3-A / PR3-B / PR3-D: this `machina-templates` repository.
+- Repo root for PR3-C: the sibling `machina-client-api` repository.
+- All paths below are repository-relative; cross-repository paths are prefixed with the repository name.
+- Test runner: `python3 -m tools.iptc.run_test_suites` is the manifest runner; individual suites run with `python3 -m pytest <path> -q` (fallback `python3 -m unittest <dotted.path> -v` if the suite is unittest-shaped).
+- **No consumer behavior changes in PR3-A or PR3-B.** Behavior changes start in PR3-D.
+- **External approval gates** (tasks 5, 8, 16) are hard stops. The implementing agent must stop and report; it must not self-approve, publish, deploy, or import to sandbox.
+
+---
+
+# PR3-A — Architecture/inventory hardening (current `machina-templates` branch)
+
+Branch: `refactor/iptc-consumers-and-compatibility` (existing, HEAD `d38baeb`).
+No consumers are modified in this PR. Only inventory tooling, review ledger, and regenerated artifacts.
+
+---
+
+## Task 1 — Document-name and storage-predicate detection in the inventory tool
+
+**Prerequisite:** HEAD is `d38baeb` (inventory commit) on `refactor/iptc-consumers-and-compatibility`; working tree clean apart from ignored `.claude/tasks/CURRENT.md`.
+
+**Objective:** Teach `tools/iptc/inventory.py` to detect two coupling classes the current scan misses: (a) **document-name coupling** — literal document names such as `worldcup:event` used in save/load/query positions; (b) **storage-predicate coupling** — filter/sorter/query paths such as `value.schema:startDate` and `value.sport:status` that bind a consumer to the persisted document shape. Detection must be evidence-bearing: each hit records file, line, matched literal, and coupling category.
+
+**Create:**
+- `tests/test_iptc_consumer_inventory.py`
+
+**Modify:**
+- `tools/iptc/inventory.py`
+
+**Test paths:**
+- `tests/test_iptc_consumer_inventory.py`
+- Fixtures inline in the test module (no new fixture tree in this task).
+
+**RED test + command + expected failure:**
+
+Write `tests/test_iptc_consumer_inventory.py` with at minimum these cases:
+1. `test_detects_document_name_coupling` — a synthetic YAML snippet containing `name: worldcup:event` in a save/load task yields a finding with `category == "document-name"` and `literal == "worldcup:event"`.
+2. `test_detects_storage_predicate_startdate` — a snippet containing `value.schema:startDate` in a filter/sorter yields `category == "storage-predicate"` and `path == "value.schema:startDate"`.
+3. `test_detects_storage_predicate_status` — same for `value.sport:status`.
+4. `test_findings_carry_file_and_line_evidence` — every finding has non-empty `file` and integer `line >= 1`.
+5. `test_real_repo_scan_detects_worldcup_event_couplings` — scanning the real `agent-templates/world-cup-intelligence/` tree returns at least one `document-name` finding for `worldcup:event` and at least one `storage-predicate` finding each for `value.schema:startDate` and `value.sport:status`.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_consumer_inventory.py -q
+```
+
+Expected failure (RED): `ImportError`/`AttributeError` for the not-yet-existing detection entrypoint (e.g. `cannot import name 'scan_couplings' from 'tools.iptc.inventory'`), or assertion failures showing zero findings of category `document-name` / `storage-predicate`. Record the exact failure text in the commit body.
+
+**Minimal implementation API:**
+
+In `tools/iptc/inventory.py`, add only:
+```python
+COUPLING_DOCUMENT_NAME = "document-name"
+COUPLING_STORAGE_PREDICATE = "storage-predicate"
+
+def scan_couplings(root: str) -> list[dict]:
+    """Return findings: {file, line, category, literal|path, snippet}."""
+```
+plus the two narrow matchers it needs. Wire `scan_couplings` into the existing inventory generation so its findings land in the generated dependency records under an added `couplings` key. Do **not** restructure the existing scanner, rename existing fields, or change existing output ordering beyond the added key.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_consumer_inventory.py -q`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `test(iptc): detect document-name and storage-predicate couplings`
+
+**Rollback / stop condition:** If wiring `couplings` into generation changes any pre-existing field of `inventory.json` other than the additive key, revert the wiring, keep `scan_couplings` standalone, and record the deviation in the commit body. Stop and report if the real-repo scan case (5) cannot pass without loosening matchers to substring-anywhere matching — a matcher that fires inside prose/comments is a false-positive generator and must not ship.
+
+---
+
+## Task 2 — Consumer review ledger and regenerated inventory
+
+**Prerequisite:** Task 1 committed and green.
+
+**Objective:** Create a durable, machine-checkable review ledger for every generated dependency, and regenerate the inventory artifacts so ledger and inventory agree. Every generated dependency must be either **reviewed** (with a disposition and evidence) or **explicitly excluded** (with a stated reason). The final unreviewed count must be **zero**. No consumer files change.
+
+**Create:**
+- `docs/iptc/consumer-review.json`
+
+**Modify (regenerated artifacts only):**
+- `docs/iptc/INVENTORY.md`
+- `docs/iptc/inventory.json`
+
+**Test paths:**
+- `tests/test_iptc_consumer_inventory.py` (extend; do not create a second suite)
+
+**RED test + command + expected failure:**
+
+Add to `tests/test_iptc_consumer_inventory.py`:
+1. `test_review_ledger_exists_and_has_schema_and_version` — file loads as JSON, has `schema` (string identifier) and `version` (string).
+2. `test_every_entry_has_required_fields` — each entry has `repo`, `path`, `category`, `owner`, `disposition`, `evidence`; `disposition` ∈ {`migrate`, `compat-alias`, `no-change`, `excluded`}; `evidence` non-empty.
+3. `test_every_generated_dependency_is_reviewed_or_excluded` — the set of `(repo, path)` from `docs/iptc/inventory.json` is a subset of the ledger's `(repo, path)` set.
+4. `test_unreviewed_count_is_zero` — computed unreviewed count == 0.
+5. `test_no_orphan_ledger_entries` — every ledger entry with `disposition != "excluded"` corresponds to a real generated dependency (guards against a ledger that drifts ahead of reality).
+
+Command:
+```
+python3 -m pytest tests/test_iptc_consumer_inventory.py -q
+```
+
+Expected failure (RED): `FileNotFoundError: docs/iptc/consumer-review.json`, then (after the file exists but is incomplete) an assertion listing the specific `(repo, path)` pairs present in `inventory.json` but absent from the ledger.
+
+**Minimal implementation API:** No new Python API. The ledger is data:
+```json
+{
+  "schema": "machina.iptc.consumer-review/v1",
+  "version": "1",
+  "entries": [
+    {"repo": "machina-templates", "path": "...", "category": "...",
+     "owner": "...", "disposition": "...", "evidence": "..."}
+  ]
+}
+```
+Regenerate artifacts with:
+```
+python3 -m tools.iptc
+```
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_consumer_inventory.py -q`
+- Full: `python3 -m tools.iptc.run_test_suites`
+- Diff check: `git diff --stat` must show only `docs/iptc/consumer-review.json`, `docs/iptc/INVENTORY.md`, `docs/iptc/inventory.json`, and `tests/test_iptc_consumer_inventory.py`.
+
+**Commit message:** `docs(iptc): add consumer review ledger and regenerate inventory`
+
+**Rollback / stop condition:** If regeneration modifies any file outside `docs/iptc/`, stop — the generator has a side effect that must be understood before PR3-B. If a dependency cannot be assigned an `owner`, do not invent one: mark `owner: "UNASSIGNED"`, `disposition: "excluded"`, and state the reason in `evidence`; report the list of `UNASSIGNED` entries in the PR description.
+
+---
+
+# PR3-B — Package foundation (new `machina-templates` branch)
+
+Branch: create `feat/iptc-canonical-package` from the PR3-A branch tip.
+`machina-templates` remains source authority. Packaging **maps** to existing bytes; it does not move or copy logic.
+
+---
+
+## Task 3 — Root packaging configuration for `machina-sports-canonical==0.1.0`
+
+**Prerequisite:** PR3-A merged (or its branch tip used as the base) and green.
+
+**Objective:** Add root packaging configuration that builds distribution `machina-sports-canonical` version `0.1.0`, exposing import namespace `machina_sports_canonical` mapped onto the existing `tools/iptc/canonical` source directory. No source file is moved or copied. Adapters ship. JSON package data ships. The built package embeds a receipt recording version, source path, and a manifest of packaged files with hashes.
+
+**Create:**
+- `pyproject.toml` packaging section (or a new root `pyproject.toml` if none exists — verify first; do not clobber an existing one)
+- `setup.py` plus `packaging/machina_sports_canonical/build.py` — minimal `build_py` filter whose only exception is the repository-only `export_official_terms.py`; no canonical runtime transformation is allowed
+- `tools/iptc/canonical/package-receipt.json` — non-executable package metadata containing distribution version, authoritative source path/commit, and the existing nine-file core manifest receipt
+- `README-machina-sports-canonical.md` (package long description) and `LICENSE` reference if absent
+
+**Modify:**
+- Root `pyproject.toml` (packaging/build-system/tool config only)
+- `MANIFEST.in` (only if sdist data inclusion requires it)
+- `tests/test_iptc_vendored_manifest.py` only to list `package-receipt.json` as an explicit, reasoned **not-vendored package-metadata file**; the nine-file sports-skills manifest and every existing canonical source byte remain unchanged
+
+**Test paths:** Task 4 provides the tests. This task's own verification is build-only.
+
+**RED test + command + expected failure:** This task's RED belongs to Task 4 and is written **first** as part of Task 4's ordering note below. To keep strict TDD, execute Task 4's step 1 (write the failing suite) before writing packaging config, then return here. The observed RED is:
+```
+python3 -m pytest tests/test_iptc_canonical_package.py -q
+```
+failing with `ModuleNotFoundError: No module named 'machina_sports_canonical'` and a build-artifact-absent assertion.
+
+**Minimal implementation API:**
+
+`pyproject.toml` must specify exactly:
+- `[project] name = "machina-sports-canonical"`, `version = "0.1.0"`, `requires-python = ">=3.9"`, `dependencies = []`.
+- `[build-system] requires = ["setuptools>=68", "wheel"]`, `build-backend = "setuptools.build_meta"`.
+- Package discovery mapping `machina_sports_canonical` → `tools/iptc/canonical` (setuptools `package-dir` mapping plus explicit `packages` listing, including the adapters subpackage).
+- `package-data` including `official-property-names.json`, `shared-context.json`, and `package-receipt.json`.
+- The custom `build_py` filter removes exactly `machina_sports_canonical.export_official_terms` from wheel/sdist runtime modules. It must reject configuration that excludes any additional module. The generator remains in the repository at its current path and is neither moved nor shipped.
+
+Receipt content (read-only JSON package data, never imported as code):
+```json
+{
+  "distribution_version": "0.1.0",
+  "source": "machina-templates:tools/iptc/canonical",
+  "source_commit": "<reviewed merge/source commit>",
+  "core_manifest": {"<relative core path>": "<sha256>"}
+}
+```
+The `core_manifest` key set and hashes must equal `tools/iptc/vendored-manifest.json`; adapters ship in the wheel but remain outside the sports-skills vendored-core receipt and are checked separately against their authoritative source bytes.
+
+**GREEN commands:**
+- `python3 -m build`
+- `python3 -m pytest tests/test_iptc_canonical_package.py -q` (passes only after Task 4's assertions are satisfied)
+- `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `build(iptc): package canonical core as machina-sports-canonical 0.1.0`
+
+**Rollback / stop condition:** Stop if packaging requires any edit to an **existing** file under `tools/iptc/canonical/`; adding the approved non-executable `package-receipt.json` is the sole package-metadata exception and must be explicitly excluded from sports-skills vendoring without changing the nine-file core manifest. Stop if a root `pyproject.toml` already exists and serves another purpose that packaging config would break; report and request direction rather than merging configs speculatively.
+
+---
+
+## Task 4 — Package proof suite
+
+**Prerequisite:** Task 3's design decided; this suite is written **before** Task 3's implementation (see Task 3 RED note).
+
+**Objective:** Prove the distribution is real, self-contained, faithful to source, and offline-capable — on a clean interpreter.
+
+**Create:**
+- `tests/test_iptc_canonical_package.py`
+
+**Modify:**
+- `tools/iptc/test-suites.json` — register the package proof suite
+- `tests/test_iptc_test_manifest.py` — keep the suite inventory exact
+- `.github/workflows/validate-iptc-sport-schema.yml` — include `pyproject.toml`, `setup.py`, `packaging/machina_sports_canonical/**`, receipt and package test paths in triggers/gates
+
+**Test paths:**
+- `tests/test_iptc_canonical_package.py`
+
+**RED test + command + expected failure:**
+
+Cases, all required:
+1. `test_wheel_and_sdist_build` — `python -m build` produces exactly one `.whl` and one `.tar.gz` for `machina_sports_canonical-0.1.0`.
+2. `test_clean_venv_import` — create a throwaway venv, install the built wheel with `--no-index` (no network), `import machina_sports_canonical` succeeds.
+3. `test_constants_functions_and_adapters_import` — importable: the canonical constants module, the serialization/validation functions, and each shipped adapter module.
+4. `test_json_resources_load_offline` — `official-property-names.json` and `shared-context.json` load from the **installed** package, with no filesystem reach-back into the repo and no network.
+5. `test_installed_source_hashes_match_authoritative` — the installed nine-file `core_manifest` key set and hashes equal `tools/iptc/vendored-manifest.json`; every installed adapter module and JSON resource is byte-equal to its authoritative source under `tools/iptc/canonical/`; `package-receipt.json` is present and no installed runtime file is unaccounted for.
+6. `test_python39_parse_and_stdlib_only` — every packaged `.py` parses under a 3.9-compatible AST feature check, and no import outside the stdlib allowlist appears in any packaged module.
+7. `test_zero_runtime_dependencies` — installed distribution metadata reports no `Requires-Dist`.
+8. `test_wheel_record_is_closed_and_excludes_generator` — wheel `RECORD` contains exactly the expected core, adapters, JSON resources and distribution metadata; it excludes `machina_sports_canonical/export_official_terms.py`, and the build filter excludes no other source module.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_canonical_package.py -q
+```
+
+Expected failure (RED): `ModuleNotFoundError: No module named 'machina_sports_canonical'` from case 2/3, and a "no dist artifacts found" assertion from case 1.
+
+**Minimal implementation API:** Test-only helpers, kept inside the test module: `_build_dists(tmp)`, `_clean_install(whl, python_exe)`, `_sha256(path)`, `_packaged_modules()`. No production API.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_canonical_package.py -q`
+- Build: `python3 -m build`
+- Clean installs: run the clean-venv install case under **Python 3.9** and **Python 3.11** where the interpreter is available; skip-with-reason (not silently pass) when absent, and print the skip.
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `test(iptc): prove canonical package build, install and source fidelity`
+
+**Rollback / stop condition:** Stop if case 5 fails because packaging rewrote or reformatted source — never "fix" it by regenerating the manifest from the installed copy; that would make the test tautological. Stop if case 6 requires adding a third-party dependency to satisfy an import: the canonical core is stdlib-only by contract.
+
+---
+
+## Task 5 — Trusted publishing workflow and release gate
+
+**Prerequisite:** Tasks 3 and 4 committed and green; PR3-B branch ready for review.
+
+**Objective:** Add release automation and the tag convention, **stopping before public PyPI publication**. Publication requires external human approval.
+
+**Create:**
+- `.github/workflows/publish-machina-sports-canonical.yml`
+- `docs/iptc/RELEASING.md` (tag convention, approval gate, post-release verification checklist)
+
+**Modify:** none.
+
+**Test paths:**
+- `tests/test_iptc_canonical_package.py` (extend with a workflow-shape test)
+
+**RED test + command + expected failure:**
+- `test_publish_workflow_uses_trusted_publishing` — the workflow file exists, triggers on tags matching the convention, requests `id-token: write`, uses PyPI trusted publishing (OIDC), and contains **no** API-token secret reference.
+- `test_release_docs_document_approval_gate` — `docs/iptc/RELEASING.md` states the external approval gate and the post-release verification steps.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_canonical_package.py -q -k publish or release
+```
+Expected failure (RED): `FileNotFoundError` for the workflow and the docs file.
+
+**Minimal implementation API:**
+- Tag convention: `machina-sports-canonical-v0.1.0` (distribution-scoped so it cannot collide with template release tags).
+- Workflow: build with `python -m build`, then `pypa/gh-action-pypi-publish` gated on a GitHub **environment** requiring reviewer approval. No token secrets.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_canonical_package.py -q`
+- Full: `python3 -m tools.iptc.run_test_suites`
+- `python3 -m build` (artifacts reproduced locally)
+
+**Commit message:** `ci(iptc): add trusted publishing workflow for canonical package`
+
+**🛑 EXTERNAL APPROVAL GATE — STOP HERE.**
+Do not publish to public PyPI. Report to the human: artifacts built, hashes, and the request to approve release.
+
+**After approval only, in order:**
+1. Merge PR3-B.
+2. Tag and release `machina-sports-canonical-v0.1.0`.
+3. Verify the GitHub release exists and references the built artifacts.
+4. Verify `https://pypi.org/pypi/machina-sports-canonical/json` returns `0.1.0`.
+5. Verify published wheel/sdist sha256 equal the locally built artifacts' hashes.
+6. Verify a clean install from PyPI (`pip install machina-sports-canonical==0.1.0`) imports and passes the Task 4 offline-resource case.
+
+**Rollback / stop condition:** PyPI releases are **not deletable in a way that frees the version**; a bad `0.1.0` burns the version number. If any pre-release verification fails, do **not** publish — fix and rebuild. If post-publish verification (steps 4–6) fails, stop the entire PR3-C sequence: yanking and shipping `0.1.1` is the correct recovery, not proceeding on a broken pin. The name being 404/unclaimed on 2026-08-10 does **not** mean it is reserved; if a name collision appears at publish time, stop and escalate.
+
+---
+
+# PR3-C — Client runtime (new `machina-client-api` branch)
+
+Repo: sibling `machina-client-api` repository.
+Branch: create `feat/iptc-canonical-runtime`.
+**No schema code lands in client-api.** The client installs and executes; it does not own vocabulary.
+
+---
+
+## Task 6 — Pin the exact package version in client requirements
+
+**Prerequisite:** Task 5 fully complete **including release and post-release verification**. Without a published, verified `0.1.0`, this task is blocked and must not be started.
+
+**Objective:** Pin `machina-sports-canonical==0.1.0` exactly (no range, no `~=`) in every dependency file actually consumed by an image build, and nowhere else.
+
+**Modify (`machina-client-api`):**
+- `requirements.txt` (production image source)
+- `docker/development/requirements.txt` (development image source)
+- `pyproject.toml`
+- `pdm.lock` — regenerate from the updated project metadata; never hand-edit only the top-level pin
+
+**Do not modify:** `requirements.prod.txt` — it is not referenced by either dockerfile.
+
+**Create:** none.
+
+**Test paths:**
+- `tests/test_connector_canonical_runtime.py` (created in Task 7; its pin assertions are written here first)
+
+**RED test + command + expected failure:**
+- `test_canonical_pinned_exactly_in_runtime_requirements` — each of the three files contains the literal `machina-sports-canonical==0.1.0`.
+- `test_unreferenced_prod_requirements_untouched` — `requirements.prod.txt` contains no `machina-sports-canonical` reference.
+
+Command:
+```
+python3 -m pytest tests/test_connector_canonical_runtime.py -q -k pinned or untouched
+```
+Expected failure (RED): assertion that the literal pin is absent from `requirements.txt`.
+
+**Minimal implementation API:** Add exactly one line per file:
+```
+machina-sports-canonical==0.1.0
+```
+placed in alphabetical position if the file is sorted; otherwise appended in the existing style.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_connector_canonical_runtime.py -q`
+- `pip install -r requirements.txt --dry-run` (resolver sanity)
+
+**Commit message:** `build(iptc): pin machina-sports-canonical==0.1.0 in client runtime`
+
+**Rollback / stop condition:** Stop if the pin conflicts with an existing resolved dependency — the canonical package has zero dependencies, so a conflict means a name clash or a stale local index, both of which need investigation, not a loosened pin. Never relax `==` to a range to make resolution pass.
+
+---
+
+## Task 7 — Connector runtime execution proof
+
+**Prerequisite:** Task 6 committed; the package installable in the local dev environment.
+
+**Objective:** Prove, through the **real** executor, that a declared pyscript connector can import `machina_sports_canonical` and call a deterministic canonical function — and that the security posture around it is fail-closed.
+
+**Create:**
+- `tests/test_connector_canonical_runtime.py` (extended from Task 6's pin assertions)
+- Test-local fixture connector declaration + pyscript sidecar under the test tree (not under production connector paths)
+
+**Modify:** none in production code.
+
+**Test paths:**
+- `machina-client-api/tests/test_connector_canonical_runtime.py`
+
+**RED test + command + expected failure:**
+1. `test_real_executor_runs_pyscript_importing_canonical` — invoke the real `core.connector.executor.connector_script`; patch only `connector_retrieve` to supply the stored connector fixture, while leaving import resolution, `exec`, declared-command dispatch and canonical functions unmocked. The fixture pyscript does `import machina_sports_canonical` and calls a deterministic canonical function; assert the exact expected return value.
+2. `test_only_declared_commands_are_callable` — a command not present in the connector declaration is refused; the refusal is an error, not a silent no-op.
+3. `test_unknown_capability_fails_closed` — an unrecognized capability name produces refusal, never a permissive default.
+4. `test_refused_rights_are_redacted` — refusal messages contain no source refs, credentials, payload contents, or internal paths.
+5. `test_no_canonical_source_in_client_api` — a repo scan asserts client-api contains **zero** canonical schema source (no `official-property-names.json`, no adapters, no serialization implementation); only the pinned dependency reference exists.
+
+Command:
+```
+python3 -m pytest tests/test_connector_canonical_runtime.py -q
+```
+Expected failure (RED): case 1 fails with `ModuleNotFoundError: No module named 'machina_sports_canonical'` before install, then with an assertion mismatch on the deterministic value before the fixture is correct; cases 3/4 fail open until the gate is exercised.
+
+**Minimal implementation API:** Test-only. No production API added to client-api. If cases 2–4 fail because the existing executor genuinely fails open, **stop and report** — that is a client-api security finding requiring its own decision, not a fix to smuggle into this PR.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_connector_canonical_runtime.py -q`
+- Full client suite: the repo's standard test command.
+
+**Commit message:** `test(iptc): prove connector runtime imports canonical package`
+
+**Rollback / stop condition:** Do **not** substitute a mocked executor to get green — a mocked executor proves nothing about in-process exec and invalidates the entire runtime claim. Stop if the only way to pass case 1 is `sys.path` manipulation inside the pyscript; that would contradict the image-installed-wheel evidence and means the pin is not actually effective.
+
+---
+
+## Task 8 — Image build verification
+
+**Prerequisite:** Task 7 green.
+
+**Objective:** Prove the pinned package is present **inside both built images**, at the exact version, and stop before deploying anything.
+
+**Create:** none.
+**Modify:** none (dockerfiles should need no change; if one does, that is a finding — report before editing).
+
+**Test paths:** verification is command-driven; record outputs in the commit body.
+
+**RED test + command + expected failure:** N/A as a code test — this is a build verification task whose RED is the pre-Task-6 state (package absent from images). If a code-level assertion is desired, extend `test_connector_canonical_runtime.py` with a marker-gated test that shells out to `docker run` and is skipped-with-reason when Docker is unavailable.
+
+**Commands:**
+```
+python3 -m pytest tests/test_connector_canonical_runtime.py -q
+docker build -f docker/production/dockerfile  -t machina-client-api:iptc-prod .
+docker build -f docker/development/dockerfile -t machina-client-api:iptc-dev  .
+docker run --rm machina-client-api:iptc-prod python -c "import machina_sports_canonical as m; print(m.__version__)"
+docker run --rm machina-client-api:iptc-dev  python -c "import machina_sports_canonical as m; print(m.__version__)"
+```
+Both `docker run` invocations must print `0.1.0`.
+
+**Commit message:** `build(iptc): verify canonical package installed in client images`
+
+**🛑 EXTERNAL APPROVAL GATE — STOP HERE.**
+Do not deploy to sandbox. Report: both image digests, both printed versions, and the request to approve the sandbox image rollout.
+
+**Rollback / stop condition:** If the production image prints nothing while development prints `0.1.0`, the production build is not consuming root `requirements.txt` as assumed — stop and re-establish the evidence before proceeding. Never add schema code to client-api to work around a missing install.
+
+---
+
+# PR3-D — Shared connector and WCI golden proof (`machina-templates`, after client sandbox runtime exists)
+
+Branch: create `feat/iptc-wci-canonical-seam` from `main` after PR3-B merged.
+**Blocked** until the sandbox runs an image containing `machina-sports-canonical==0.1.0` (Task 8 approval executed).
+
+---
+
+## Task 9 — Shared canonical connector
+
+**Prerequisite:** Task 8 approved and the sandbox image live.
+
+**Objective:** Add a thin shared pyscript connector that exposes canonical operations to templates. It contains **only** dispatch and injected-crosswalk resolution. It contains **no** schema vocabulary, **no** serialization logic, and **no** CLI or long-running service.
+
+**Create:**
+- `connectors/machina-sports-canonical/machina-sports-canonical.yml`
+- `connectors/machina-sports-canonical/machina-sports-canonical.py`
+- `connectors/machina-sports-canonical/_install.yml` (optional; include only if the repo's install convention requires it)
+- `tests/test_iptc_canonical_connector.py`
+
+**Modify:** none.
+
+**Test paths:**
+- `tests/test_iptc_canonical_connector.py`
+
+**RED test + command + expected failure:**
+1. `test_declared_commands_exist` — the YAML declares exactly: provider preflight, canonicalize event envelope, validate event envelope, capability/rights gate; each maps to a function present in the pyscript.
+2. `test_connector_contains_no_schema_vocabulary` — the pyscript source contains no IPTC property literals (`sport:`, `schema:` prefixed names), no serialization implementation, and no hardcoded vocabulary tables.
+3. `test_connector_delegates_to_package` — canonicalize/validate paths call `machina_sports_canonical` functions (`adapters.*.to_observation`, `serialize.canonical_envelope`, `check_compatibility`, `rights_findings`, `surrogate_resolver`); assert via import-graph/source inspection, not by mocking.
+4. `test_provider_allowlist_enforced` — a provider absent from the allowlist is refused.
+5. `test_no_cli_or_service_entrypoint` — no `__main__`, no server/loop construct.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_canonical_connector.py -q
+```
+Expected failure (RED): `FileNotFoundError` for the connector YAML and pyscript.
+
+**Minimal implementation API (pyscript functions, dispatch-only):**
+```python
+def provider_preflight(...): ...
+def canonicalize_event(...): ...
+def validate_event(...): ...
+def capability_rights_gate(...): ...
+```
+Each body: resolve injected crosswalk, delegate to the package, return the package result. Crosswalk maps are **injected**, never embedded.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_canonical_connector.py -q`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `feat(iptc): add shared machina-sports-canonical connector`
+
+**Rollback / stop condition:** Stop if any test can only pass by inlining vocabulary into the connector — that duplicates the seam and defeats the whole PR. Stop if the connector needs to reach the filesystem for JSON resources; those load from the installed package.
+
+---
+
+## Task 10 — Fail-closed provider preflight before retrieval
+
+**Prerequisite:** Task 9 green.
+
+**Objective:** Preflight must **refuse all current prototype-only adapters at production tier before any provider retrieval occurs**, with zero provider calls made. Post-render rights evaluation is a **drift check**, not the gate.
+
+**Modify:**
+- `connectors/machina-sports-canonical/machina-sports-canonical.py`
+- `connectors/machina-sports-canonical/machina-sports-canonical.yml` (capability declarations only)
+
+**Test paths:**
+- `tests/test_iptc_canonical_connector.py` (extend)
+
+**RED test + command + expected failure:**
+1. `test_production_tier_refuses_prototype_adapters` — for each currently prototype-only adapter, preflight at production tier refuses.
+2. `test_zero_provider_calls_on_refusal` — instrument the provider call surface with a counter; assert the count is exactly `0` on refusal (refusal must precede retrieval, not follow it).
+3. `test_unknown_capability_name_fails_closed` — an undeclared/unknown dotted capability refuses.
+4. `test_capabilities_use_existing_dotted_names` — declared capabilities are drawn from the existing dotted capability vocabulary; no new ad-hoc names introduced.
+5. `test_post_render_rights_is_drift_check_only` — post-render `rights_findings` output is recorded as a drift finding and does not itself authorize or block retrieval.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_canonical_connector.py -q
+```
+Expected failure (RED): case 2 fails with a nonzero provider-call count (refusal happening after retrieval), and case 1 fails because production tier currently permits prototype adapters.
+
+**Minimal implementation API:** Extend `provider_preflight` to evaluate `(provider, tier, capability)` and return a refusal before any retrieval path is reachable. Unknown capability → refuse.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_canonical_connector.py -q`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `feat(iptc): fail-closed provider preflight before retrieval`
+
+**Rollback / stop condition:** Stop if any adapter must be promoted out of prototype tier to make a downstream test pass — tier promotion is a rights/parity decision requiring Amendment B authority, not a test convenience. Do not weaken case 2 to "at most one call".
+
+---
+
+## Task 11 — WCI install reference and canonical resolver workflow
+
+**Prerequisite:** Task 10 green.
+
+**Objective:** Make the shared connector available to WCI and add a stable resolver workflow that turns provider-scoped identifiers into stable Machina URNs using the existing crosswalk maps.
+
+**Create:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-resolve-canonical-event.yml` (exact chosen name; do not vary)
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py`
+
+**Modify:**
+- `agent-templates/world-cup-intelligence/_install.yml` (add cross-template install reference to `connectors/machina-sports-canonical`)
+
+**Test paths:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py` — resolver, compatibility, ingest and read-seam cases for Tasks 11–14
+
+**RED test + command + expected failure:**
+1. `test_install_reference_present` — `_install.yml` references the shared connector.
+2. `test_resolver_workflow_exists_with_exact_name` — `workflows/worldcup-resolve-canonical-event.yml` exists.
+3. `test_resolver_accepts_event_urn_provider_and_provider_event_id` — the workflow's declared inputs are exactly `event_urn`, `provider`, `provider_event_id`.
+4. `test_equivalent_provider_ids_resolve_to_same_machina_urn` — for event, team, and competition, equivalent provider IDs across providers resolve to the same stable Machina URN.
+5. `test_unmapped_structural_resources_get_marked_surrogates` — an unmapped structural resource yields a surrogate URN that is explicitly **marked** as a surrogate (never silently indistinguishable from a real mapping).
+
+Command:
+```
+python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k resolver
+```
+Expected failure (RED): `FileNotFoundError` for the resolver workflow; then case 4 failing with divergent URNs per provider.
+
+**Minimal implementation API:** Workflow tasks: preflight → crosswalk lookup via existing maps → `surrogate_resolver` fallback for unmapped structural resources → return `{event_urn, team_urns, competition_urn, surrogates[]}`. No provider branching in the workflow body.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k resolver`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `feat(wci): add canonical event resolver workflow and install reference`
+
+**Rollback / stop condition:** Stop if resolution requires a new crosswalk map — this task uses **existing** maps. Stop if a surrogate would be minted for a *non-structural* resource; surrogates are for structural gaps only.
+
+---
+
+## Task 12 — Versioned deprecated compatibility projection
+
+**Prerequisite:** Task 11 green.
+
+**Objective:** Add exactly **one** explicit, versioned, deprecated compatibility projection derived **only** from `event_view`. The persisted document name stays `worldcup:event`. The document root value is the canonical envelope **plus** the exact legacy top-level aliases that existing filters/readers require. Nested-only compatibility is **forbidden** — the storage-predicate findings from Task 1 prove readers filter on top-level paths.
+
+**Create:**
+- Compatibility projection definition (mapping or workflow fragment) under `agent-templates/world-cup-intelligence/mappings/` — exact filename chosen at implementation time and recorded in the commit body
+- Snapshot fixtures, one per alias, under the WCI test fixture tree
+
+**Modify:** none of the existing consumer readers.
+
+**Test paths:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py` (extend) — compatibility cases
+
+**RED test + command + expected failure:**
+1. `test_document_name_unchanged` — persisted name is exactly `worldcup:event`.
+2. `test_root_is_canonical_envelope_plus_aliases` — root contains the canonical envelope keys **and** each legacy top-level alias.
+3. `test_aliases_derived_only_from_event_view` — each alias's value equals the exact `event_view` path it derives from; no alias is computed from raw provider payloads.
+4. `test_nested_only_compatibility_rejected` — a projection that nests the aliases fails the check (guards regression).
+5. `test_snapshot_per_alias_with_removal_owner` — one snapshot test per alias; each alias carries a documented removal owner and deprecation version.
+6. `test_no_rename_and_no_index_removal` — no document rename and no index removal in the diff.
+7. `test_storage_predicates_still_resolve` — `value.schema:startDate` and `value.sport:status` resolve against the projected document (direct tie-back to Task 1 findings).
+
+Command:
+```
+python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k compat
+```
+Expected failure (RED): case 2 fails — root is the bare canonical envelope with no legacy aliases; case 7 fails — storage predicates do not resolve.
+
+**Minimal implementation API:** A single declarative alias table: `legacy_top_level_key -> event_view.<exact.path>`, plus `deprecated_since` and `removal_owner` per entry. No logic beyond exact-path projection.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k compat`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `feat(wci): add versioned deprecated compatibility projection`
+
+**Rollback / stop condition:** Stop if more than one projection is needed — a second projection means the alias set is not actually closed and the inventory (Task 2) is incomplete. Stop if any alias cannot be derived from `event_view` by exact path; computing it would make the projection a second source of truth.
+
+---
+
+## Task 13 — Rewire fixture ingestion through the seam
+
+**Prerequisite:** Task 12 green.
+
+**Objective:** Make `worldcup-ingest-fixtures.yml` preflight before provider retrieval, canonicalize the retrieved payload, derive compatibility, and persist. Stop calling `worldcup-market-intelligence.py::mint_event_identity`. Retain the deprecated function **only if** the inventory says a remaining consumer exists.
+
+**Modify:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-ingest-fixtures.yml`
+- `agent-templates/world-cup-intelligence/worldcup-market-intelligence.py` — only if the inventory shows zero remaining consumers of `mint_event_identity`, and then only to mark it deprecated (removal is a later PR)
+
+**Do not touch:** standings, injuries, squads, brackets workflows.
+
+**Test paths:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py` (extend) — ingest cases
+
+**RED test + command + expected failure:**
+1. `test_preflight_precedes_provider_retrieval` — task order in the workflow places preflight strictly before the retrieval task.
+2. `test_ingest_canonicalizes_and_derives_compatibility` — persisted document is envelope + aliases (Task 12 shape).
+3. `test_mint_event_identity_not_called_by_ingest` — the ingest workflow no longer references `mint_event_identity`.
+4. `test_deprecated_function_retention_matches_inventory` — if `docs/iptc/inventory.json` lists a remaining consumer, the function is retained and marked deprecated; if not, retention is not required.
+5. `test_adjacent_workflows_unchanged` — `git diff --name-only` shows no standings/injuries/squads/brackets workflow files.
+
+Command:
+```
+python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k ingest
+```
+Expected failure (RED): case 1 fails (retrieval currently precedes any gate); case 3 fails (`mint_event_identity` still referenced).
+
+**Minimal implementation API:** Workflow edits only — insert preflight task, replace identity-minting task with the resolver + canonicalize + compatibility tasks, keep persistence target unchanged.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k ingest`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `refactor(wci): route fixture ingestion through canonical seam`
+
+**Rollback / stop condition:** Stop if removing `mint_event_identity` from ingest changes the persisted document's identity values — identity must be **equal**, not merely well-formed. Do not "clean up" adjacent workflows even if they look wrong; note them for a later PR.
+
+---
+
+## Task 14 — Serve canonical through the read seam without behavior change
+
+**Prerequisite:** Task 13 green.
+
+**Objective:** Serve the canonical envelope / `event_view` through the existing read seam, changing nothing observable downstream.
+
+**Modify:**
+- `agent-templates/world-cup-intelligence/workflows/worldcup-get-iptc-event-context.yml`
+- `agent-templates/world-cup-intelligence/mappings/worldcup-iptc-event-to-api-response.yml`
+- `agent-templates/world-cup-intelligence/workflows/worldcup-match-preview.yml` — **only at the lookup task**
+
+**Test paths:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py` (extend) — seam cases
+
+**RED test + command + expected failure:**
+1. `test_prompt_task_unchanged_by_hash` — sha256 of the match-preview prompt task block is byte-identical before and after.
+2. `test_post_lookup_task_order_unchanged` — the ordered list of task names after the lookup task is identical.
+3. `test_cache_semantics_unchanged` — cache key inputs and TTL are identical.
+4. `test_api_response_snapshot_unchanged` — the mapping's output snapshot is byte-identical.
+5. `test_downstream_behavior_unchanged` — end-to-end fixture through the seam produces the same downstream outputs.
+
+Command:
+```
+python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k seam
+```
+Expected failure (RED): snapshot files absent → the snapshot tests fail on first run; capture the pre-change baseline **before** editing the workflows (baseline capture is part of the RED step).
+
+**Minimal implementation API:** Read-path source substitution only: lookup reads the canonical envelope/`event_view`; mapping projects from it. No new tasks, no reordering, no cache-key change.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py -q -k seam`
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `refactor(wci): serve canonical envelope through read seam`
+
+**Rollback / stop condition:** Stop if any snapshot changes. A changed prompt hash or a changed post-lookup order means the seam is leaking into behavior — revert and re-scope. Do not update a snapshot to match new output in this task; snapshots here exist precisely to forbid change.
+
+---
+
+## Task 15 — Four-provider substitution proof
+
+**Prerequisite:** Task 14 green.
+
+**Objective:** Prove that the **same WCI workflow source** produces an equivalent canonical result across four providers, with provider selection changing **only in configuration** — no provider branches above the seam.
+
+**Create:**
+- Synthetic equivalent fixtures under a clearly named prototype path, e.g. `tests/fixtures/iptc/prototype-four-provider/{sports-skills,api-football,sportradar-soccer,opta}/`
+- `tests/test_iptc_wci_provider_substitution.py` (this task completes the suite)
+
+**Modify:**
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py` — replace legacy-only `TestMintEventIdentity` assertions with canonical-envelope plus compatibility assertions
+- `tools/iptc/test-suites.json` and `tests/test_iptc_test_manifest.py` — register the new WCI/substitution suites exactly
+
+**Test paths:**
+- `tests/test_iptc_wci_provider_substitution.py`
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py`
+- `agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py`
+- Existing `tests/test_iptc_cross_provider_equivalence.py` remains a required regression suite
+
+**RED test + command + expected failure:**
+
+Four legs, one per provider: sports-skills canonical envelope, API-Football adapter, Sportradar soccer adapter, Opta adapter.
+1. `test_same_workflow_source_all_providers` — the workflow file hash is identical across legs; only configuration differs.
+2. `test_identity_equivalent_across_providers` — resolved Machina **event**, **team**, and **competition** URNs are equal across legs.
+3. `test_participants_equivalent` — participant sets equal.
+4. `test_start_equivalent` — start instant equal.
+5. `test_normalized_status_equivalent` — normalized status equal.
+6. `test_score_result_equivalent_where_supported` — where the provider supports score/result **and** the value is stable, values equal; where unsupported, the leg is recorded as unsupported rather than skipped silently.
+7. `test_workflow_output_contract_stable` — output contract shape identical across legs.
+8. `test_allowed_differences_are_closed_set` — differences are confined to the closed set: **provider IDs, provenance, rights, capabilities, raw evidence, and actions/statistics not shared by capability**. Any difference outside this set fails.
+9. `test_llm_prose_semantic_not_byte_equal` — LLM-generated prose is compared semantically, never byte-for-byte.
+10. `test_expected_capability_differences_are_explicit` — the synthetic matrix records the reviewed expectations rather than treating absence as failure: sports-skills lacks result/clock/actions; API-Football provides result+clock; Sportradar adds result+attendance/country; Opta adds actions/play-by-play. The test reads capability reports, never provider-name branches in workflow code.
+11. `test_every_leg_is_prototype_only` — each fixture leg passes at prototype tier and fails at production tier with `rights-prototype-only`.
+
+Command:
+```
+python3 -m pytest tests/test_iptc_wci_provider_substitution.py -q
+```
+Expected failure (RED): fixtures absent → collection error; then case 2 failing with per-provider divergent URNs before the resolver is wired for all four legs.
+
+**Minimal implementation API:** Fixtures + configuration matrix only. If a leg needs a code branch to pass, that is the failure this task exists to detect — report it, do not add the branch.
+
+**GREEN commands:**
+- Focused: `python3 -m pytest tests/test_iptc_wci_provider_substitution.py agent-templates/world-cup-intelligence/tests/test_worldcup_canonical_event.py agent-templates/world-cup-intelligence/tests/test_worldcup_market_intelligence.py -q`
+- Existing equivalence regression: `python3 tests/test_iptc_cross_provider_equivalence.py -v` (review baseline: 44 tests passed)
+- Full: `python3 -m tools.iptc.run_test_suites`
+
+**Commit message:** `test(wci): prove four-provider canonical substitution`
+
+**Scope honesty:** These are **synthetic** fixtures. This proves **prototype shape and behavior**. It does **not** prove live provider rights or live data parity, and the test module docstring must say so verbatim.
+
+**Rollback / stop condition:** Stop if passing requires widening the allowed-difference set — the set is closed by Amendment B. Stop if any leg requires live network access; fixtures are offline by construction.
+
+---
+
+## Task 16 — Full audit, static checks, and sandbox proof gate
+
+**Prerequisite:** Task 15 green.
+
+**Objective:** Run the complete verification surface, then stop for approval before touching the Machina sandbox.
+
+**Commands:**
+```
+python3 -m pytest tests/test_iptc_wci_provider_substitution.py -q
+python3 -m pytest tests/test_iptc_canonical_connector.py -q
+python3 -m tools.iptc.run_test_suites
+python3 -m tools.iptc                      # regenerate; diff must be empty or explained
+scripts/check-no-openai.sh                 # repo AI-route lint
+```
+Plus: full install audit (every `_install.yml` reference resolves) and static template import checks (every workflow/mapping/connector reference resolves without executing).
+
+**Create/Modify:** none beyond regenerated inventory artifacts, if any.
+
+**Commit message:** `chore(iptc): full audit for WCI canonical substitution`
+
+**🛑 EXTERNAL APPROVAL GATE — STOP HERE.**
+Do not import to or execute in the Machina sandbox. Report: all command outputs, the four-provider result matrix, and the request to approve sandbox import.
+
+**After approval only:**
+1. Import the templates into the **sandbox**.
+2. Execute the synthetic four-provider proof in the sandbox.
+3. Record the sandbox run outputs against the local matrix.
+
+**No production deployment** in this plan under any circumstance.
+
+**Rollback / stop condition:** If the sandbox run diverges from the local matrix on any non-allowed-difference field, stop and treat it as a real seam defect — the local fixtures are then insufficient and must be corrected before any further work. Do not adjust the sandbox to match local.
+
+---
+
+## Task 17 — Stop and review
+
+**Prerequisite:** Task 16 sandbox proof recorded.
+
+**Objective:** Hard stop. Full review of PR3-A..PR3-D before any further consumer migration.
+
+**Create:** a short review note appended to this plan file (or a sibling `-review.md`) recording: what shipped, what was proven, what was explicitly not proven, and open findings.
+
+**Later work — outline only, not authorized by this plan:**
+- **E** — Machina Media / shared selectors
+- **F** — SportsClaw `get_canonical_event`
+- **G** — Sports TV
+- Customer migration and alias-removal plans
+
+**Explicitly out of scope:** Sports Moment, Sports Experience, Coach Mode.
+
+**Commit message:** `docs(iptc): record PR3 stop-and-review outcome`
+
+**Rollback / stop condition:** No new consumer work begins until this review is signed off.
+
+---
+
+# Acceptance matrix
+
+| # | Task | Primary artifact | Green proof | Gate |
+|---|---|---|---|---|
+| 1 | Coupling detection | `tools/iptc/inventory.py` | `test_iptc_consumer_inventory.py` detects `worldcup:event`, `value.schema:startDate`, `value.sport:status` | — |
+| 2 | Review ledger | `docs/iptc/consumer-review.json` | unreviewed count == 0; artifacts regenerated | — |
+| 3 | Packaging config | `pyproject.toml` | `python -m build` produces wheel + sdist | — |
+| 4 | Package proof | `tests/test_iptc_canonical_package.py` | clean-venv import, offline resources, hash fidelity, py39 parse, zero deps | — |
+| 5 | Publish workflow | `.github/workflows/publish-*.yml` | trusted publishing, no token secret | 🛑 release approval |
+| 6 | Runtime pin | 3 dependency files | exact `==0.1.0`; `requirements.prod.txt` untouched | blocked on release |
+| 7 | Executor proof | `tests/test_connector_canonical_runtime.py` | real `connector_script` imports package; fail-closed + redacted | — |
+| 8 | Image verify | both dockerfiles | `0.1.0` printed inside prod and dev images | 🛑 sandbox image approval |
+| 9 | Shared connector | `connectors/machina-sports-canonical/` | delegates to package; no vocabulary; no CLI | blocked on sandbox runtime |
+| 10 | Preflight | connector pyscript | prototype adapters refused at production tier; **zero** provider calls | — |
+| 11 | Resolver | `workflows/worldcup-resolve-canonical-event.yml` | equivalent provider IDs → same Machina URN; marked surrogates | — |
+| 12 | Compat projection | WCI mapping | name stays `worldcup:event`; root = envelope + exact top-level aliases; per-alias snapshots + removal owner | — |
+| 13 | Ingest rewire | `worldcup-ingest-fixtures.yml` | preflight before retrieval; `mint_event_identity` not called | — |
+| 14 | Read seam | context workflow + response mapping + preview lookup | prompt hash, task order, cache semantics, outputs unchanged | — |
+| 15 | Four-provider proof | `tests/test_iptc_wci_provider_substitution.py` | identity/participants/start/status/score equivalent; closed difference set | — |
+| 16 | Full audit | all suites + install/static checks | all green; four-provider matrix recorded | 🛑 sandbox template approval |
+| 17 | Stop/review | review note | sign-off recorded | 🛑 hard stop |
+
+---
+
+# Strict merge order
+
+```
+CoS Amendment B
+  → PR3-A
+  → PR3-B merge
+  → 0.1.0 publish approval / release
+  → PR3-C merge
+  → sandbox image approval
+  → PR3-D
+  → sandbox template approval / proof
+  → stop & review
+```
+
+No step may be started before its predecessor is complete. In particular: **PR3-C task 6 is blocked until `0.1.0` is published and verified**, and **PR3-D task 9 is blocked until the sandbox runs an image containing the pinned package**.

--- a/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
+++ b/docs/plans/2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md
@@ -37,14 +37,16 @@ These facts constrain the design and must not be re-litigated during implementat
 
 # PR3-A — Architecture/inventory hardening (current `machina-templates` branch)
 
-Branch: `refactor/iptc-consumers-and-compatibility` (existing, HEAD `d38baeb`).
+Branch: `refactor/iptc-consumers-and-compatibility` (existing). The branch was opened at
+inventory commit `d38baeb`; the reviewed plan commit `02fe533` sits on top of it, so the
+branch tip is not `d38baeb` and no task should assert that it is.
 No consumers are modified in this PR. Only inventory tooling, review ledger, and regenerated artifacts.
 
 ---
 
 ## Task 1 — Document-name and storage-predicate detection in the inventory tool
 
-**Prerequisite:** HEAD is `d38baeb` (inventory commit) on `refactor/iptc-consumers-and-compatibility`; working tree clean apart from ignored `.claude/tasks/CURRENT.md`.
+**Prerequisite:** On `refactor/iptc-consumers-and-compatibility`, with inventory commit `d38baeb` present and the reviewed plan commit `02fe533` applied on top of it — `02fe533` is the base this task builds on, not `d38baeb`. Working tree clean apart from ignored `.claude/tasks/CURRENT.md`.
 
 **Objective:** Teach `tools/iptc/inventory.py` to detect two coupling classes the current scan misses: (a) **document-name coupling** — literal document names such as `worldcup:event` used in save/load/query positions; (b) **storage-predicate coupling** — filter/sorter/query paths such as `value.schema:startDate` and `value.sport:status` that bind a consumer to the persisted document shape. Detection must be evidence-bearing: each hit records file, line, matched literal, and coupling category.
 
@@ -53,6 +55,7 @@ No consumers are modified in this PR. Only inventory tooling, review ledger, and
 
 **Modify:**
 - `tools/iptc/inventory.py`
+- `tools/iptc/test-suites.json` — **mechanically required, not discretionary.** `tests/test_iptc_test_manifest.py` asserts exact set equality between the manifest and the `tests/test_iptc_*.py` files on disk, so creating the new suite without registering it fails the manifest gate and `run_test_suites` refuses to start. Register the new suite in its existing group at its sorted position; touch no other manifest field.
 
 **Test paths:**
 - `tests/test_iptc_consumer_inventory.py`
@@ -65,7 +68,10 @@ Write `tests/test_iptc_consumer_inventory.py` with at minimum these cases:
 2. `test_detects_storage_predicate_startdate` — a snippet containing `value.schema:startDate` in a filter/sorter yields `category == "storage-predicate"` and `path == "value.schema:startDate"`.
 3. `test_detects_storage_predicate_status` — same for `value.sport:status`.
 4. `test_findings_carry_file_and_line_evidence` — every finding has non-empty `file` and integer `line >= 1`.
-5. `test_real_repo_scan_detects_worldcup_event_couplings` — scanning the real `agent-templates/world-cup-intelligence/` tree returns at least one `document-name` finding for `worldcup:event` and at least one `storage-predicate` finding each for `value.schema:startDate` and `value.sport:status`.
+5. `test_real_repo_scan_detects_worldcup_event_couplings` — a real-repo scan returns findings at their **verified** locations, which are two different trees:
+   - at least one `document-name` finding for the literal `worldcup:event` from `agent-templates/world-cup-intelligence/`;
+   - at least one `storage-predicate` finding for the exact path `value.schema:startDate` **and** at least one for the exact path `value.sport:status`, both from the real `connectors/` tree — `connectors/sportradar-soccer/` and `connectors/stats-perform/` are the confirmed carriers of both paths.
+6. `test_the_storage_predicates_are_absent_from_wci_and_present_in_connectors` — a separate guard asserting the inverse: scanning `agent-templates/world-cup-intelligence/` alone yields **zero** `storage-predicate` findings for either exact path, while the connectors scan yields both. WCI filters on `name`, `value._id`, `value.@type`, `value.event_urn`, `value.subject_urn`, `value.status` and `value.ts`; it reads `schema:startDate` and `sport:status` in Python off an already-loaded document, which is not a storage predicate. This guard exists so that a later change moving a predicate into WCI fails loudly, and so that case 5 can never be made to pass by broadening the matcher — matching a bare `sport:status` or `schema:startDate` anywhere in a file is the forbidden false-positive matcher and must not be used to manufacture a WCI hit.
 
 Command:
 ```
@@ -84,7 +90,7 @@ COUPLING_STORAGE_PREDICATE = "storage-predicate"
 def scan_couplings(root: str) -> list[dict]:
     """Return findings: {file, line, category, literal|path, snippet}."""
 ```
-plus the two narrow matchers it needs. Wire `scan_couplings` into the existing inventory generation so its findings land in the generated dependency records under an added `couplings` key. Do **not** restructure the existing scanner, rename existing fields, or change existing output ordering beyond the added key.
+plus the two narrow matchers it needs. Wire `scan_couplings` into the existing inventory generation so its findings land in the generated inventory under an added **top-level** `couplings` key — a sibling of the existing top-level keys, appended after them. Every pre-existing top-level key must survive unchanged, with its existing position preserved; a test pins that key set and its order. Do **not** restructure the existing scanner, rename existing fields, or change existing output ordering beyond appending the one additive key.
 
 **GREEN commands:**
 - Focused: `python3 -m pytest tests/test_iptc_consumer_inventory.py -q`
@@ -92,7 +98,15 @@ plus the two narrow matchers it needs. Wire `scan_couplings` into the existing i
 
 **Commit message:** `test(iptc): detect document-name and storage-predicate couplings`
 
-**Rollback / stop condition:** If wiring `couplings` into generation changes any pre-existing field of `inventory.json` other than the additive key, revert the wiring, keep `scan_couplings` standalone, and record the deviation in the commit body. Stop and report if the real-repo scan case (5) cannot pass without loosening matchers to substring-anywhere matching — a matcher that fires inside prose/comments is a false-positive generator and must not ship.
+**Rollback / stop condition:** If wiring `couplings` into generation changes any pre-existing top-level key of `inventory.json` — its presence, its value or its position — other than appending the additive `couplings` key, revert the wiring, keep `scan_couplings` standalone, and record the deviation in the commit body.
+
+Stop and report if case 5 cannot pass **against its corrected evidence roots**: the `document-name` finding from `agent-templates/world-cup-intelligence/`, and both exact `value.*` `storage-predicate` findings from the real `connectors/` tree. Do not relocate an assertion to a root the evidence does not support, and do not loosen matchers to substring-anywhere matching to force a hit — a matcher that fires inside prose, docstrings, `description:` fields or commented-out tasks is a false-positive generator and must not ship.
+
+### ⚠️ Task 1 evidence amendment / implementation deviation
+
+The approved spec asserted that both `value.schema:startDate` and `value.sport:status` storage-predicate couplings exist inside `agent-templates/world-cup-intelligence`. Verified repository evidence says otherwise: WCI carries `worldcup:event` document-name couplings, but neither of those two exact `value.*` paths. They live in the provider connector trees, principally `connectors/sportradar-soccer/` and `connectors/stats-perform/`. **The code candidate remains `9f563a0`; no code change was required** — it already used narrow, context-aware matchers and already pinned the WCI absence with its own test, so the plan was wrong and the code was right. Two consequences carry forward and must be honoured downstream: **Task 2** must assign owners and dispositions for those provider connector consumers, not treat WCI as the coupled party; and **Task 12** cannot reason about alias closure from WCI alone, because the readers that filter on the persisted storage shape are those connector workflows.
+
+**Recorded history:** candidate commit `9f563a0` triggered this correction. It ran against the earlier version of case 5, which asserted all three findings inside `agent-templates/world-cup-intelligence/`; the repository evidence contradicted that premise. The plan has been amended to the verified roots above. The prohibition on broad matching is unchanged and still absolute — broadening was, and remains, the wrong way to satisfy the old assertion.
 
 ---
 
@@ -583,7 +597,9 @@ Expected failure (RED): `FileNotFoundError` for the resolver workflow; then case
 
 **Prerequisite:** Task 11 green.
 
-**Objective:** Add exactly **one** explicit, versioned, deprecated compatibility projection derived **only** from `event_view`. The persisted document name stays `worldcup:event`. The document root value is the canonical envelope **plus** the exact legacy top-level aliases that existing filters/readers require. Nested-only compatibility is **forbidden** — the storage-predicate findings from Task 1 prove readers filter on top-level paths.
+**Objective:** Add exactly **one** explicit, versioned, deprecated compatibility projection derived **only** from `event_view`. The persisted document name stays `worldcup:event`. The document root value is the canonical envelope **plus** the exact legacy top-level aliases that existing filters/readers require. Nested-only compatibility is **forbidden** — the Task 1 storage-predicate findings prove readers filter on top-level paths.
+
+The consumers those findings name are **provider connector workflows**, principally under `connectors/sportradar-soccer/` and `connectors/stats-perform/`, not WCI itself: WCI reads `schema:startDate` and `sport:status` in Python from an already-loaded document. Top-level aliases therefore remain necessary, but the compatibility they preserve is owed to those real provider connector consumers. This does **not** widen the task: the scope stays the single WCI projection under the unchanged document name `worldcup:event`, and no connector workflow is modified here. Migrating those consumers is later work outside this plan.
 
 **Create:**
 - Compatibility projection definition (mapping or workflow fragment) under `agent-templates/world-cup-intelligence/mappings/` — exact filename chosen at implementation time and recorded in the commit body
@@ -601,7 +617,7 @@ Expected failure (RED): `FileNotFoundError` for the resolver workflow; then case
 4. `test_nested_only_compatibility_rejected` — a projection that nests the aliases fails the check (guards regression).
 5. `test_snapshot_per_alias_with_removal_owner` — one snapshot test per alias; each alias carries a documented removal owner and deprecation version.
 6. `test_no_rename_and_no_index_removal` — no document rename and no index removal in the diff.
-7. `test_storage_predicates_still_resolve` — `value.schema:startDate` and `value.sport:status` resolve against the projected document (direct tie-back to Task 1 findings).
+7. `test_storage_predicates_still_resolve` — the exact predicates `value.schema:startDate` and `value.sport:status`, as written by the real provider connector consumers Task 1 located under `connectors/sportradar-soccer/` and `connectors/stats-perform/`, still resolve against the projected document. Direct tie-back to the Task 1 findings at their verified locations; assert against the predicate paths those connectors actually use, not against a WCI-authored predicate, which does not exist.
 
 Command:
 ```

--- a/tests/test_iptc_consumer_inventory.py
+++ b/tests/test_iptc_consumer_inventory.py
@@ -1,0 +1,344 @@
+"""Coupling detection in the consumer inventory (PR 3-A, task 1).
+
+Run from the repository root:
+
+    python3 -m pytest tests/test_iptc_consumer_inventory.py -q
+    python3 tests/test_iptc_consumer_inventory.py -v
+
+Run the file directly, for the same reason as the other IPTC suites: ``tests/``
+is a namespace directory with no ``__init__.py``, so ``-m unittest
+tests.<module>`` can be shadowed by an installed distribution that ships a
+top-level regular ``tests`` package.
+
+**The hole this closes.** ``build_consumers`` finds a consumer by matching known
+IPTC *field paths* and *payload state keys* as substrings. That misses two ways a
+consumer can be welded to the persisted document, both of which the PR 3 seam has
+to preserve:
+
+1. **document-name coupling** — a literal document name such as ``worldcup:event``
+   in a save, load or query position. Rename the document and every one of these
+   silently reads nothing. The current scan never looks at document names.
+2. **storage-predicate coupling** — a filter, sorter or query path such as
+   ``value.schema:startDate`` or ``value.sport:status``. These bind the consumer
+   to the *storage* shape rather than to the response shape, so a projection that
+   only supplies the field nested under a canonical envelope breaks them while
+   every field-path check still passes.
+
+Both are evidence-bearing: a finding nobody can locate is a finding nobody can
+act on, so each records file, line, category, the matched literal or path, and
+the source line.
+
+**Why the matchers are narrow, and why that is the point.** ``worldcup:event``
+and ``sport:status`` both appear in ordinary prose and in commented-out YAML all
+over this repository — docstrings, ``description:`` fields, disabled tasks. A
+substring-anywhere matcher would report those, and an inventory that cries wolf
+is an inventory whose findings get skimmed. So detection keys on *position*: a
+document-name literal is only a finding under a document-name key, and a storage
+predicate is only a finding on a line that is not a comment. Two tests below
+exist purely to hold that line.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.iptc.inventory import (  # noqa: E402
+    COUPLING_DOCUMENT_NAME,
+    COUPLING_STORAGE_PREDICATE,
+    SCAN_ROOTS,
+    build_inventory,
+    scan_couplings,
+)
+
+#: The consumer tree PR 3-D substitutes providers underneath.
+WCI_ROOT = "agent-templates/world-cup-intelligence"
+
+#: A document task that loads by literal document name — the shape used across
+#: the WCI workflows, minus the quoting the workflow engine happens to require.
+DOCUMENT_NAME_SNIPPET = """\
+workflow:
+  tasks:
+    - type: document
+      name: load-events
+      description: Load cached worldcup:event docs from same-pod document state.
+      config:
+        action: search
+      filters:
+        name: worldcup:event
+"""
+
+#: A document task that filters and sorts on the persisted document shape.
+STORAGE_PREDICATE_SNIPPET = """\
+workflow:
+  tasks:
+    - type: document
+      name: load-upcoming
+      config:
+        action: search
+        search-sorters: ["value.schema:startDate", 1]
+      filters:
+        value.schema:startDate: "{'$gt': 'now'}"
+        value.sport:status: "{'$in': ['not_started']}"
+"""
+
+
+class CouplingScanTestCase(unittest.TestCase):
+    """Scans run against a throwaway tree, never against this repository, except
+    where a test says it is checking the real thing."""
+
+    def scan_snippet(self, filename: str, text: str) -> list:
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        (directory / filename).write_text(text, encoding="utf-8")
+        return scan_couplings(str(directory))
+
+    def of_category(self, findings, category) -> list:
+        return [f for f in findings if f["category"] == category]
+
+
+class TestDocumentNameCoupling(CouplingScanTestCase):
+
+    def test_detects_document_name_coupling(self):
+        """A literal document name in a load position, reported as such."""
+        findings = self.scan_snippet("consumer.yml", DOCUMENT_NAME_SNIPPET)
+        document_name = self.of_category(findings, COUPLING_DOCUMENT_NAME)
+        self.assertEqual([f["literal"] for f in document_name], ["worldcup:event"])
+        self.assertEqual(document_name[0]["category"], "document-name")
+
+    def test_the_task_name_is_not_mistaken_for_a_document_name(self):
+        """``name: load-events`` is a task name. Reporting it would mean the
+        matcher is keying on the key alone and not on the value being a
+        prefixed literal at all."""
+        findings = self.scan_snippet("consumer.yml", DOCUMENT_NAME_SNIPPET)
+        self.assertNotIn(
+            "load-events",
+            [f.get("literal") for f in self.of_category(findings,
+                                                        COUPLING_DOCUMENT_NAME)])
+
+    def test_a_prose_mention_of_a_document_name_is_not_a_finding(self):
+        """``worldcup:event`` appears in the snippet's ``description:`` too, and
+        in docstrings throughout the real tree. A matcher that reports prose is a
+        false-positive generator; this is the stop condition, as a test."""
+        findings = self.scan_snippet("consumer.yml", DOCUMENT_NAME_SNIPPET)
+        lines = [f["line"] for f in self.of_category(findings,
+                                                     COUPLING_DOCUMENT_NAME)]
+        description_line = DOCUMENT_NAME_SNIPPET.splitlines().index(
+            "      description: Load cached worldcup:event docs from same-pod"
+            " document state.") + 1
+        self.assertNotIn(description_line, lines)
+
+
+class TestStoragePredicateCoupling(CouplingScanTestCase):
+
+    def test_detects_storage_predicate_startdate(self):
+        findings = self.scan_snippet("consumer.yml", STORAGE_PREDICATE_SNIPPET)
+        predicates = self.of_category(findings, COUPLING_STORAGE_PREDICATE)
+        self.assertIn("value.schema:startDate", [f["path"] for f in predicates])
+        for finding in predicates:
+            self.assertEqual(finding["category"], "storage-predicate")
+
+    def test_detects_storage_predicate_status(self):
+        findings = self.scan_snippet("consumer.yml", STORAGE_PREDICATE_SNIPPET)
+        predicates = self.of_category(findings, COUPLING_STORAGE_PREDICATE)
+        self.assertIn("value.sport:status", [f["path"] for f in predicates])
+
+    def test_the_sorter_position_is_detected_as_well_as_the_filter_key(self):
+        """``search-sorters`` binds the consumer to the storage shape exactly as
+        a filter key does, and it is the position the real repository uses most."""
+        findings = self.scan_snippet("consumer.yml", STORAGE_PREDICATE_SNIPPET)
+        sorter_line = [
+            index + 1
+            for index, line in enumerate(STORAGE_PREDICATE_SNIPPET.splitlines())
+            if "search-sorters" in line
+        ][0]
+        self.assertIn(sorter_line,
+                      [f["line"] for f in self.of_category(
+                          findings, COUPLING_STORAGE_PREDICATE)])
+
+    def test_a_commented_out_predicate_is_not_a_finding(self):
+        """``connectors/sportradar-soccer/workflows/event-consumer-prelive.yml``
+        carries a whole disabled task whose filter lines are commented out. A
+        matcher that reports those reports work nobody has to do."""
+        findings = self.scan_snippet("consumer.yml", """\
+workflow:
+  tasks:
+    # - type: document
+    #   filters:
+    #     value.schema:startDate: "{'$gt': 'now'}"
+    #     value.sport:status: "{'$in': ['not_started']}"
+""")
+        self.assertEqual(self.of_category(findings, COUPLING_STORAGE_PREDICATE),
+                         [])
+
+
+class TestEveryFindingCanBeLocated(CouplingScanTestCase):
+
+    def all_findings(self) -> list:
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        (directory / "names.yml").write_text(DOCUMENT_NAME_SNIPPET,
+                                             encoding="utf-8")
+        (directory / "predicates.yml").write_text(STORAGE_PREDICATE_SNIPPET,
+                                                  encoding="utf-8")
+        return scan_couplings(str(directory))
+
+    def test_findings_carry_file_and_line_evidence(self):
+        findings = self.all_findings()
+        self.assertTrue(findings, "the scan found nothing to carry evidence for")
+        for finding in findings:
+            with self.subTest(finding=finding):
+                self.assertIsInstance(finding["file"], str)
+                self.assertTrue(finding["file"])
+                self.assertIsInstance(finding["line"], int)
+                self.assertNotIsInstance(finding["line"], bool)
+                self.assertGreaterEqual(finding["line"], 1)
+
+    def test_every_finding_carries_a_category_and_a_snippet(self):
+        for finding in self.all_findings():
+            with self.subTest(finding=finding):
+                self.assertIn(finding["category"],
+                              (COUPLING_DOCUMENT_NAME,
+                               COUPLING_STORAGE_PREDICATE))
+                self.assertTrue(finding["snippet"].strip())
+
+    def test_the_recorded_line_really_contains_the_matched_text(self):
+        """Evidence that cannot be checked is decoration. The recorded line
+        number is read back off the file it names."""
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        (directory / "predicates.yml").write_text(STORAGE_PREDICATE_SNIPPET,
+                                                  encoding="utf-8")
+        for finding in scan_couplings(str(directory)):
+            with self.subTest(finding=finding):
+                matched = finding.get("literal") or finding.get("path")
+                source = (directory / "predicates.yml").read_text(
+                    encoding="utf-8").splitlines()
+                self.assertIn(matched, source[finding["line"] - 1])
+
+
+class TestTheRealRepositoryIsScanned(CouplingScanTestCase):
+    """The synthetic cases prove the matchers bite. These prove they bite on the
+    tree PR 3 actually has to keep working."""
+
+    def test_real_repo_scan_detects_worldcup_event_couplings(self):
+        """WCI's document-name coupling, and the storage-predicate couplings, on
+        real bytes.
+
+        **Deviation from the task brief, recorded here rather than hidden.** The
+        brief expected all three findings inside
+        ``agent-templates/world-cup-intelligence/``. The document-name coupling
+        is there. The two storage predicates are **not**: WCI filters only on
+        ``name``, ``value._id``, ``value.@type``, ``value.event_urn``,
+        ``value.subject_urn``, ``value.status`` and ``value.ts``, and reads
+        ``schema:startDate`` / ``sport:status`` in Python off an already-loaded
+        document instead. ``value.schema:startDate`` and ``value.sport:status``
+        live in ``connectors/sportradar-soccer/`` and
+        ``connectors/stats-perform/``.
+
+        Making this test pass against the WCI root alone would require matching a
+        bare ``sport:status`` anywhere in a file, which fires in prose and
+        comments — the explicitly forbidden outcome. So the assertion is split to
+        follow the evidence: document-name where the document name is, storage
+        predicates where the storage predicates are. The consequence for PR 3-D
+        task 12 is real and is not this task's to fix: the consumers coupled to
+        the persisted event shape are in the provider connector trees, not in WCI.
+        """
+        wci = scan_couplings(WCI_ROOT)
+        document_names = [f for f in wci
+                          if f["category"] == COUPLING_DOCUMENT_NAME
+                          and f["literal"] == "worldcup:event"]
+        self.assertTrue(
+            document_names,
+            "no document-name coupling found for worldcup:event under "
+            "{0}".format(WCI_ROOT))
+
+        predicates = {f["path"] for f in scan_couplings("connectors")
+                      if f["category"] == COUPLING_STORAGE_PREDICATE}
+        for path in ("value.schema:startDate", "value.sport:status"):
+            with self.subTest(path=path):
+                self.assertIn(path, predicates)
+
+    def test_the_storage_predicates_are_absent_from_wci_and_present_in_connectors(self):
+        """The deviation above, asserted rather than asserted-about. If a later
+        change puts a storage predicate into WCI, this test fails and the
+        compatibility-projection reasoning in task 12 has to be revisited."""
+        wci = {f["path"] for f in scan_couplings(WCI_ROOT)
+               if f["category"] == COUPLING_STORAGE_PREDICATE}
+        self.assertEqual(
+            wci & {"value.schema:startDate", "value.sport:status"}, set())
+
+        connectors = {f["path"] for f in scan_couplings("connectors")
+                      if f["category"] == COUPLING_STORAGE_PREDICATE}
+        self.assertIn("value.schema:startDate", connectors)
+        self.assertIn("value.sport:status", connectors)
+
+    def test_every_real_finding_is_locatable_in_the_file_it_names(self):
+        """The same read-back check as the synthetic case, against real bytes —
+        this is what makes the findings usable as a work list."""
+        for finding in scan_couplings(WCI_ROOT):
+            with self.subTest(finding=finding):
+                path = REPO_ROOT / finding["file"]
+                self.assertTrue(path.is_file(), finding["file"])
+                lines = path.read_text(encoding="utf-8",
+                                       errors="replace").splitlines()
+                matched = finding.get("literal") or finding.get("path")
+                self.assertIn(matched, lines[finding["line"] - 1])
+
+    def test_no_finding_lands_on_a_comment_line(self):
+        """Narrowness, measured on the real tree rather than promised."""
+        for root in SCAN_ROOTS:
+            for finding in scan_couplings(root):
+                with self.subTest(finding=finding):
+                    self.assertFalse(finding["snippet"].lstrip().startswith("#"))
+
+
+class TestTheInventoryExposesCouplings(unittest.TestCase):
+    """The findings have to reach the generated inventory, or task 2's review
+    ledger has nothing to review."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inventory = build_inventory()
+
+    def test_the_inventory_carries_the_couplings_additively(self):
+        self.assertIn("couplings", self.inventory)
+        self.assertTrue(self.inventory["couplings"])
+
+    def test_the_inventory_couplings_cover_both_categories_from_the_scan_roots(self):
+        """The findings task 2's ledger has to account for: the WCI document name
+        and the connector storage predicates, reached from the inventory rather
+        than from a second scan a reader would have to run themselves."""
+        couplings = self.inventory["couplings"]
+        for finding in couplings:
+            with self.subTest(finding=finding):
+                self.assertTrue(finding["file"].startswith(SCAN_ROOTS))
+        self.assertIn(
+            ("{0}/_folders.yml".format(WCI_ROOT), "worldcup:event"),
+            [(f["file"], f.get("literal")) for f in couplings
+             if f["category"] == COUPLING_DOCUMENT_NAME])
+        predicates = {f["path"] for f in couplings
+                      if f["category"] == COUPLING_STORAGE_PREDICATE}
+        self.assertIn("value.schema:startDate", predicates)
+        self.assertIn("value.sport:status", predicates)
+
+    def test_the_pre_existing_top_level_keys_are_unchanged_and_in_order(self):
+        """The one shape change allowed is the added key. This pins every other
+        key and its position, so a refactor that reorders or renames one fails
+        here rather than in a reviewer's diff of a regenerated artifact."""
+        self.assertEqual(
+            [key for key in self.inventory if key != "couplings"],
+            ["inventory_version", "inventory_kind", "reproduce", "pin",
+             "categories", "scope_boundary", "known_gaps", "totals",
+             "sport_namespace_usage", "emitters", "consumers"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_iptc_consumer_inventory.py
+++ b/tests/test_iptc_consumer_inventory.py
@@ -1,4 +1,9 @@
-"""Coupling detection in the consumer inventory (PR 3-A, task 1).
+"""Coupling detection in the consumer inventory (PR 3-A, tasks 1 and 2).
+
+Task 1 is the scan (everything up to :class:`TestTheInventoryExposesCouplings`).
+Task 2 is the review ledger it feeds — ``docs/iptc/consumer-review.json``, which
+has to account for every dependency the generated inventory records; see
+:class:`ReviewLedgerTestCase` onwards.
 
 Run from the repository root:
 
@@ -47,6 +52,7 @@ description's job is to name the very path it is describing.
 
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 import tempfile
@@ -409,6 +415,242 @@ class TestTheInventoryExposesCouplings(unittest.TestCase):
             ["inventory_version", "inventory_kind", "reproduce", "pin",
              "categories", "scope_boundary", "known_gaps", "totals",
              "sport_namespace_usage", "emitters", "consumers"])
+
+
+#: The review ledger task 2 adds. Hand-authored data, not a generated artefact.
+LEDGER_PATH = REPO_ROOT / "docs/iptc/consumer-review.json"
+
+#: The generated artefact the ledger is checked against. Read off disk rather than
+#: from :func:`build_inventory`, because the point is that the *committed* artefact
+#: and the *committed* ledger agree — a ledger that only agrees with a fresh
+#: in-memory scan would let a stale artefact ship.
+INVENTORY_JSON_PATH = REPO_ROOT / "docs/iptc/inventory.json"
+
+LEDGER_SCHEMA = "machina.iptc.consumer-review/v1"
+
+#: No fifth disposition. A row nobody can place is ``excluded`` with a reason.
+ALLOWED_DISPOSITIONS = ("migrate", "compat-alias", "no-change", "excluded")
+
+#: This repository. The ledger carries ``repo`` because later PR 3 lanes review
+#: cross-repository consumers, and a bare path would then be ambiguous.
+REPO = "machina-templates"
+
+#: The generated inventory sections that record a file-level dependency on the
+#: legacy shape: files that read it, files that emit it, files welded to the
+#: document name or the storage predicate.
+DEPENDENCY_SECTIONS = ("consumers", "emitters", "couplings")
+
+#: Owner label for a dependency whose ownership cannot be grounded. Paired with
+#: ``disposition: excluded`` — inventing an owner is worse than admitting there
+#: isn't one, because an invented owner reads as a commitment somebody made.
+UNASSIGNED = "UNASSIGNED"
+
+
+class ReviewLedgerTestCase(unittest.TestCase):
+    """Base for the ledger cases.
+
+    Every test loads the ledger **first**. That ordering is deliberate: before
+    ``docs/iptc/consumer-review.json`` exists, the failure has to be the missing
+    ledger (``FileNotFoundError``) and not some incidental complaint about the
+    inventory artefact, or the RED step proves nothing about the file under test.
+    """
+
+    def load_ledger(self) -> dict:
+        with LEDGER_PATH.open(encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def entries(self) -> list:
+        return self.load_ledger()["entries"]
+
+    def load_inventory(self) -> dict:
+        inventory = json.loads(INVENTORY_JSON_PATH.read_text(encoding="utf-8"))
+        for section in DEPENDENCY_SECTIONS:
+            self.assertIn(
+                section, inventory,
+                "docs/iptc/inventory.json is stale — regenerate it with "
+                "`python3 -m tools.iptc`")
+        return inventory
+
+    def generated_dependencies(self) -> set:
+        """Every ``(repo, path)`` the generated inventory records as depending on
+        the legacy shape."""
+        inventory = self.load_inventory()
+        return {
+            (REPO, row["file"])
+            for section in DEPENDENCY_SECTIONS
+            for row in inventory[section]
+        }
+
+    def reviewed(self, entry: dict) -> bool:
+        """A row counts as reviewed only if it carries a disposition from the
+        allowed set *and* evidence. A row with a blank ``evidence`` is a row
+        somebody ticked, not a row somebody reviewed."""
+        return (entry.get("disposition") in ALLOWED_DISPOSITIONS
+                and isinstance(entry.get("evidence"), str)
+                and bool(entry["evidence"].strip()))
+
+
+class TestTheReviewLedgerIsWellFormed(ReviewLedgerTestCase):
+
+    def test_review_ledger_exists_and_has_schema_and_version(self):
+        ledger = self.load_ledger()
+        self.assertEqual(ledger["schema"], LEDGER_SCHEMA)
+        self.assertIsInstance(ledger["version"], str)
+        self.assertTrue(ledger["version"].strip())
+        self.assertIsInstance(ledger["entries"], list)
+        self.assertTrue(ledger["entries"], "a ledger with no entries reviews nothing")
+
+    def test_every_entry_has_required_fields(self):
+        for entry in self.entries():
+            with self.subTest(entry=entry.get("path"), category=entry.get("category")):
+                for field in ("repo", "path", "category", "owner", "disposition",
+                              "evidence"):
+                    self.assertIsInstance(entry.get(field), str, field)
+                    self.assertTrue(entry[field].strip(), field)
+                self.assertIn(entry["disposition"], ALLOWED_DISPOSITIONS)
+                self.assertEqual(entry["repo"], REPO)
+
+    def test_every_owner_is_grounded_in_the_path_it_owns(self):
+        """Ownership is a claim, so it has to be checkable. An owner is either
+        ``UNASSIGNED`` — which forces ``excluded`` — or a
+        ``<repo>:<surface-directory>`` label that the reviewed path actually lives
+        under. This is what stops the ledger naming a person, a team that owns
+        nothing here, or a directory the row is not in."""
+        for entry in self.entries():
+            with self.subTest(path=entry["path"], owner=entry["owner"]):
+                if entry["owner"] == UNASSIGNED:
+                    self.assertEqual(entry["disposition"], "excluded")
+                    continue
+                repo, separator, surface = entry["owner"].partition(":")
+                self.assertEqual(repo, REPO)
+                self.assertTrue(separator, "owner must be <repo>:<surface>")
+                self.assertTrue(
+                    entry["path"].startswith(surface + "/"),
+                    "{0} does not live under its claimed owner {1}".format(
+                        entry["path"], surface))
+
+
+class TestTheLedgerCoversEveryGeneratedDependency(ReviewLedgerTestCase):
+
+    def test_every_generated_dependency_is_reviewed_or_excluded(self):
+        ledger_keys = {(entry["repo"], entry["path"]) for entry in self.entries()}
+        missing = sorted(self.generated_dependencies() - ledger_keys)
+        self.assertEqual(missing, [],
+                         "{0} generated dependencies are absent from the "
+                         "ledger".format(len(missing)))
+
+    def test_unreviewed_count_is_zero(self):
+        """The headline number. A dependency is unreviewed when no ledger entry
+        for it carries both a disposition and evidence."""
+        reviewed_keys = {(entry["repo"], entry["path"]) for entry in self.entries()
+                         if self.reviewed(entry)}
+        unreviewed = sorted(self.generated_dependencies() - reviewed_keys)
+        self.assertEqual(len(unreviewed), 0, "unreviewed: {0}".format(unreviewed))
+
+    def test_no_orphan_ledger_entries(self):
+        """A ledger that drifts ahead of reality is worse than no ledger: it
+        reports work as accounted for against paths that no longer exist.
+        ``excluded`` rows are exempt, since exclusion is how a row that is *not*
+        a generated dependency gets recorded."""
+        entries = self.entries()
+        generated = self.generated_dependencies()
+        orphans = sorted(
+            (entry["repo"], entry["path"], entry["category"])
+            for entry in entries
+            if entry["disposition"] != "excluded"
+            and (entry["repo"], entry["path"]) not in generated)
+        self.assertEqual(orphans, [])
+
+
+class TestTheLedgerAgreesWithTheGeneratedEvidence(ReviewLedgerTestCase):
+    """Coverage is necessary and not sufficient. These hold the ledger to the
+    *category* the inventory recorded, in both directions, so a row cannot be
+    filed under a dependency it does not have."""
+
+    def coupling_triples(self) -> set:
+        return {(finding["file"], finding["category"],
+                 finding.get("literal") or finding.get("path"))
+                for finding in self.load_inventory()["couplings"]}
+
+    def test_the_coupling_entries_and_the_generated_findings_agree(self):
+        entries = self.entries()
+        ledger_triples = {
+            (entry["path"], entry["category"], entry.get("literal"))
+            for entry in entries
+            if entry["category"] in (COUPLING_DOCUMENT_NAME,
+                                     COUPLING_STORAGE_PREDICATE)}
+        generated = self.coupling_triples()
+        self.assertEqual(sorted(ledger_triples - generated), [],
+                         "ledger claims couplings the inventory does not record")
+        self.assertEqual(sorted(generated - ledger_triples), [],
+                         "inventory records couplings the ledger does not review")
+
+    def test_read_and_emitter_entries_match_their_inventory_section(self):
+        entries = self.entries()
+        inventory = self.load_inventory()
+        field_readers = {c["file"] for c in inventory["consumers"]
+                         if c["reads_field_paths"]}
+        payload_readers = {c["file"] for c in inventory["consumers"]
+                           if c["reads_payload_keys"]}
+        emitters = {e["file"] for e in inventory["emitters"]}
+        expected = {"field-path-read": field_readers,
+                    "payload-key-read": payload_readers,
+                    "emitter": emitters}
+        actual = {category: set() for category in expected}
+        for entry in entries:
+            if entry["category"] in actual:
+                actual[entry["category"]].add(entry["path"])
+        self.assertEqual(actual, expected)
+
+
+class TestTheDispositionsFollowTheDependencyCategory(ReviewLedgerTestCase):
+    """The failure mode this guards against is a ledger filled in with one
+    disposition everywhere, which satisfies coverage while recording no decision.
+    Each case below pins a disposition the PR 3 plan actually commits to."""
+
+    def dispositions_for(self, category, literal=None, path_prefix="") -> set:
+        return {entry["disposition"] for entry in self.entries()
+                if entry["category"] == category
+                and (literal is None or entry.get("literal") == literal)
+                and entry["path"].startswith(path_prefix)}
+
+    def test_the_worldcup_event_document_name_is_kept_by_compatibility_alias(self):
+        """The plan keeps the ``worldcup:event`` document name unchanged and
+        derives exact-path compatibility aliases underneath it. So every WCI row
+        coupled to that literal is ``compat-alias`` — not ``migrate``, which would
+        mean renaming the document, and not ``no-change``, which would mean the
+        alias requirement did not exist."""
+        dispositions = self.dispositions_for(
+            COUPLING_DOCUMENT_NAME, literal="worldcup:event",
+            path_prefix=WCI_ROOT + "/")
+        self.assertTrue(dispositions, "no worldcup:event document-name rows")
+        self.assertEqual(dispositions, {"compat-alias"})
+
+    def test_the_storage_predicates_are_owned_by_the_connector_surfaces(self):
+        """Task 1's evidence amendment, carried into the ledger: the consumers
+        welded to the persisted event shape are provider connector workflows, so
+        those connector paths — not WCI — are what carries an owner and a
+        disposition for ``value.schema:startDate`` and ``value.sport:status``."""
+        for literal in ("value.schema:startDate", "value.sport:status"):
+            with self.subTest(literal=literal):
+                owners = {entry["owner"] for entry in self.entries()
+                          if entry["category"] == COUPLING_STORAGE_PREDICATE
+                          and entry.get("literal") == literal
+                          and entry["path"].startswith("connectors/")}
+                self.assertTrue(owners, "no connector owner for " + literal)
+                for owner in owners:
+                    self.assertTrue(owner.startswith(REPO + ":connectors/"), owner)
+                self.assertEqual(
+                    self.dispositions_for(COUPLING_STORAGE_PREDICATE,
+                                          literal=literal,
+                                          path_prefix="connectors/"),
+                    {"compat-alias"})
+
+    def test_the_dispositions_are_not_uniform(self):
+        """Belt and braces on the same failure mode, measured over the whole
+        ledger rather than per case."""
+        used = {entry["disposition"] for entry in self.entries()}
+        self.assertEqual(used, set(ALLOWED_DISPOSITIONS))
 
 
 if __name__ == "__main__":

--- a/tests/test_iptc_consumer_inventory.py
+++ b/tests/test_iptc_consumer_inventory.py
@@ -34,8 +34,15 @@ over this repository — docstrings, ``description:`` fields, disabled tasks. A
 substring-anywhere matcher would report those, and an inventory that cries wolf
 is an inventory whose findings get skimmed. So detection keys on *position*: a
 document-name literal is only a finding under a document-name key, and a storage
-predicate is only a finding on a line that is not a comment. Two tests below
-exist purely to hold that line.
+predicate is only a finding on a line that is neither a comment nor part of a
+``description:`` scalar. Several tests below exist purely to hold that line.
+
+The ``description:`` exclusion was **missing** from the first version of this
+suite, and the resulting false positive
+(``connectors/sportradar-mlb/sync-results.yml:7``) survived review — see
+:class:`TestDescriptionProseIsNotAStoragePredicate`. Anchoring on ``value.`` was
+assumed to be enough to keep the matcher off prose. It is not, because a
+description's job is to name the very path it is describing.
 """
 
 from __future__ import annotations
@@ -87,6 +94,33 @@ workflow:
       filters:
         value.schema:startDate: "{'$gt': 'now'}"
         value.sport:status: "{'$in': ['not_started']}"
+"""
+
+
+#: A multi-line ``description:`` scalar that names storage paths in prose, plus a
+#: real filter after the scalar ends. Modelled on
+#: ``connectors/sportradar-mlb/sync-results.yml``, where the description explains
+#: which storage path a *downstream* workflow reads. Explaining a path is not
+#: evaluating one, so nothing in the scalar is a coupling; the ``filters:`` key
+#: below it is.
+DESCRIPTION_PROSE_SNIPPET = """\
+workflow:
+  name: sportradar-mlb-sync-results
+  description: 'Companion to sportradar-mlb-sync-games. The season schedule.json
+    carries NO runs, so this merges the score onto the existing docs.
+
+    Without this, extract-team-stats has nothing to read — it needs
+    value.sport:score.sport:homeScore / sport:awayScore — so no team stats.
+
+    Merge-not-replace: only value.sport:matchStatus is written, so version_control
+    survives.'
+  tasks:
+  - type: document
+    name: load-upcoming
+    description: |
+      A block scalar names value.sport:competition without evaluating it either.
+    filters:
+      value.sport:status: "{'$in': ['not_started']}"
 """
 
 
@@ -177,6 +211,43 @@ workflow:
 """)
         self.assertEqual(self.of_category(findings, COUPLING_STORAGE_PREDICATE),
                          [])
+
+
+class TestDescriptionProseIsNotAStoragePredicate(CouplingScanTestCase):
+    """Regression. ``value.`` anchoring was assumed to keep the storage-predicate
+    matcher off prose, and it does not: a ``description:`` scalar is prose that
+    happens to quote the storage path, and a multi-line one puts that quote on an
+    indented continuation line that looks exactly like a nested mapping key.
+
+    The narrowness claim in this module's docstring — and the "0 prose false
+    positives" claim in the commit that introduced the scan — were therefore
+    wrong for description scalars. This holds the corrected line.
+    """
+
+    def test_a_multi_line_description_scalar_is_not_a_storage_predicate(self):
+        """Prose inside the scalar is skipped; the ``filters:`` key that follows
+        it is still reported. Asserted as an exact list, because a fix that
+        swallowed the real filter along with the prose would pass a
+        ``assertNotIn`` and still be wrong."""
+        findings = self.scan_snippet("consumer.yml", DESCRIPTION_PROSE_SNIPPET)
+        predicates = self.of_category(findings, COUPLING_STORAGE_PREDICATE)
+        self.assertEqual([f["path"] for f in predicates], ["value.sport:status"])
+
+    def test_the_sportradar_mlb_description_line_is_not_reported(self):
+        """The real-repo instance the review found: line 7 of
+        ``connectors/sportradar-mlb/sync-results.yml`` is a continuation line of
+        the ``description:`` scalar opened on line 4."""
+        source = (REPO_ROOT / "connectors/sportradar-mlb/sync-results.yml").read_text(
+            encoding="utf-8").splitlines()
+        self.assertIn(
+            "value.sport:score", source[6],
+            "line 7 no longer carries the prose this regression is about; "
+            "re-point the assertion rather than deleting it")
+        self.assertEqual(
+            [f for f in scan_couplings("connectors")
+             if f["file"] == "connectors/sportradar-mlb/sync-results.yml"
+             and f["line"] == 7],
+            [])
 
 
 class TestEveryFindingCanBeLocated(CouplingScanTestCase):

--- a/tests/test_iptc_validation_harness.py
+++ b/tests/test_iptc_validation_harness.py
@@ -739,6 +739,11 @@ class TestPublicSanitization(unittest.TestCase):
             for path in sorted((REPO_ROOT / directory).rglob("*")):
                 if path.is_file() and "__pycache__" not in path.parts:
                     found.append(path)
+        # Authored plan prose. Restricted to Markdown so the scan picks up the
+        # documents without reaching into any binary or generated companion.
+        for path in sorted((REPO_ROOT / "docs" / "plans").rglob("*.md")):
+            if path.is_file():
+                found.append(path)
         found.extend([
             REPO_ROOT / "tools" / "__init__.py",
             REPO_ROOT / "docs" / "rfcs" / "001-machina-iptc-sport-schema-profile.md",
@@ -780,6 +785,21 @@ class TestPublicSanitization(unittest.TestCase):
         ):
             self.assertIn(required, scanned)
         self.assertGreater(len(scanned), 40)
+
+    def test_the_scan_covers_authored_plan_documents(self):
+        """Plan documents are authored prose that ships in this PUBLIC repo.
+
+        They are the likeliest place for internal identifiers and roadmap names
+        to survive, so leaving `docs/plans` outside the scan makes the
+        sanitization gate pass for the wrong reason.
+        """
+        scanned = {p.relative_to(REPO_ROOT).as_posix() for p in self.scanned_files()}
+        plans = {p for p in scanned if p.startswith("docs/plans/")}
+        self.assertIn(
+            "docs/plans/"
+            "2026-08-10-iptc-pr3-canonical-runtime-wci-provider-substitution.md",
+            plans,
+        )
 
     def test_the_only_exclusion_is_the_byte_exact_vendored_upstream(self):
         """The three Machina-authored reference files are scanned; the pin is not."""

--- a/tools/iptc/inventory.py
+++ b/tools/iptc/inventory.py
@@ -149,10 +149,45 @@ _DOCUMENT_NAME_LITERAL = re.compile(
 
 #: A ``value.…prefix:localName`` storage path, as it appears both as a filter key
 #: and inside a ``search-sorters`` list. Anchored on the ``value.`` root the
-#: document store actually uses, which is what keeps it off prose.
+#: document store actually uses, which keeps it off most prose — but NOT off a
+#: ``description:`` scalar, which is prose whose whole job is to name the storage
+#: path a downstream workflow reads. See :data:`_DESCRIPTION_KEY`.
 _STORAGE_PREDICATE_PATH = re.compile(
     r'(?<![\w.])value(?:\.[A-Za-z0-9_@$-]+)*'
     r'\.[A-Za-z][A-Za-z0-9_-]*:[A-Za-z][A-Za-z0-9_-]+')
+
+#: A ``description:`` key, capturing everything before it so its column is known.
+#: The column is what makes the skip safe: a YAML scalar's continuation lines are
+#: always indented *past* their key's column, so the scalar ends at the first
+#: subsequent line indented at or before it — which is the sibling key, and a
+#: sibling key is a real task parameter that must still be scanned.
+_DESCRIPTION_KEY = re.compile(r'^(\s*(?:-\s+)?)"?description"?\s*:')
+
+
+def _description_scalar_lines(lines: list[str]) -> set[int]:
+    """1-based line numbers occupied by a ``description:`` key and its scalar.
+
+    Covers every scalar style the repository uses — single-quoted spanning
+    several lines, block (``|`` / ``>``) and plain — because none of them need
+    telling apart: all three continue on lines indented past the key's column and
+    all three end at the first line that is not.
+    """
+    inside: set[int] = set()
+    column: int | None = None
+    for number, line in enumerate(lines, start=1):
+        if column is not None:
+            if not line.strip():
+                inside.add(number)
+                continue
+            if len(line) - len(line.lstrip()) > column:
+                inside.add(number)
+                continue
+            column = None
+        match = _DESCRIPTION_KEY.match(line)
+        if match:
+            column = len(match.group(1))
+            inside.add(number)
+    return inside
 
 
 def _coupling_files(root: Path) -> list[Path]:
@@ -181,7 +216,13 @@ def scan_couplings(root: str) -> list[dict]:
     mostly noise is one whose findings get skimmed. A document name therefore
     counts only under a document-name key, a storage predicate only when rooted at
     the ``value.`` path the document store uses, and neither counts on a comment
-    line.
+    line or inside a ``description:`` scalar.
+
+    The description skip is the one exclusion that is not about the *shape* of the
+    text. ``value.sport:score`` inside a description is spelled exactly like a
+    filter key, and on a multi-line scalar it even sits on an indented
+    continuation line — so position alone cannot separate the two. What separates
+    them is that a description explains a path rather than evaluating one.
     """
     base = Path(root)
     if not base.is_absolute():
@@ -193,8 +234,10 @@ def scan_couplings(root: str) -> list[dict]:
         except ValueError:
             relative = str(path.relative_to(base))
         text = path.read_text(encoding="utf-8", errors="replace")
-        for number, line in enumerate(text.splitlines(), start=1):
-            if line.lstrip().startswith("#"):
+        lines = text.splitlines()
+        described = _description_scalar_lines(lines)
+        for number, line in enumerate(lines, start=1):
+            if line.lstrip().startswith("#") or number in described:
                 continue
             snippet = line.strip()
             key_match = _DOCUMENT_NAME_KEY.match(line)

--- a/tools/iptc/inventory.py
+++ b/tools/iptc/inventory.py
@@ -123,6 +123,99 @@ CATEGORIES = {
 CV_PREFIX_STEM = NEWSCODE_STEM
 STAT_NAMESPACE_STEM = "https://sportschema.org/ontologies/"
 
+#: A consumer welded to a literal document name — ``worldcup:event`` in a save,
+#: load or query position. Rename the document and every one of these reads
+#: nothing, silently.
+COUPLING_DOCUMENT_NAME = "document-name"
+
+#: A consumer welded to the *storage* shape through a filter, sorter or query
+#: path such as ``value.schema:startDate``. A projection that supplies the field
+#: only nested under a canonical envelope breaks these while every field-path
+#: check in :func:`build_consumers` still passes.
+COUPLING_STORAGE_PREDICATE = "storage-predicate"
+
+#: The keys whose value is a document name. This allowlist is the whole reason
+#: the document-name matcher does not fire in prose: ``worldcup:event`` appears in
+#: docstrings and ``description:`` fields throughout this repository, and only a
+#: ``name``/``document_name`` key puts it in a save, load or query position.
+_DOCUMENT_NAME_KEY = re.compile(
+    r'^\s*(?:-\s*)?"?(?:name|document_name|document-name)"?\s*:\s*(\S.*)$')
+
+#: A ``prefix:localName`` literal inside a document-name value. The lookbehind and
+#: lookahead keep it from matching a segment of a longer colon-delimited token, so
+#: a URN value yields nothing rather than yielding its first two segments.
+_DOCUMENT_NAME_LITERAL = re.compile(
+    r'(?<![\w.:-])([a-z][a-z0-9_-]*):([A-Za-z][A-Za-z0-9_-]*)(?![\w:-])')
+
+#: A ``value.…prefix:localName`` storage path, as it appears both as a filter key
+#: and inside a ``search-sorters`` list. Anchored on the ``value.`` root the
+#: document store actually uses, which is what keeps it off prose.
+_STORAGE_PREDICATE_PATH = re.compile(
+    r'(?<![\w.])value(?:\.[A-Za-z0-9_@$-]+)*'
+    r'\.[A-Za-z][A-Za-z0-9_-]*:[A-Za-z][A-Za-z0-9_-]+')
+
+
+def _coupling_files(root: Path) -> list[Path]:
+    found = [
+        path
+        for pattern in ("*.yml", "*.py")
+        for path in root.rglob(pattern)
+        if path.is_file() and "__pycache__" not in path.parts
+    ]
+    return sorted(set(found))
+
+
+def scan_couplings(root: str) -> list[dict]:
+    """Every document-name and storage-predicate coupling under ``root``.
+
+    Returns findings of the form
+    ``{file, line, category, literal|path, snippet}`` — ``literal`` for a
+    document name, ``path`` for a storage predicate.
+
+    ``root`` is repository-relative or absolute.
+
+    Detection is deliberately **position-aware rather than substring-anywhere**.
+    Both ``worldcup:event`` and ``sport:status`` occur constantly in prose,
+    docstrings and commented-out tasks here, so a substring scan would report
+    dozens of lines nobody has to change — and an inventory whose findings are
+    mostly noise is one whose findings get skimmed. A document name therefore
+    counts only under a document-name key, a storage predicate only when rooted at
+    the ``value.`` path the document store uses, and neither counts on a comment
+    line.
+    """
+    base = Path(root)
+    if not base.is_absolute():
+        base = REPO_ROOT / base
+    findings: list[dict] = []
+    for path in _coupling_files(base):
+        try:
+            relative = str(path.relative_to(REPO_ROOT))
+        except ValueError:
+            relative = str(path.relative_to(base))
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for number, line in enumerate(text.splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            snippet = line.strip()
+            key_match = _DOCUMENT_NAME_KEY.match(line)
+            if key_match:
+                for prefix, local in _DOCUMENT_NAME_LITERAL.findall(
+                        key_match.group(1)):
+                    if prefix in URI_SCHEMES:
+                        continue
+                    findings.append({
+                        "file": relative, "line": number,
+                        "category": COUPLING_DOCUMENT_NAME,
+                        "literal": f"{prefix}:{local}", "snippet": snippet,
+                    })
+            for predicate in _STORAGE_PREDICATE_PATH.findall(line):
+                findings.append({
+                    "file": relative, "line": number,
+                    "category": COUPLING_STORAGE_PREDICATE,
+                    "path": predicate, "snippet": snippet,
+                })
+    return findings
+
 
 def _mapping_files() -> list[Path]:
     found: list[Path] = []
@@ -399,6 +492,14 @@ def build_inventory() -> dict:
         "sport_namespace_usage": {k: sorted(v) for k, v in sorted(namespaces.items())},
         "emitters": emitters,
         "consumers": consumers,
+        # Additive. The field-path scan above cannot see a literal document name
+        # or a storage-predicate path, and both are consumer dependencies the
+        # migration has to carry. Kept as its own list rather than folded into
+        # `consumers` because a coupled file is not necessarily a field-path
+        # consumer — `_folders.yml` names the document and reads no field at all.
+        "couplings": [
+            finding for root in SCAN_ROOTS for finding in scan_couplings(root)
+        ],
     }
 
 

--- a/tools/iptc/test-suites.json
+++ b/tools/iptc/test-suites.json
@@ -32,6 +32,10 @@
       "timeout_seconds": 600
     },
     {
+      "path": "tests/test_iptc_consumer_inventory.py",
+      "group": "canonical"
+    },
+    {
       "path": "tests/test_iptc_cross_provider_equivalence.py",
       "group": "canonical"
     },


### PR DESCRIPTION
## Summary
- adds evidence-bearing document-name and storage-predicate coupling detection
- registers a machine-checkable review ledger with zero unreviewed dependencies
- regenerates the additive coupling inventory without changing consumers
- expands public sanitization coverage to authored plan documents

## Scope
Inventory tooling, tests, generated evidence, and implementation plan only. No consumer behavior, canonical runtime bytes, packaging, publication, or deployment changes.

## Verification
- consumer inventory: 30 tests passed
- test manifest: 53 tests passed
- public sanitization: 7 tests passed
- full IPTC runner: 18/18 suites passed
- generator check: current
- final exact-candidate release review: APPROVE

Related task: 86ajwr1yg