### PR TITLE
feat(prophetx): Affiliate API connector — authenticated read-only market data + Auto-Fill handoff

### DIFF
--- a/connectors/prophetx/README.md
+++ b/connectors/prophetx/README.md
@@ -1,0 +1,69 @@
+# ProphetX Affiliate API connector
+
+Authenticated, **read-only** market data from the ProphetX betting exchange
+(tournaments, sport events, markets with odds and per-level liquidity), plus
+official **Auto-Fill** deep links for bet-slip handoff. Machina never places,
+modifies, or cancels wagers — the write surface (MM/ISV APIs) is intentionally
+not implemented. Design: `docs/plans/2026-08-13-001-feat-prophetx-affiliate-connector-design-log.md`.
+
+## Environments (fixed allowlist — arbitrary endpoints rejected)
+
+| environment | Base URL |
+|---|---|
+| `sandbox` (default) | `https://api.sandbox.prophetx.dev/partner` |
+| `production` | `https://cash.api.prophetx.co/partner` |
+
+Note: the pre-2026 sandbox domain (`*-ss-sandbox.betprophet.co`) is dead.
+
+## Credentials (vault only)
+
+Store as two logical connections — `prophetx-affiliate-sandbox` and
+`prophetx-affiliate-production` — and reference via context variables. Never
+commit or log token values.
+
+- **Mode A (single API key):** `MACHINA_CONTEXT_VARIABLE_PROPHETX_API_KEY` —
+  sent in the `Authorization` header. Default is the **raw key without
+  `Bearer`** (per the official Market Data guide); the spec text contradicts
+  this, so `auth_scheme: bearer` is available as an opt-in and the sandbox
+  smoke reports which one the environment accepts.
+- **Mode B (login session):** `MACHINA_CONTEXT_VARIABLE_PROPHETX_ACCESS_KEY` +
+  `..._SECRET_KEY` → `POST /auth/login` → access token (10-minute expiry,
+  cached in-process, refresh-then-relogin on expiry, one re-login on 401).
+- `MACHINA_CONTEXT_VARIABLE_PROPHETX_PARTNER_ID` — Auto-Fill attribution id.
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `get_tournaments` | Tournaments (optionally only those with active events) |
+| `get_sport_events` | Events by `tournament_id` (MLB=109, NFL=31, NBA=132, NHL=234) or explicit `event_ids` |
+| `get_markets` | Markets for one event — `api_version` v1–v4, default **v3** (liquidity levels); v4 = CFTC naming mapped onto the same neutral fields; `cftc_terminology: true` sends the v3 opt-in header |
+| `get_multiple_markets` | Markets for up to **50** events per call; tolerates the documented dual-shape response (dict keyed by event id OR flat list) |
+| `build_autofill_link` | Pure: `line_id(s)` + `partner_id` (+ optional odds) → official app/OneLink/web handoff links |
+| `health` | One bounded authenticated GET — credential + reachability check |
+
+Normalized records preserve `_raw`, keep `line_id` **verbatim** (it is the
+Auto-Fill handoff currency), and do **not** derive implied probability yet —
+official examples disagree on the odds format (American vs decimal) and the
+sandbox smoke settles it before any conversion is added.
+
+Upstream limits honored: 50 req/s account budget (client backs off on 429 and
+honors `Retry-After`), `event_ids` ≤ 50, no pagination on this API.
+
+## Verify
+
+```bash
+# offline unit tests (no network, no credentials)
+python3 -m pytest connectors/prophetx/tests/ -q
+
+# bounded sandbox smoke (~8 GETs; requires the sandbox key in the environment)
+PROPHETX_API_SANDBOX=... python3 connectors/prophetx/tests/smoke_sandbox.py
+
+# in-platform credential check (after vault setup)
+# run workflow: prophetx-test-credentials   (health, sandbox by default)
+# run workflow: prophetx-market-discovery   (events + v3 markets)
+```
+
+The production smoke is read-only, bounded, and **separately approved** —
+`python3 connectors/prophetx/tests/smoke_sandbox.py --environment production`
+only after that approval.

--- a/connectors/prophetx/README.md
+++ b/connectors/prophetx/README.md
@@ -42,10 +42,13 @@ commit or log token values.
 | `build_autofill_link` | Pure: `line_id(s)` + `partner_id` (+ optional odds) → official app/OneLink/web handoff links |
 | `health` | One bounded authenticated GET — credential + reachability check |
 
-Normalized records preserve `_raw`, keep `line_id` **verbatim** (it is the
-Auto-Fill handoff currency), and do **not** derive implied probability yet —
-official examples disagree on the odds format (American vs decimal) and the
-sandbox smoke settles it before any conversion is added.
+Normalized records preserve `_raw` and keep `line_id` **verbatim** (it is the
+Auto-Fill handoff currency). Odds format was **resolved by the sandbox smoke
+(2026-08-13): American** (`-375` / `+320`; `adjusted_odds` = commission-adjusted
+float; `stake` = available liquidity per level) — `implied_probability` is
+derived when odds are present. Selection `updated_at` is epoch **nanoseconds**;
+`updated_at_s` carries the seconds-normalized value. Auth resolved as **raw
+key** (no `Bearer`) — the `bearer` opt-in stays available for drift.
 
 Upstream limits honored: 50 req/s account budget (client backs off on 429 and
 honors `Retry-After`), `event_ids` ≤ 50, no pagination on this API.

--- a/connectors/prophetx/README.md
+++ b/connectors/prophetx/README.md
@@ -70,3 +70,23 @@ PROPHETX_API_SANDBOX=... python3 connectors/prophetx/tests/smoke_sandbox.py
 The production smoke is read-only, bounded, and **separately approved** —
 `python3 connectors/prophetx/tests/smoke_sandbox.py --environment production`
 only after that approval.
+
+## Demo — odds screen + Auto-Fill handoff (reproducible)
+
+```bash
+# terminal demo: renders the odds screen and builds the handoff links
+# (defaults: sandbox, game tournaments MLB=109/NFL=31/NBA=132/NHL=234,
+#  partner_id "machina-sports")
+PROPHETX_API_SANDBOX=... python3 connectors/prophetx/tests/demo_odds_screen.py
+
+# in-platform demo (after vault setup):
+# run workflow prophetx-demo-autofill-handoff with inputs
+#   {"event_id": <id>, "partner_id": "machina-sports"}
+# outputs: odds_screen (market/selection/odds/prob/stake rows),
+#          selected_line, autofill_links (app / OneLink / web)
+```
+
+Machina's involvement in bet placement ends at the Auto-Fill links — account,
+geolocation, wallet, and wager execution are entirely ProphetX's. The legacy
+Medium "Direct Play" flow (partner-managed session + private wager POST) is
+intentionally NOT implemented.

--- a/connectors/prophetx/_install.yml
+++ b/connectors/prophetx/_install.yml
@@ -33,3 +33,6 @@ datasets:
 
   - type: workflow
     path: workflows/market-discovery.yml
+
+  - type: workflow
+    path: workflows/demo-autofill-handoff.yml

--- a/connectors/prophetx/_install.yml
+++ b/connectors/prophetx/_install.yml
@@ -1,0 +1,35 @@
+setup:
+  title: ProphetX Affiliate API
+  description: Authenticated read-only access to ProphetX betting-exchange market data (tournaments, sport events, markets with odds and liquidity levels) and official Auto-Fill handoff links for odds-screen integrations. Machina never places wagers.
+  category:
+    - sports-data
+    - betting-exchange
+    - odds
+  estimatedTime: 5 minutes
+  features:
+    - Tournaments and sport events discovery (sandbox and production environments)
+    - Markets with odds, lines, and per-level liquidity (Affiliate API v1-v4; v3 default, v4 CFTC naming)
+    - Batch markets for up to 50 events per call
+    - Official Auto-Fill deep links (app, OneLink, web) for bet-slip handoff with partner attribution
+    - Read-only by design - no wager, order, or balance operations
+  integrations:
+    - prophetx
+  requirements:
+    - MACHINA_CONTEXT_VARIABLE_PROPHETX_API_KEY (mode A - single Affiliate API key; leave empty when using mode B)
+    - MACHINA_CONTEXT_VARIABLE_PROPHETX_ACCESS_KEY (mode B - access key for /auth/login session flow)
+    - MACHINA_CONTEXT_VARIABLE_PROPHETX_SECRET_KEY (mode B - secret key for /auth/login session flow)
+    - MACHINA_CONTEXT_VARIABLE_PROPHETX_PARTNER_ID (Auto-Fill attribution identifier)
+  status: available
+  value: connectors/prophetx
+  version: 0.1.0
+
+datasets:
+
+  - type: connector
+    path: prophetx.yml
+
+  - type: workflow
+    path: test-credentials.yml
+
+  - type: workflow
+    path: workflows/market-discovery.yml

--- a/connectors/prophetx/prophetx.py
+++ b/connectors/prophetx/prophetx.py
@@ -28,10 +28,12 @@ API. The multiple-markets response schema is empty in the official spec; the
 real shape is a dict keyed by event id that may occasionally arrive as a flat
 list — both shapes are parsed defensively.
 
-Odds format note: official examples disagree (American ``-470`` vs "decimal
-price" ``1.95``). Until the sandbox smoke settles it per version, ``odds`` is
-passed through verbatim (plus ``display_odds``) and NO implied probability is
-derived here.
+Odds format — RESOLVED by the sandbox smoke (2026-08-13): ``odds`` is
+**American** (e.g. ``-375`` / ``+320``; ``display_odds`` carries the sign,
+``adjusted_odds`` is a commission-adjusted float, ``stake`` is the available
+liquidity at that level). ``implied_probability`` is derived from the American
+``odds`` when present. Selection ``updated_at`` is epoch **nanoseconds**
+(normalized to seconds in ``updated_at_s``).
 
 Credentials are injected by the workflow runtime from vault context variables
 (MACHINA_CONTEXT_VARIABLE_PROPHETX_*). They are never logged, never echoed in
@@ -64,6 +66,22 @@ _AUTOFILL_WEB = "https://www.prophetx.co/"
 # Mode-B session cache: (environment, access_key) -> token record.
 _token_cache = {}
 _token_lock = threading.Lock()
+
+
+def _american_to_probability(odds):
+    """Implied probability from American odds (format confirmed live).
+
+    Returns None when odds are absent/zero/non-numeric.
+    """
+    try:
+        value = float(odds)
+    except (TypeError, ValueError):
+        return None
+    if value == 0:
+        return None
+    if value > 0:
+        return round(100.0 / (value + 100.0), 4)
+    return round(-value / (-value + 100.0), 4)
 
 
 # ============================================================
@@ -381,10 +399,13 @@ def _normalize_selection(selection, api_version):
         "name": selection.get("display_name") or selection.get("name", ""),
         "odds": odds,
         "display_odds": display_odds,
+        "adjusted_odds": selection.get("adjusted_price") if api_version == "v4" else selection.get("adjusted_odds"),
+        "implied_probability": _american_to_probability(odds),
         "line": line,
         "display_line": display_line,
         "stake": stake,
         "updated_at": selection.get("updated_at"),
+        "updated_at_s": _as_epoch_seconds(selection.get("updated_at")) or None,
         "_raw": selection,
     }
 
@@ -443,16 +464,27 @@ def _extract_markets_payload(payload):
 
 def _extract_multiple_markets_payload(payload, requested_ids):
     """Multiple-events markets: officially a dict keyed by event id, but 'a
-    small number of responses may come back as a flat list' (official guide).
-    The spec schema is empty, so both shapes are handled. Returns dict
-    str(event_id) -> [raw markets] or None on drift."""
+    small number of responses may come back as a flat list' (official guide),
+    and per-event values have been observed varying too. The spec schema is
+    empty, so parsing is defensive: null values become empty lists and any
+    other odd per-event value lands in '_unattributed' instead of failing the
+    whole batch. Returns dict str(event_id) -> [raw markets] or None only
+    when `data` itself is neither dict nor list (true drift)."""
     data = payload.get("data") if isinstance(payload, dict) else None
     if isinstance(data, dict):
         grouped = {}
+        oddities = []
         for key, value in data.items():
-            if not isinstance(value, list):
-                return None
-            grouped[str(key)] = value
+            if value is None:
+                grouped[str(key)] = []
+            elif isinstance(value, list):
+                grouped[str(key)] = value
+            elif isinstance(value, dict):
+                grouped[str(key)] = [value]
+            else:
+                oddities.append({"event_key": str(key), "value": value})
+        if oddities:
+            grouped.setdefault("_unattributed", []).extend(oddities)
         return grouped
     if isinstance(data, list):
         grouped = {str(eid): [] for eid in requested_ids}
@@ -703,7 +735,11 @@ def get_multiple_markets(request_data):
             return _error("Unexpected multiple-markets payload shape", error_class="provider_bad_response")
         if _want_normalize(params):
             grouped = {
-                key: [_normalize_market(m, key, api_version) for m in markets]
+                key: (
+                    markets  # oddities/orphans stay raw — never fake-normalized
+                    if key == "_unattributed"
+                    else [_normalize_market(m, key, api_version) for m in markets]
+                )
                 for key, markets in grouped.items()
             }
         total = sum(len(markets) for markets in grouped.values())

--- a/connectors/prophetx/prophetx.py
+++ b/connectors/prophetx/prophetx.py
@@ -1,0 +1,797 @@
+"""ProphetX Affiliate API connector — authenticated, read-only market data.
+
+Implements the approved design log
+(docs/plans/2026-08-13-001-feat-prophetx-affiliate-connector-design-log.md).
+
+Surface: the External Affiliate API (Swagger 2.0, 10 GET endpoints, zero write
+surface). Odds/liquidity exist ONLY here — the public catalog API exposes none
+(verified live 2026-08-13). Wager placement lives in ProphetX's MM/ISV APIs and
+is intentionally NOT implemented: the Direct Play demo hands off via official
+Auto-Fill deep links (`build_autofill_link`), never executing a wager.
+
+Environments (fixed allowlist — arbitrary endpoints are rejected by design):
+- sandbox:    https://api.sandbox.prophetx.dev/partner
+- production: https://cash.api.prophetx.co/partner
+
+Auth (two documented modes, resolved per call from injected headers):
+- mode A: single API key sent raw in the ``Authorization`` header
+- mode B: access_key + secret_key -> POST /auth/login -> access_token
+  (documented expiry: 10 minutes) + refresh_token; cached per
+  (environment, access_key); one re-login on 401, then typed failure.
+Upstream docs contradict each other on a ``Bearer`` prefix (spec says Bearer,
+integration guide says raw). ``auth_scheme`` param ("raw" default | "bearer")
+keeps both paths open until the sandbox smoke resolves it empirically.
+
+Upstream limits honored: 50 req/s account budget (client stays far below and
+backs off on 429), ``event_ids`` batches capped at 50, no pagination on this
+API. The multiple-markets response schema is empty in the official spec; the
+real shape is a dict keyed by event id that may occasionally arrive as a flat
+list — both shapes are parsed defensively.
+
+Odds format note: official examples disagree (American ``-470`` vs "decimal
+price" ``1.95``). Until the sandbox smoke settles it per version, ``odds`` is
+passed through verbatim (plus ``display_odds``) and NO implied probability is
+derived here.
+
+Credentials are injected by the workflow runtime from vault context variables
+(MACHINA_CONTEXT_VARIABLE_PROPHETX_*). They are never logged, never echoed in
+errors or receipts, and never stored beyond the in-process token cache.
+"""
+
+import threading
+import time
+
+import requests
+
+BASE_URLS = {
+    "sandbox": "https://api.sandbox.prophetx.dev/partner",
+    "production": "https://cash.api.prophetx.co/partner",
+}
+
+MARKET_API_VERSIONS = ("v1", "v2", "v3", "v4")
+DEFAULT_MARKET_VERSION = "v3"
+MAX_EVENT_IDS = 50
+
+_TIMEOUT_S = 30
+_MAX_RETRIES = 2
+_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+# Auto-Fill deep-link templates (official Auto-Fill Integration Guide).
+_AUTOFILL_APP = "prophetx://addtobetslip"
+_AUTOFILL_ONELINK = "https://prophetx.onelink.me/E5Yi/autofill"
+_AUTOFILL_WEB = "https://www.prophetx.co/"
+
+# Mode-B session cache: (environment, access_key) -> token record.
+_token_cache = {}
+_token_lock = threading.Lock()
+
+
+# ============================================================
+# Envelope helpers
+# ============================================================
+
+
+def _success(data, message=""):
+    return {"status": True, "data": data, "message": message}
+
+
+def _error(message, error_class="upstream_error", data=None):
+    return {"status": False, "data": data, "message": message, "error_class": error_class}
+
+
+def _sanitize_upstream(body_json, status_code):
+    """Build a safe upstream error string — codes and upstream error/message
+    fields only; never headers, never credentials."""
+    if isinstance(body_json, dict):
+        upstream_error = body_json.get("error")
+        upstream_message = body_json.get("message")
+        detail = " / ".join(str(part) for part in (upstream_error, upstream_message) if part)
+        if detail:
+            return f"HTTP {status_code}: {detail}"
+    return f"HTTP {status_code}"
+
+
+# ============================================================
+# Auth
+# ============================================================
+
+
+def _resolve_environment(params):
+    environment = str((params or {}).get("environment", "sandbox")).strip().lower()
+    if environment not in BASE_URLS:
+        return None, _error(
+            f"Unknown environment '{environment}'. Allowed: {', '.join(sorted(BASE_URLS))}.",
+            error_class="invalid_request",
+        )
+    return environment, None
+
+
+def _auth_header_value(token, auth_scheme):
+    if str(auth_scheme).strip().lower() == "bearer":
+        return f"Bearer {token}"
+    return token
+
+
+def _login(base_url, access_key, secret_key):
+    """POST /auth/login -> token record. Returns (record, error)."""
+    try:
+        response = requests.post(
+            f"{base_url}/auth/login",
+            json={"access_key": access_key, "secret_key": secret_key},
+            headers={"Accept": "application/json"},
+            timeout=_TIMEOUT_S,
+        )
+    except requests.RequestException as exc:
+        return None, _error(f"Login request failed: {exc.__class__.__name__}", error_class="provider_unavailable")
+    if response.status_code != 200:
+        body = _safe_json(response)
+        return None, _error(
+            f"Login rejected ({_sanitize_upstream(body, response.status_code)})",
+            error_class="credential_invalid",
+        )
+    body = _safe_json(response) or {}
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict) or not data.get("access_token"):
+        return None, _error("Login response missing access_token", error_class="provider_bad_response")
+    record = {
+        "access_token": data.get("access_token"),
+        "access_expire_time": _as_epoch_seconds(data.get("access_expire_time")),
+        "refresh_token": data.get("refresh_token"),
+        "refresh_expire_time": _as_epoch_seconds(data.get("refresh_expire_time")),
+    }
+    return record, None
+
+
+def _refresh(base_url, record):
+    """POST /auth/refresh -> updated record or None (caller falls back to login)."""
+    refresh_token = (record or {}).get("refresh_token")
+    if not refresh_token:
+        return None
+    try:
+        response = requests.post(
+            f"{base_url}/auth/refresh",
+            json={"refresh_token": refresh_token},
+            headers={"Accept": "application/json"},
+            timeout=_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None
+    if response.status_code != 200:
+        return None
+    body = _safe_json(response) or {}
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict) or not data.get("access_token"):
+        return None
+    updated = dict(record)
+    updated["access_token"] = data.get("access_token")
+    updated["access_expire_time"] = _as_epoch_seconds(data.get("access_expire_time"))
+    if data.get("refresh_token"):
+        updated["refresh_token"] = data.get("refresh_token")
+        updated["refresh_expire_time"] = _as_epoch_seconds(data.get("refresh_expire_time"))
+    return updated
+
+
+def _as_epoch_seconds(value):
+    """Upstream timestamps have shown ns/ms/s variants — normalize to seconds."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number > 1e17:  # nanoseconds
+        return number / 1e9
+    if number > 1e14:  # microseconds
+        return number / 1e6
+    if number > 1e11:  # milliseconds
+        return number / 1e3
+    return number
+
+
+def _get_token(environment, base_url, access_key, secret_key):
+    """Cached mode-B token with refresh-then-login fallback. Returns (token, error)."""
+    cache_key = (environment, access_key)
+    now = time.time()
+    with _token_lock:
+        record = _token_cache.get(cache_key)
+    if record:
+        expire = record.get("access_expire_time")
+        if expire is None or now < expire - 30:
+            return record["access_token"], None
+        refreshed = _refresh(base_url, record)
+        if refreshed:
+            with _token_lock:
+                _token_cache[cache_key] = refreshed
+            return refreshed["access_token"], None
+    record, err = _login(base_url, access_key, secret_key)
+    if err:
+        return None, err
+    with _token_lock:
+        _token_cache[cache_key] = record
+    return record["access_token"], None
+
+
+def _invalidate_token(environment, access_key):
+    with _token_lock:
+        _token_cache.pop((environment, access_key), None)
+
+
+def _resolve_auth(request_data, environment, base_url):
+    """Resolve the Authorization header from injected credentials.
+
+    Returns (auth_value, mode, error). mode is 'api_key' or 'session'.
+    """
+    headers = request_data.get("headers") or {}
+    auth_scheme = (request_data.get("params") or {}).get("auth_scheme", "raw")
+    api_key = (headers.get("api_key") or "").strip()
+    access_key = (headers.get("access_key") or "").strip()
+    secret_key = (headers.get("secret_key") or "").strip()
+
+    if api_key:
+        return _auth_header_value(api_key, auth_scheme), "api_key", None
+    if access_key and secret_key:
+        token, err = _get_token(environment, base_url, access_key, secret_key)
+        if err:
+            return None, "session", err
+        return _auth_header_value(token, auth_scheme), "session", None
+    return None, None, _error(
+        "Credentials missing: provide either 'api_key' or 'access_key'+'secret_key' "
+        "(vault context variables MACHINA_CONTEXT_VARIABLE_PROPHETX_*).",
+        error_class="credential_missing",
+    )
+
+
+# ============================================================
+# HTTP
+# ============================================================
+
+
+def _safe_json(response):
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _api_get(request_data, environment, base_url, path, query=None, extra_headers=None):
+    """Authenticated GET with bounded retries/backoff and one 401 re-login.
+
+    Returns (payload_json, error).
+    """
+    auth_value, mode, err = _resolve_auth(request_data, environment, base_url)
+    if err:
+        return None, err
+
+    relogged = False
+    attempt = 0
+    while True:
+        request_headers = {"Authorization": auth_value, "Accept": "application/json"}
+        if extra_headers:
+            request_headers.update(extra_headers)
+        try:
+            response = requests.get(
+                f"{base_url}{path}",
+                params={k: v for k, v in (query or {}).items() if v is not None and v != ""},
+                headers=request_headers,
+                timeout=_TIMEOUT_S,
+            )
+        except requests.RequestException as exc:
+            if attempt < _MAX_RETRIES:
+                attempt += 1
+                time.sleep(min(5.0, 0.5 * (2**attempt)))
+                continue
+            return None, _error(f"Request failed: {exc.__class__.__name__}", error_class="provider_unavailable")
+
+        if response.status_code == 200:
+            body = _safe_json(response)
+            if body is None:
+                return None, _error("Malformed JSON from upstream", error_class="provider_bad_response")
+            return body, None
+
+        body = _safe_json(response)
+
+        if response.status_code == 401 and mode == "session" and not relogged:
+            headers = request_data.get("headers") or {}
+            _invalidate_token(environment, (headers.get("access_key") or "").strip())
+            auth_value, mode, err = _resolve_auth(request_data, environment, base_url)
+            if err:
+                return None, err
+            relogged = True
+            continue
+        if response.status_code == 401:
+            return None, _error(
+                f"Unauthorized ({_sanitize_upstream(body, 401)})", error_class="credential_invalid"
+            )
+        if response.status_code == 403:
+            return None, _error(
+                f"Forbidden — key/session caps or blocked ({_sanitize_upstream(body, 403)})",
+                error_class="credential_invalid",
+            )
+        if response.status_code in _RETRYABLE_STATUSES and attempt < _MAX_RETRIES:
+            attempt += 1
+            retry_after = response.headers.get("Retry-After")
+            try:
+                delay = min(10.0, float(retry_after))
+            except (TypeError, ValueError):
+                delay = min(10.0, 0.5 * (2**attempt))
+            time.sleep(delay)
+            continue
+        if response.status_code == 429:
+            return None, _error(
+                f"Rate limited ({_sanitize_upstream(body, 429)})", error_class="provider_rate_limited"
+            )
+        if response.status_code == 404:
+            return None, _error(
+                f"Not found ({_sanitize_upstream(body, 404)})", error_class="data_not_found"
+            )
+        return None, _error(_sanitize_upstream(body, response.status_code))
+
+
+# ============================================================
+# Normalizers (provider-neutral + _raw; no invented fields)
+# ============================================================
+
+
+def _normalize_competitor(competitor):
+    return {
+        "id": competitor.get("id"),
+        "name": competitor.get("display_name") or competitor.get("name", ""),
+        "abbreviation": competitor.get("abbreviation", ""),
+        "side": competitor.get("side", ""),
+        "_raw": competitor,
+    }
+
+
+def _normalize_event(event):
+    return {
+        "event_id": event.get("event_id"),
+        "name": event.get("display_name") or event.get("name", ""),
+        "tournament_id": event.get("tournament_id"),
+        "tournament": event.get("tournament_name", ""),
+        "sport": event.get("sport_name", ""),
+        "scheduled": event.get("scheduled", ""),
+        "status": event.get("status", ""),
+        "type": event.get("type", ""),
+        "competitors": [_normalize_competitor(c) for c in event.get("competitors") or []],
+        "_raw": event,
+    }
+
+
+def _normalize_selection(selection, api_version):
+    """One selection/liquidity level. v4 uses CFTC names — mapped onto the
+    same neutral fields; `line_id` is preserved verbatim (handoff currency)."""
+    if not isinstance(selection, dict):
+        return None
+    if api_version == "v4":
+        line_id = selection.get("strike_id")
+        odds = selection.get("price")
+        line = selection.get("strike")
+        stake = selection.get("quantity")
+        display_odds = selection.get("display_price", "")
+        display_line = selection.get("display_strike", "")
+    else:
+        line_id = selection.get("line_id")
+        odds = selection.get("odds")
+        line = selection.get("line")
+        stake = selection.get("stake")
+        display_odds = selection.get("display_odds", "")
+        display_line = selection.get("display_line", "")
+    return {
+        "line_id": line_id,
+        "outcome_id": selection.get("outcome_id"),
+        "competitor_id": selection.get("competitor_id"),
+        "name": selection.get("display_name") or selection.get("name", ""),
+        "odds": odds,
+        "display_odds": display_odds,
+        "line": line,
+        "display_line": display_line,
+        "stake": stake,
+        "updated_at": selection.get("updated_at"),
+        "_raw": selection,
+    }
+
+
+def _normalize_selections(raw_selections, api_version):
+    """v1/v2: flat list of selections. v3/v4: list of side-groups, each group a
+    list of liquidity levels (order-book depth). Output mirrors the input
+    nesting so depth is never flattened away."""
+    if not isinstance(raw_selections, list):
+        return []
+    normalized = []
+    for item in raw_selections:
+        if isinstance(item, list):
+            group = [_normalize_selection(level, api_version) for level in item]
+            normalized.append([level for level in group if level is not None])
+        else:
+            level = _normalize_selection(item, api_version)
+            if level is not None:
+                normalized.append(level)
+    return normalized
+
+
+def _normalize_market(market, event_id, api_version):
+    line = market.get("strike") if api_version == "v4" else market.get("line")
+    return {
+        "id": market.get("id"),
+        "market_key": f"{event_id}:{market.get('id')}",
+        "event_id": event_id,
+        "name": market.get("display_name") or market.get("name", ""),
+        "group_name": market.get("group_name", ""),
+        "type": market.get("type", ""),
+        "sub_type": market.get("sub_type", ""),
+        "category": market.get("category_name", ""),
+        "player_id": market.get("player_id"),
+        "favourite": bool(market.get("favourite")),
+        "line": line,
+        "selections": _normalize_selections(market.get("selections"), api_version),
+        "api_version": api_version,
+        "_raw": market,
+    }
+
+
+def _extract_markets_payload(payload):
+    """Single-event markets: {"data": {"event_id": ..., "markets": [...]}}."""
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if isinstance(data, dict):
+        markets = data.get("markets")
+        if isinstance(markets, list):
+            return data.get("event_id"), markets
+        if markets is None:
+            return data.get("event_id"), []
+    if isinstance(data, list):
+        return None, data
+    return None, None
+
+
+def _extract_multiple_markets_payload(payload, requested_ids):
+    """Multiple-events markets: officially a dict keyed by event id, but 'a
+    small number of responses may come back as a flat list' (official guide).
+    The spec schema is empty, so both shapes are handled. Returns dict
+    str(event_id) -> [raw markets] or None on drift."""
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if isinstance(data, dict):
+        grouped = {}
+        for key, value in data.items():
+            if not isinstance(value, list):
+                return None
+            grouped[str(key)] = value
+        return grouped
+    if isinstance(data, list):
+        grouped = {str(eid): [] for eid in requested_ids}
+        orphans = []
+        for market in data:
+            event_id = market.get("sport_event_id") or market.get("sportEventId") or market.get("event_id")
+            if event_id is not None and str(event_id) in grouped:
+                grouped[str(event_id)].append(market)
+            else:
+                orphans.append(market)
+        if orphans:
+            grouped.setdefault("_unattributed", []).extend(orphans)
+        return grouped
+    return None
+
+
+# ============================================================
+# Commands — read-only Affiliate endpoints
+# ============================================================
+
+
+def get_tournaments(request_data):
+    """List tournaments (leagues/competitions).
+
+    headers: api_key OR access_key+secret_key (vault-injected)
+    params:
+        environment (str): 'sandbox' (default) or 'production'
+        has_active_events (bool): only tournaments with active events
+        auth_scheme (str): 'raw' (default) or 'bearer'
+        normalize (bool): default True
+    """
+    try:
+        params = request_data.get("params") or {}
+        environment, err = _resolve_environment(params)
+        if err:
+            return err
+        base_url = BASE_URLS[environment]
+        query = {}
+        if params.get("has_active_events") is not None:
+            query["has_active_events"] = str(bool(params["has_active_events"])).lower()
+        payload, err = _api_get(request_data, environment, base_url, "/affiliate/get_tournaments", query)
+        if err:
+            return err
+        data = payload.get("data") if isinstance(payload, dict) else None
+        tournaments = (data or {}).get("tournaments") if isinstance(data, dict) else None
+        if tournaments is None:
+            tournaments = data if isinstance(data, list) else []
+        if not isinstance(tournaments, list):
+            return _error("Unexpected tournaments payload shape", error_class="provider_bad_response")
+        return _success(
+            {"tournaments": tournaments, "count": len(tournaments), "environment": environment},
+            f"Retrieved {len(tournaments)} tournaments",
+        )
+    except Exception as exc:  # noqa: BLE001 - connector must fail gracefully
+        return _error(f"Error fetching tournaments: {exc.__class__.__name__}: {exc}")
+
+
+def get_sport_events(request_data):
+    """List sport events for a tournament (or explicit event ids).
+
+    params:
+        environment (str): 'sandbox' (default) or 'production'
+        tournament_id (int): tournament filter (e.g. MLB=109, NFL=31, NBA=132)
+        event_ids (list[int]): explicit event ids (alternative to tournament_id)
+        normalize (bool): default True
+    """
+    try:
+        params = request_data.get("params") or {}
+        environment, err = _resolve_environment(params)
+        if err:
+            return err
+        tournament_id = params.get("tournament_id")
+        event_ids = params.get("event_ids") or []
+        if tournament_id in (None, "") and not event_ids:
+            return _error("tournament_id or event_ids is required", error_class="invalid_request")
+        query = {}
+        if tournament_id not in (None, ""):
+            query["tournament_id"] = tournament_id
+        if event_ids:
+            query["event_ids"] = ",".join(str(eid) for eid in event_ids)
+        payload, err = _api_get(
+            request_data, environment, BASE_URLS[environment], "/affiliate/get_sport_events", query
+        )
+        if err:
+            return err
+        data = payload.get("data") if isinstance(payload, dict) else None
+        events = (data or {}).get("sport_events") if isinstance(data, dict) else None
+        if events is None:
+            events = data if isinstance(data, list) else []
+        if not isinstance(events, list):
+            return _error("Unexpected sport_events payload shape", error_class="provider_bad_response")
+        normalized = [_normalize_event(e) for e in events] if _want_normalize(params) else events
+        return _success(
+            {"sport_events": normalized, "count": len(normalized), "environment": environment},
+            f"Retrieved {len(normalized)} sport events",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error(f"Error fetching sport events: {exc.__class__.__name__}: {exc}")
+
+
+def _want_normalize(params):
+    value = params.get("normalize", True)
+    if isinstance(value, str):
+        return value.strip().lower() not in ("false", "0", "no")
+    return bool(value)
+
+
+def _resolve_market_version(params):
+    api_version = str(params.get("api_version", DEFAULT_MARKET_VERSION)).strip().lower()
+    if api_version not in MARKET_API_VERSIONS:
+        return None, _error(
+            f"api_version must be one of {', '.join(MARKET_API_VERSIONS)}", error_class="invalid_request"
+        )
+    return api_version, None
+
+
+def _market_path(api_version, multiple=False):
+    suffix = "get_multiple_markets" if multiple else "get_markets"
+    if api_version == "v1":
+        return f"/affiliate/{suffix}"
+    return f"/{api_version}/affiliate/{suffix}"
+
+
+def _market_query(params):
+    query = {}
+    if params.get("get_all_market") is not None:
+        query["get_all_market"] = str(bool(params["get_all_market"])).lower()
+    if params.get("market_types"):
+        value = params["market_types"]
+        query["market_types"] = ",".join(value) if isinstance(value, list) else str(value)
+    if params.get("min_liquidity") is not None:
+        query["min_liquidity"] = params["min_liquidity"]
+    return query
+
+
+def _as_bool(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "false", "0", "no")
+    return bool(value)
+
+
+def _cftc_headers(params, api_version):
+    """X-CFTC-Terminology opt-in is documented for v3 only."""
+    if api_version == "v3" and _as_bool(params.get("cftc_terminology"), default=False):
+        return {"X-CFTC-Terminology": "true"}
+    return None
+
+
+def get_markets(request_data):
+    """Markets (with odds/liquidity) for one event.
+
+    params:
+        environment (str): 'sandbox' (default) or 'production'
+        event_id (int): required
+        api_version (str): v1|v2|v3|v4 (default v3 — liquidity levels;
+            v4 = CFTC naming, normalized onto the same neutral fields)
+        get_all_market (bool), market_types (csv|list), min_liquidity (number)
+        cftc_terminology (bool): v3 only — sends X-CFTC-Terminology: true
+        normalize (bool): default True (raw payload always kept under _raw)
+    """
+    try:
+        params = request_data.get("params") or {}
+        environment, err = _resolve_environment(params)
+        if err:
+            return err
+        event_id = params.get("event_id")
+        if event_id in (None, ""):
+            return _error("event_id is required", error_class="invalid_request")
+        api_version, err = _resolve_market_version(params)
+        if err:
+            return err
+        query = {"event_id": event_id}
+        query.update(_market_query(params))
+        payload, err = _api_get(
+            request_data,
+            environment,
+            BASE_URLS[environment],
+            _market_path(api_version),
+            query,
+            extra_headers=_cftc_headers(params, api_version),
+        )
+        if err:
+            return err
+        payload_event_id, markets = _extract_markets_payload(payload)
+        if markets is None:
+            return _error("Unexpected markets payload shape", error_class="provider_bad_response")
+        resolved_event_id = payload_event_id or event_id
+        if _want_normalize(params):
+            markets = [_normalize_market(m, resolved_event_id, api_version) for m in markets]
+        return _success(
+            {
+                "markets": markets,
+                "count": len(markets),
+                "event_id": resolved_event_id,
+                "api_version": api_version,
+                "environment": environment,
+            },
+            f"Retrieved {len(markets)} markets",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error(f"Error fetching markets: {exc.__class__.__name__}: {exc}")
+
+
+def get_multiple_markets(request_data):
+    """Markets for up to 50 events in one call (dual-shape tolerant).
+
+    params:
+        environment (str): 'sandbox' (default) or 'production'
+        event_ids (list[int]): required, 1..50 ids
+        api_version (str): v1|v2|v3|v4 (default v3)
+        get_all_market, market_types, min_liquidity, cftc_terminology, normalize
+    """
+    try:
+        params = request_data.get("params") or {}
+        environment, err = _resolve_environment(params)
+        if err:
+            return err
+        event_ids = params.get("event_ids") or []
+        if isinstance(event_ids, str):
+            event_ids = [part.strip() for part in event_ids.split(",") if part.strip()]
+        if not event_ids:
+            return _error("event_ids is required (1..50 ids)", error_class="invalid_request")
+        if len(event_ids) > MAX_EVENT_IDS:
+            return _error(
+                f"event_ids accepts at most {MAX_EVENT_IDS} ids per call (got {len(event_ids)}); "
+                "split into batches",
+                error_class="invalid_request",
+            )
+        api_version, err = _resolve_market_version(params)
+        if err:
+            return err
+        query = {"event_ids": ",".join(str(eid) for eid in event_ids)}
+        query.update(_market_query(params))
+        payload, err = _api_get(
+            request_data,
+            environment,
+            BASE_URLS[environment],
+            _market_path(api_version, multiple=True),
+            query,
+            extra_headers=_cftc_headers(params, api_version),
+        )
+        if err:
+            return err
+        grouped = _extract_multiple_markets_payload(payload, event_ids)
+        if grouped is None:
+            return _error("Unexpected multiple-markets payload shape", error_class="provider_bad_response")
+        if _want_normalize(params):
+            grouped = {
+                key: [_normalize_market(m, key, api_version) for m in markets]
+                for key, markets in grouped.items()
+            }
+        total = sum(len(markets) for markets in grouped.values())
+        return _success(
+            {
+                "markets_by_event": grouped,
+                "event_count": len([k for k in grouped if k != "_unattributed"]),
+                "market_count": total,
+                "api_version": api_version,
+                "environment": environment,
+            },
+            f"Retrieved {total} markets across {len(grouped)} events",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error(f"Error fetching multiple markets: {exc.__class__.__name__}: {exc}")
+
+
+def build_autofill_link(request_data):
+    """Build the official ProphetX Auto-Fill handoff links (pure — no network).
+
+    Machina's involvement in bet placement ends at these links: account,
+    geolocation, wallet, and wager execution are entirely ProphetX's.
+
+    params:
+        line_id (str): single selection line id (or use line_ids)
+        line_ids (list[str]): multiple selections
+        partner_id (str): required — attribution identifier
+        odds: optional odds hint passed through to the betslip
+    """
+    try:
+        params = request_data.get("params") or {}
+        partner_id = str(params.get("partner_id") or "").strip()
+        if not partner_id:
+            return _error("partner_id is required for attribution", error_class="invalid_request")
+        line_ids = params.get("line_ids") or []
+        if isinstance(line_ids, str):
+            line_ids = [part.strip() for part in line_ids.split(",") if part.strip()]
+        single = str(params.get("line_id") or "").strip()
+        if single and not line_ids:
+            line_ids = [single]
+        if not line_ids:
+            return _error("line_id or line_ids is required", error_class="invalid_request")
+        line_ids = [str(item) for item in line_ids]
+        primary = line_ids[0]
+        joined = ",".join(line_ids)
+        odds = params.get("odds")
+
+        app_query = f"line_id={primary}&line_ids={joined}&partner_id={partner_id}"
+        web_query = f"action=addtobetslip&line_id={primary}&line_ids={joined}&partner_id={partner_id}"
+        onelink_query = (
+            f"deep_link_value=addtobetslip&deep_link_sub1={partner_id}"
+            f"&deep_link_sub2={joined}"
+        )
+        if odds is not None:
+            app_query += f"&odds={odds}"
+            web_query += f"&odds={odds}"
+            onelink_query += f"&deep_link_sub3={odds}"
+
+        return _success(
+            {
+                "app_link": f"{_AUTOFILL_APP}?{app_query}",
+                "onelink": f"{_AUTOFILL_ONELINK}?{onelink_query}",
+                "web_link": f"{_AUTOFILL_WEB}?{web_query}",
+                "line_ids": line_ids,
+                "partner_id": partner_id,
+            },
+            "Auto-Fill links built (handoff only — no wager is executed by Machina)",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error(f"Error building Auto-Fill link: {exc.__class__.__name__}: {exc}")
+
+
+def health(request_data):
+    """Credential + reachability check: one bounded GET (tournaments).
+
+    params:
+        environment (str): 'sandbox' (default) or 'production'
+        auth_scheme (str): 'raw' (default) or 'bearer'
+    """
+    result = get_tournaments(request_data)
+    if not result.get("status"):
+        return result
+    data = result.get("data") or {}
+    return _success(
+        {
+            "healthy": True,
+            "environment": data.get("environment"),
+            "tournament_count": data.get("count", 0),
+        },
+        "ProphetX Affiliate API reachable and credentials accepted",
+    )

--- a/connectors/prophetx/prophetx.yml
+++ b/connectors/prophetx/prophetx.yml
@@ -1,0 +1,18 @@
+connector:
+  name: "prophetx"
+  description: "ProphetX Affiliate API - Authenticated read-only market data (tournaments, events, markets with odds/liquidity) plus official Auto-Fill handoff links. No wager execution."
+  filename: "prophetx.py"
+  filetype: "pyscript"
+  commands:
+    - name: "Get Tournaments"
+      value: "get_tournaments"
+    - name: "Get Sport Events"
+      value: "get_sport_events"
+    - name: "Get Markets"
+      value: "get_markets"
+    - name: "Get Multiple Markets"
+      value: "get_multiple_markets"
+    - name: "Build Auto-Fill Link"
+      value: "build_autofill_link"
+    - name: "Health"
+      value: "health"

--- a/connectors/prophetx/test-credentials.yml
+++ b/connectors/prophetx/test-credentials.yml
@@ -1,0 +1,33 @@
+workflow:
+  name: "prophetx-test-credentials"
+  title: "ProphetX Affiliate - Test Credentials"
+  description: "Bounded credential smoke: one authenticated GET against the selected environment (sandbox by default). No wagers, no writes."
+  context-variables:
+    debugger:
+      enabled: true
+    prophetx:
+      api_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_API_KEY
+      access_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_ACCESS_KEY
+      secret_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_SECRET_KEY
+  inputs:
+    environment: "$.get('environment', 'sandbox')"
+    auth_scheme: "$.get('auth_scheme', 'raw')"
+  outputs:
+    result: "$.get('health_result', {})"
+    workflow-status: "$.get('health_ok') is True and 'executed' or 'failed'"
+  tasks:
+
+    # task-health-check
+    - type: connector
+      name: task-health-check
+      description: Authenticated reachability check (one GET get_tournaments)
+      connector:
+        name: prophetx
+        command: health
+      inputs:
+        environment: "$.get('environment')"
+        auth_scheme: "$.get('auth_scheme')"
+      outputs:
+        health_result: $
+        health_ok: "$.get('status', False)"
+        tournament_count: "$.get('data', {}).get('tournament_count', 0)"

--- a/connectors/prophetx/tests/demo_odds_screen.py
+++ b/connectors/prophetx/tests/demo_odds_screen.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Repeatable ProphetX demo: browse markets on an odds screen, hand off via Auto-Fill.
+
+Proves the task's end-to-end experience (ClickUp 86ak0a1jm) with sandbox data:
+  1. discover an event with priced markets (bounded scan)
+  2. render a terminal odds screen (market / selection / American odds /
+     implied probability / available stake)
+  3. pick the first priced selection and build the OFFICIAL Auto-Fill handoff
+     links (app deep link, OneLink, web fallback) with partner attribution
+
+Machina never executes a wager: the demo ends at the links — account,
+geolocation, wallet, and wager placement are entirely ProphetX's.
+
+Credentials: reads PROPHETX_API_SANDBOX (or PROPHETX_API_PROD with
+--environment production, which requires separate approval). Values are never
+printed. partner_id defaults to "machina-sports" (--partner_id to override).
+
+Usage:
+  python3 connectors/prophetx/tests/demo_odds_screen.py \
+      [--environment sandbox] [--tournament-id 109] [--event-id N] \
+      [--partner-id machina-sports] [--max-rows 12]
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+CONNECTOR_DIR = Path(__file__).resolve().parents[1]
+
+ENV_VAR_CANDIDATES = {
+    "sandbox": ("PROPHETX_API_SANDBOX", "EXPORT_PROPHETX_API_SANDBOX"),
+    "production": ("PROPHETX_API_PROD", "EXPORT_PROPHETX_API_PROD"),
+}
+
+# Upstream-documented game tournaments (the active-tournaments head is
+# dominated by futures catalogs with empty books).
+DEFAULT_TOURNAMENTS = (109, 31, 132, 234)  # MLB, NFL, NBA, NHL
+
+
+def load_connector():
+    spec = importlib.util.spec_from_file_location("prophetx_demo", CONNECTOR_DIR / "prophetx.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_key(environment):
+    for name in ENV_VAR_CANDIDATES[environment]:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return None
+
+
+def iter_levels(market):
+    for side in market.get("selections") or []:
+        for level in side if isinstance(side, list) else [side]:
+            if isinstance(level, dict):
+                yield level
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment", default="sandbox", choices=("sandbox", "production"))
+    parser.add_argument("--tournament-id", type=int, default=None)
+    parser.add_argument("--event-id", type=int, default=None)
+    parser.add_argument("--partner-id", default="machina-sports")
+    parser.add_argument("--max-rows", type=int, default=12)
+    args = parser.parse_args()
+
+    key = resolve_key(args.environment)
+    if not key:
+        print(f"SKIPPED: no credential in env ({' or '.join(ENV_VAR_CANDIDATES[args.environment])})")
+        return 1
+
+    px = load_connector()
+
+    def rd(**params):
+        merged = {"environment": args.environment}
+        merged.update(params)
+        return {"headers": {"api_key": key}, "params": merged}
+
+    requests_used = 0
+
+    # ---- 1. discover an event (prefer one with priced selections) ----
+    event = None
+    markets = []
+    if args.event_id:
+        candidates = [{"event_id": args.event_id, "name": f"event {args.event_id}"}]
+    else:
+        candidates = []
+        tournament_ids = [args.tournament_id] if args.tournament_id else list(DEFAULT_TOURNAMENTS)
+        for tid in tournament_ids:
+            result = px.get_sport_events(rd(tournament_id=tid))
+            requests_used += 1
+            events = (result.get("data") or {}).get("sport_events") or []
+            candidates.extend(sorted(events, key=lambda e: e.get("scheduled") or "9999")[:5])
+            if len(candidates) >= 10:
+                break
+
+    for candidate in candidates[:8]:
+        result = px.get_markets(rd(event_id=candidate["event_id"], api_version="v3"))
+        requests_used += 1
+        found = (result.get("data") or {}).get("markets") or []
+        if not found:
+            continue
+        priced = any(level.get("odds") is not None for m in found for level in iter_levels(m))
+        if event is None or priced:
+            event, markets = candidate, found
+        if priced:
+            break
+
+    if event is None:
+        print(f"No event with markets found ({requests_used} requests). Try --tournament-id or --event-id.")
+        return 1
+
+    # ---- 2. odds screen ----
+    print()
+    print(f"PROPHETX ODDS SCREEN — {args.environment.upper()}  ({requests_used} read-only requests)")
+    print(f"Event: {event.get('name')}  |  scheduled: {event.get('scheduled', '?')}  |  status: {event.get('status', '?')}")
+    print("-" * 92)
+    print(f"{'MARKET':<34} {'SELECTION':<26} {'ODDS':>7} {'PROB':>6} {'STAKE $':>10}")
+    print("-" * 92)
+    rows = 0
+    first_priced = None
+    first_any = None
+    for market in markets:
+        for level in iter_levels(market):
+            if rows >= args.max_rows:
+                break
+            odds = level.get("display_odds") or "—"
+            prob = level.get("implied_probability")
+            stake = level.get("stake")
+            print(
+                f"{market.get('name', '')[:33]:<34} {str(level.get('name', ''))[:25]:<26} "
+                f"{odds:>7} {(f'{prob:.1%}' if prob else '—'):>6} {(f'{stake:,.0f}' if stake else '—'):>10}"
+            )
+            rows += 1
+            if level.get("line_id"):
+                first_any = first_any or level
+                if level.get("odds") is not None:
+                    first_priced = first_priced or level
+        if rows >= args.max_rows:
+            break
+    print("-" * 92)
+    if not first_priced:
+        print("NOTE: no priced selections on this event right now (empty public book) — handoff links still work by line_id.")
+
+    # ---- 3. Auto-Fill handoff (pure — no network, no wager) ----
+    selected = first_priced or first_any
+    if not selected:
+        print("No selection with a line_id available — cannot build handoff links.")
+        return 1
+    links = px.build_autofill_link(
+        {
+            "params": {
+                "line_id": selected["line_id"],
+                "partner_id": args.partner_id,
+                "odds": selected.get("odds"),
+            }
+        }
+    )
+    print()
+    print(f"AUTO-FILL HANDOFF — selection: {selected.get('name')} {selected.get('display_odds', '')}".rstrip())
+    print(f"(attribution partner_id={args.partner_id}; Machina executes NO wager — the flow ends at these links)")
+    print(json.dumps(links.get("data") or {}, indent=2))
+    return 0 if links.get("status") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/connectors/prophetx/tests/smoke_sandbox.py
+++ b/connectors/prophetx/tests/smoke_sandbox.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Bounded read-only smoke test for the ProphetX Affiliate connector.
+
+Answers the design log's open questions empirically, with ~8 GETs max:
+  1. auth scheme: raw key vs `Bearer` prefix (tries raw first, bearer on 401)
+  2. odds format evidence (American-looking ints vs decimal floats)
+  3. `updated_at` unit (s/ms/ns magnitude)
+  4. selections nesting on v3/v4 (side groups x liquidity levels)
+  5. multiple-markets response shape (dict-by-event vs flat list)
+
+Credential handoff (never printed, never logged): reads the FIRST present of
+  PROPHETX_API_SANDBOX | EXPORT_PROPHETX_API_SANDBOX   (sandbox, default)
+  PROPHETX_API_PROD    | EXPORT_PROPHETX_API_PROD      (--environment production)
+Output contains counts, shapes, booleans, and error classes only.
+
+Production runs are read-only and bounded like sandbox, but require separate
+approval (task 86ak0a1jm AC) — do not run --environment production without it.
+
+Usage:
+  python3 connectors/prophetx/tests/smoke_sandbox.py [--environment sandbox|production] [--out FILE.json]
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+CONNECTOR_DIR = Path(__file__).resolve().parents[1]
+
+ENV_VAR_CANDIDATES = {
+    "sandbox": ("PROPHETX_API_SANDBOX", "EXPORT_PROPHETX_API_SANDBOX"),
+    "production": ("PROPHETX_API_PROD", "EXPORT_PROPHETX_API_PROD"),
+}
+
+
+def load_connector():
+    spec = importlib.util.spec_from_file_location("prophetx_smoke", CONNECTOR_DIR / "prophetx.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_key(environment):
+    for name in ENV_VAR_CANDIDATES[environment]:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value, name
+    return None, None
+
+
+def classify_odds(values):
+    """Evidence only — never converts. American odds are int-like with |v|>=100;
+    decimal odds are floats typically in (1.01, ~20)."""
+    ints = [v for v in values if float(v) == int(float(v)) and abs(float(v)) >= 100]
+    decimals = [v for v in values if 1.0 < float(v) < 50 and float(v) != int(float(v))]
+    if ints and not decimals:
+        return "american-like"
+    if decimals and not ints:
+        return "decimal-like"
+    if ints and decimals:
+        return "mixed"
+    return "inconclusive"
+
+
+def updated_at_unit(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "absent"
+    if number > 1e17:
+        return "nanoseconds"
+    if number > 1e14:
+        return "microseconds"
+    if number > 1e11:
+        return "milliseconds"
+    return "seconds"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment", default="sandbox", choices=("sandbox", "production"))
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    key, var_name = resolve_key(args.environment)
+    if not key:
+        print(
+            json.dumps(
+                {
+                    "status": "SKIPPED",
+                    "reason": f"no credential found in env ({' or '.join(ENV_VAR_CANDIDATES[args.environment])})",
+                }
+            )
+        )
+        return 1
+
+    px = load_connector()
+    report = {
+        "environment": args.environment,
+        "credential_source_var": var_name,  # the NAME only — never the value
+        "requests_used": 0,
+        "findings": {},
+        "steps": [],
+    }
+
+    def request_data(scheme, **params):
+        merged = {"environment": args.environment, "auth_scheme": scheme}
+        merged.update(params)
+        return {"headers": {"api_key": key}, "params": merged}
+
+    # ---- Step 1: auth scheme resolution (raw first, bearer fallback) ----
+    scheme_used = None
+    health = None
+    for scheme in ("raw", "bearer"):
+        health = px.health(request_data(scheme))
+        report["requests_used"] += 1
+        if health.get("status"):
+            scheme_used = scheme
+            break
+        if health.get("error_class") != "credential_invalid":
+            break  # unreachable/rate-limited — bearer retry won't change it
+    report["findings"]["auth_scheme"] = scheme_used or "FAILED"
+    report["steps"].append(
+        {
+            "step": "health",
+            "ok": bool(health and health.get("status")),
+            "error_class": None if health.get("status") else health.get("error_class"),
+            "tournament_count": (health.get("data") or {}).get("tournament_count"),
+        }
+    )
+    if not scheme_used:
+        print(json.dumps(report, indent=2))
+        return 1
+
+    # ---- Step 2: tournaments with active events ----
+    tournaments = px.get_tournaments(request_data(scheme_used, has_active_events=True))
+    report["requests_used"] += 1
+    tournament_list = (tournaments.get("data") or {}).get("tournaments") or []
+    report["steps"].append(
+        {"step": "get_tournaments(active)", "ok": tournaments.get("status"), "count": len(tournament_list)}
+    )
+    if not tournament_list:
+        fallback = px.get_tournaments(request_data(scheme_used))
+        report["requests_used"] += 1
+        tournament_list = (fallback.get("data") or {}).get("tournaments") or []
+        report["steps"].append(
+            {"step": "get_tournaments(all)", "ok": fallback.get("status"), "count": len(tournament_list)}
+        )
+
+    # ---- Step 3: events of the first active tournament ----
+    events = []
+    tournament_id = None
+    for tournament in tournament_list[:3]:
+        tournament_id = tournament.get("id")
+        if tournament_id is None:
+            continue
+        events_result = px.get_sport_events(request_data(scheme_used, tournament_id=tournament_id))
+        report["requests_used"] += 1
+        events = (events_result.get("data") or {}).get("sport_events") or []
+        report["steps"].append(
+            {
+                "step": f"get_sport_events(tournament={tournament_id})",
+                "ok": events_result.get("status"),
+                "count": len(events),
+            }
+        )
+        if events:
+            break
+    if not events:
+        report["findings"]["note"] = "no events found in first active tournaments — markets steps skipped"
+        print(json.dumps(report, indent=2))
+        return 0
+
+    event_id = events[0].get("event_id")
+    scheduled = events[0].get("scheduled")
+    report["findings"]["sample_event"] = {"event_id": event_id, "scheduled": scheduled}
+
+    # ---- Step 4: markets v3 (default) ----
+    markets_v3 = px.get_markets(request_data(scheme_used, event_id=event_id, api_version="v3"))
+    report["requests_used"] += 1
+    v3_list = (markets_v3.get("data") or {}).get("markets") or []
+    odds_values = []
+    nesting = {"markets": len(v3_list), "sides_max": 0, "levels_max": 0}
+    updated_at_sample = None
+    for market in v3_list:
+        selections = market.get("selections") or []
+        nesting["sides_max"] = max(nesting["sides_max"], len(selections))
+        for side in selections:
+            levels = side if isinstance(side, list) else [side]
+            nesting["levels_max"] = max(nesting["levels_max"], len(levels))
+            for level in levels:
+                if isinstance(level, dict):
+                    if level.get("odds") is not None:
+                        odds_values.append(level["odds"])
+                    if updated_at_sample is None and level.get("updated_at") is not None:
+                        updated_at_sample = level["updated_at"]
+    report["steps"].append({"step": "get_markets(v3)", "ok": markets_v3.get("status"), "count": len(v3_list)})
+    report["findings"]["v3_nesting"] = nesting
+    report["findings"]["odds_format_evidence"] = {
+        "sampled": len(odds_values),
+        "classification": classify_odds(odds_values) if odds_values else "no-odds-sampled",
+        "sample_values": odds_values[:6],
+    }
+    report["findings"]["updated_at_unit"] = updated_at_unit(updated_at_sample)
+
+    # ---- Step 5: markets v4 (CFTC naming check) ----
+    markets_v4 = px.get_markets(request_data(scheme_used, event_id=event_id, api_version="v4"))
+    report["requests_used"] += 1
+    v4_list = (markets_v4.get("data") or {}).get("markets") or []
+    v4_mapped = bool(
+        v4_list
+        and any(
+            level.get("line_id") is not None and level.get("odds") is not None
+            for market in v4_list
+            for side in (market.get("selections") or [])
+            for level in (side if isinstance(side, list) else [side])
+            if isinstance(level, dict)
+        )
+    )
+    report["steps"].append({"step": "get_markets(v4)", "ok": markets_v4.get("status"), "count": len(v4_list)})
+    report["findings"]["v4_cftc_mapping_populated"] = v4_mapped
+
+    # ---- Step 6: multiple markets dual-shape check (2 ids) ----
+    ids = [event_id] + [e.get("event_id") for e in events[1:2] if e.get("event_id")]
+    multi = px.get_multiple_markets(request_data(scheme_used, event_ids=ids, api_version="v3"))
+    report["requests_used"] += 1
+    multi_data = multi.get("data") or {}
+    report["steps"].append(
+        {
+            "step": f"get_multiple_markets({len(ids)} ids)",
+            "ok": multi.get("status"),
+            "market_count": multi_data.get("market_count"),
+            "unattributed": len((multi_data.get("markets_by_event") or {}).get("_unattributed", [])),
+        }
+    )
+    report["findings"]["multiple_markets_shape"] = (
+        "dict-by-event" if multi.get("status") and "_unattributed" not in (multi_data.get("markets_by_event") or {}) else "flat-list-or-error"
+    )
+
+    report["status"] = "PASSED" if all(step.get("ok") for step in report["steps"]) else "PARTIAL"
+    output = json.dumps(report, indent=2)
+    print(output)
+    if args.out:
+        Path(args.out).write_text(output + "\n")
+    return 0 if report["status"] == "PASSED" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/connectors/prophetx/tests/smoke_sandbox.py
+++ b/connectors/prophetx/tests/smoke_sandbox.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Bounded read-only smoke test for the ProphetX Affiliate connector.
 
-Answers the design log's open questions empirically, with ~8 GETs max:
+Answers the design log's open questions empirically, with ~15 GETs max:
   1. auth scheme: raw key vs `Bearer` prefix (tries raw first, bearer on 401)
   2. odds format evidence (American-looking ints vs decimal floats)
   3. `updated_at` unit (s/ms/ns magnitude)
@@ -149,13 +149,22 @@ def main() -> int:
             {"step": "get_tournaments(all)", "ok": fallback.get("status"), "count": len(tournament_list)}
         )
 
-    # ---- Step 3: events of the first active tournament ----
-    events = []
-    tournament_id = None
-    for tournament in tournament_list[:3]:
+    # ---- Step 3: find an event that actually carries markets ----
+    # Futures/outright tournaments can list events with zero markets; scan a
+    # few tournaments (soonest events first) until v3 returns markets, within
+    # a hard request budget.
+    event_id = None
+    sibling_event_id = None
+    markets_v3 = None
+    v3_list = []
+    market_probes = 0
+    seen_event_ids = []
+    for tournament in tournament_list[:6]:
         tournament_id = tournament.get("id")
         if tournament_id is None:
             continue
+        if market_probes >= 5:
+            break
         events_result = px.get_sport_events(request_data(scheme_used, tournament_id=tournament_id))
         report["requests_used"] += 1
         events = (events_result.get("data") or {}).get("sport_events") or []
@@ -166,21 +175,42 @@ def main() -> int:
                 "count": len(events),
             }
         )
-        if events:
-            break
-    if not events:
-        report["findings"]["note"] = "no events found in first active tournaments — markets steps skipped"
-        print(json.dumps(report, indent=2))
-        return 0
+        events = sorted(events, key=lambda e: e.get("scheduled") or "9999")
+        seen_event_ids.extend(e.get("event_id") for e in events if e.get("event_id"))
+        if event_id is not None:
+            continue  # markets already found — keep collecting ids for step 6
+        for event in events[:3]:
+            candidate_id = event.get("event_id")
+            if candidate_id is None or market_probes >= 5:
+                continue
+            probe = px.get_markets(request_data(scheme_used, event_id=candidate_id, api_version="v3"))
+            report["requests_used"] += 1
+            market_probes += 1
+            probe_list = (probe.get("data") or {}).get("markets") or []
+            report["steps"].append(
+                {"step": f"get_markets(v3, event={candidate_id})", "ok": probe.get("status"), "count": len(probe_list)}
+            )
+            if probe_list:
+                event_id = candidate_id
+                markets_v3 = probe
+                v3_list = probe_list
+                siblings = [e.get("event_id") for e in events if e.get("event_id") not in (None, candidate_id)]
+                sibling_event_id = siblings[0] if siblings else None
+                report["findings"]["sample_event"] = {
+                    "event_id": candidate_id,
+                    "scheduled": event.get("scheduled"),
+                    "tournament_id": tournament_id,
+                }
+                break
 
-    event_id = events[0].get("event_id")
-    scheduled = events[0].get("scheduled")
-    report["findings"]["sample_event"] = {"event_id": event_id, "scheduled": scheduled}
-
-    # ---- Step 4: markets v3 (default) ----
-    markets_v3 = px.get_markets(request_data(scheme_used, event_id=event_id, api_version="v3"))
-    report["requests_used"] += 1
-    v3_list = (markets_v3.get("data") or {}).get("markets") or []
+    if event_id is None:
+        report["findings"]["note"] = "no event with markets found within the probe budget — odds questions remain open"
+        report["status"] = "PARTIAL"
+        output = json.dumps(report, indent=2)
+        print(output)
+        if args.out:
+            Path(args.out).write_text(output + "\n")
+        return 1
     odds_values = []
     nesting = {"markets": len(v3_list), "sides_max": 0, "levels_max": 0}
     updated_at_sample = None
@@ -194,9 +224,8 @@ def main() -> int:
                 if isinstance(level, dict):
                     if level.get("odds") is not None:
                         odds_values.append(level["odds"])
-                    if updated_at_sample is None and level.get("updated_at") is not None:
+                    if updated_at_sample is None and level.get("updated_at"):
                         updated_at_sample = level["updated_at"]
-    report["steps"].append({"step": "get_markets(v3)", "ok": markets_v3.get("status"), "count": len(v3_list)})
     report["findings"]["v3_nesting"] = nesting
     report["findings"]["odds_format_evidence"] = {
         "sampled": len(odds_values),
@@ -222,22 +251,46 @@ def main() -> int:
     report["steps"].append({"step": "get_markets(v4)", "ok": markets_v4.get("status"), "count": len(v4_list)})
     report["findings"]["v4_cftc_mapping_populated"] = v4_mapped
 
-    # ---- Step 6: multiple markets dual-shape check (2 ids) ----
-    ids = [event_id] + [e.get("event_id") for e in events[1:2] if e.get("event_id")]
+    # ---- Step 6: multiple markets dual-shape check + broad odds evidence ----
+    # One batched call over up to 25 seen events: exercises the dual-shape
+    # parser and gives the odds/updated_at questions a much wider sample than
+    # the single probed event.
+    ordered_ids = [event_id] + [eid for eid in seen_event_ids if eid != event_id]
+    ids = list(dict.fromkeys(ordered_ids))[:25]
     multi = px.get_multiple_markets(request_data(scheme_used, event_ids=ids, api_version="v3"))
     report["requests_used"] += 1
     multi_data = multi.get("data") or {}
+    grouped = multi_data.get("markets_by_event") or {}
     report["steps"].append(
         {
             "step": f"get_multiple_markets({len(ids)} ids)",
             "ok": multi.get("status"),
             "market_count": multi_data.get("market_count"),
-            "unattributed": len((multi_data.get("markets_by_event") or {}).get("_unattributed", [])),
+            "unattributed": len(grouped.get("_unattributed", [])),
         }
     )
     report["findings"]["multiple_markets_shape"] = (
-        "dict-by-event" if multi.get("status") and "_unattributed" not in (multi_data.get("markets_by_event") or {}) else "flat-list-or-error"
+        "dict-by-event" if multi.get("status") and "_unattributed" not in grouped else "flat-list-or-error"
     )
+    batch_odds = []
+    for key, markets in grouped.items():
+        if key == "_unattributed":
+            continue
+        for market in markets:
+            for side in market.get("selections") or []:
+                for level in (side if isinstance(side, list) else [side]):
+                    if isinstance(level, dict):
+                        if level.get("odds") not in (None, 0):
+                            batch_odds.append(level["odds"])
+                        if updated_at_sample is None and level.get("updated_at"):
+                            updated_at_sample = level["updated_at"]
+    if batch_odds:
+        report["findings"]["odds_format_evidence"] = {
+            "sampled": len(batch_odds),
+            "classification": classify_odds(batch_odds),
+            "sample_values": batch_odds[:6],
+        }
+    report["findings"]["updated_at_unit"] = updated_at_unit(updated_at_sample)
 
     report["status"] = "PASSED" if all(step.get("ok") for step in report["steps"]) else "PARTIAL"
     output = json.dumps(report, indent=2)

--- a/connectors/prophetx/tests/test_prophetx_connector.py
+++ b/connectors/prophetx/tests/test_prophetx_connector.py
@@ -363,6 +363,7 @@ class TestMarkets:
         level = market["selections"][0][0]
         assert level["line_id"] == "abc123"
         assert level["odds"] == -150
+        assert level["implied_probability"] == 0.6  # American odds confirmed live
         assert level["stake"] == 250.0
         assert level["_raw"]["line_id"] == "abc123"
 
@@ -372,7 +373,25 @@ class TestMarkets:
         level = result["data"]["markets"][0]["selections"][0][0]
         assert level["line_id"] == "abc123"  # strike_id mapped
         assert level["odds"] == -150  # price mapped
+        assert level["implied_probability"] == 0.6
         assert level["stake"] == 250.0  # quantity mapped
+
+    def test_implied_probability_absent_when_no_odds(self, fake):
+        market = _market_v3()
+        market["selections"] = [[{"line_id": "x", "odds": None, "stake": 0}]]
+        fake.queue(FakeResponse(200, {"data": {"event_id": 101, "markets": [market]}}))
+        result = px.get_markets(_req(params={"event_id": 101, "api_version": "v3"}))
+        level = result["data"]["markets"][0]["selections"][0][0]
+        assert level["implied_probability"] is None
+
+    def test_updated_at_ns_normalized_to_seconds(self, fake):
+        market = _market_v3()
+        market["selections"] = [[{"line_id": "x", "odds": -110, "updated_at": 1786643339351933000}]]
+        fake.queue(FakeResponse(200, {"data": {"event_id": 101, "markets": [market]}}))
+        result = px.get_markets(_req(params={"event_id": 101, "api_version": "v3"}))
+        level = result["data"]["markets"][0]["selections"][0][0]
+        assert level["updated_at"] == 1786643339351933000
+        assert level["updated_at_s"] == pytest.approx(1786643339.35, abs=0.01)
 
     def test_empty_markets_is_success(self, fake):
         fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
@@ -411,6 +430,22 @@ class TestMultipleMarkets:
         assert len(grouped["101"]) == 1
         assert grouped["102"] == []
         assert len(grouped["_unattributed"]) == 1
+
+    def test_null_and_odd_values_do_not_fail_the_batch(self, fake):
+        # Observed live: per-event values vary between calls; null and odd
+        # scalars must not poison the whole batch.
+        fake.queue(
+            FakeResponse(
+                200,
+                {"data": {"101": [_market_v3()], "102": None, "103": "weird"}},
+            )
+        )
+        result = px.get_multiple_markets(_req(params={"event_ids": [101, 102, 103]}))
+        assert result["status"] is True
+        grouped = result["data"]["markets_by_event"]
+        assert len(grouped["101"]) == 1
+        assert grouped["102"] == []
+        assert grouped["_unattributed"][0]["event_key"] == "103"
 
     def test_drift_fails_closed(self, fake):
         fake.queue(FakeResponse(200, {"data": "garbage"}))

--- a/connectors/prophetx/tests/test_prophetx_connector.py
+++ b/connectors/prophetx/tests/test_prophetx_connector.py
@@ -1,0 +1,527 @@
+"""Offline unit tests for the ProphetX Affiliate connector (no network)."""
+
+import importlib.util
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+CONNECTOR_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name="prophetx_connector_tests"):
+    spec = importlib.util.spec_from_file_location(name, CONNECTOR_DIR / "prophetx.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+px = load_module()
+
+SANDBOX = "https://api.sandbox.prophetx.dev/partner"
+PROD = "https://cash.api.prophetx.co/partner"
+
+FAKE_KEY = "unit-test-api-key-value"
+FAKE_TOKEN = "unit-test-access-token-value"
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, body=None, headers=None, raw_text=None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = headers or {}
+        self._raw_text = raw_text
+
+    def json(self):
+        if self._raw_text is not None:
+            raise ValueError("not json")
+        return self._body
+
+
+class FakeRequests:
+    """Captures every call; scripted responses per (method, path-suffix)."""
+
+    RequestException = px.requests.RequestException
+
+    def __init__(self):
+        self.calls = []
+        self.script = []
+
+    def queue(self, response):
+        self.script.append(response)
+        return self
+
+    def _next(self):
+        if not self.script:
+            raise AssertionError("no scripted response left")
+        item = self.script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append({"method": "GET", "url": url, "params": params, "headers": headers})
+        return self._next()
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append({"method": "POST", "url": url, "json": json, "headers": headers})
+        return self._next()
+
+
+@pytest.fixture()
+def fake():
+    original = px.requests
+    fake_requests = FakeRequests()
+    px.requests = fake_requests
+    px._token_cache.clear()
+    yield fake_requests
+    px.requests = original
+    px._token_cache.clear()
+
+
+def _req(params=None, api_key=FAKE_KEY, access_key=None, secret_key=None):
+    headers = {}
+    if api_key:
+        headers["api_key"] = api_key
+    if access_key:
+        headers["access_key"] = access_key
+    if secret_key:
+        headers["secret_key"] = secret_key
+    return {"headers": headers, "params": params or {}}
+
+
+def _tournaments_body(count=2):
+    return {"data": {"tournaments": [{"id": i, "name": f"T{i}"} for i in range(count)]}}
+
+
+# ============================================================
+# Auth
+# ============================================================
+
+
+class TestAuth:
+    def test_mode_a_raw_key_no_bearer(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        result = px.get_tournaments(_req())
+        assert result["status"] is True
+        assert fake.calls[0]["headers"]["Authorization"] == FAKE_KEY
+
+    def test_mode_a_bearer_scheme_opt_in(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        px.get_tournaments(_req(params={"auth_scheme": "bearer"}))
+        assert fake.calls[0]["headers"]["Authorization"] == f"Bearer {FAKE_KEY}"
+
+    def test_mode_b_login_then_cached(self, fake):
+        login_body = {
+            "data": {
+                "access_token": FAKE_TOKEN,
+                "access_expire_time": time.time() + 600,
+                "refresh_token": "refresh-1",
+                "refresh_expire_time": time.time() + 3600,
+            }
+        }
+        fake.queue(FakeResponse(200, login_body))
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        fake.queue(FakeResponse(200, _tournaments_body(3)))
+
+        request = _req(api_key=None, access_key="ak", secret_key="sk")
+        first = px.get_tournaments(request)
+        second = px.get_tournaments(request)
+        assert first["status"] is True and second["status"] is True
+        posts = [c for c in fake.calls if c["method"] == "POST"]
+        assert len(posts) == 1  # login happened once; token cached
+        assert posts[0]["url"] == f"{SANDBOX}/auth/login"
+        gets = [c for c in fake.calls if c["method"] == "GET"]
+        assert all(c["headers"]["Authorization"] == FAKE_TOKEN for c in gets)
+
+    def test_mode_b_401_relogin_once_then_typed_error(self, fake):
+        login_body = {"data": {"access_token": FAKE_TOKEN, "access_expire_time": time.time() + 600}}
+        # login -> GET 401 -> re-login -> GET 401 again => credential_invalid
+        fake.queue(FakeResponse(200, login_body))
+        fake.queue(FakeResponse(401, {"error": "unauthorized"}))
+        fake.queue(FakeResponse(200, login_body))
+        fake.queue(FakeResponse(401, {"error": "unauthorized"}))
+
+        result = px.get_tournaments(_req(api_key=None, access_key="ak", secret_key="sk"))
+        assert result["status"] is False
+        assert result["error_class"] == "credential_invalid"
+        assert len([c for c in fake.calls if c["method"] == "POST"]) == 2
+
+    def test_mode_a_401_is_typed_without_relogin(self, fake):
+        fake.queue(FakeResponse(401, {"error": "unauthorized"}))
+        result = px.get_tournaments(_req())
+        assert result["status"] is False
+        assert result["error_class"] == "credential_invalid"
+        assert len(fake.calls) == 1
+
+    def test_credentials_missing_is_typed(self, fake):
+        result = px.get_tournaments({"headers": {}, "params": {}})
+        assert result["status"] is False
+        assert result["error_class"] == "credential_missing"
+        assert fake.calls == []
+
+    def test_expired_token_uses_refresh(self, fake):
+        expired = {
+            "data": {
+                "access_token": "old-token",
+                "access_expire_time": time.time() - 10,
+                "refresh_token": "refresh-1",
+                "refresh_expire_time": time.time() + 3600,
+            }
+        }
+        refreshed = {"data": {"access_token": "new-token", "access_expire_time": time.time() + 600}}
+        fake.queue(FakeResponse(200, expired))  # login
+        fake.queue(FakeResponse(200, _tournaments_body()))  # first GET (old token still fresh enough? no - expired)
+        request = _req(api_key=None, access_key="ak", secret_key="sk")
+        # Prime the cache with the expired record via one call path:
+        px._token_cache[("sandbox", "ak")] = {
+            "access_token": "old-token",
+            "access_expire_time": time.time() - 10,
+            "refresh_token": "refresh-1",
+            "refresh_expire_time": time.time() + 3600,
+        }
+        fake.script = []
+        fake.queue(FakeResponse(200, refreshed))  # POST /auth/refresh
+        fake.queue(FakeResponse(200, _tournaments_body()))  # GET with new token
+        result = px.get_tournaments(request)
+        assert result["status"] is True
+        posts = [c for c in fake.calls if c["method"] == "POST"]
+        assert posts[-1]["url"] == f"{SANDBOX}/auth/refresh"
+        gets = [c for c in fake.calls if c["method"] == "GET"]
+        assert gets[-1]["headers"]["Authorization"] == "new-token"
+
+    def test_no_credential_echo_in_errors(self, fake):
+        fake.queue(FakeResponse(500, {"error": "boom", "message": "internal"}))
+        fake.queue(FakeResponse(500, {"error": "boom", "message": "internal"}))
+        fake.queue(FakeResponse(500, {"error": "boom", "message": "internal"}))
+        with patch.object(px.time, "sleep"):
+            result = px.get_tournaments(_req())
+        assert result["status"] is False
+        assert FAKE_KEY not in str(result)
+        assert "Authorization" not in str(result)
+
+
+# ============================================================
+# Environment allowlist
+# ============================================================
+
+
+class TestEnvironment:
+    def test_sandbox_default_host(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        px.get_tournaments(_req())
+        assert fake.calls[0]["url"].startswith(SANDBOX)
+
+    def test_production_host(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        px.get_tournaments(_req(params={"environment": "production"}))
+        assert fake.calls[0]["url"].startswith(PROD)
+
+    def test_unknown_environment_rejected(self, fake):
+        result = px.get_tournaments(_req(params={"environment": "staging"}))
+        assert result["status"] is False
+        assert result["error_class"] == "invalid_request"
+        assert fake.calls == []
+
+    def test_arbitrary_base_url_param_is_ignored(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        px.get_tournaments(_req(params={"base_url": "https://evil.example.com"}))
+        assert fake.calls[0]["url"].startswith(SANDBOX)
+
+
+# ============================================================
+# Retries / rate limit / errors
+# ============================================================
+
+
+class TestResilience:
+    def test_429_backoff_honors_retry_after_then_typed(self, fake):
+        for _ in range(3):
+            fake.queue(FakeResponse(429, {"error": "rate_limit_reached"}, headers={"Retry-After": "2"}))
+        sleeps = []
+        with patch.object(px.time, "sleep", side_effect=sleeps.append):
+            result = px.get_tournaments(_req())
+        assert result["status"] is False
+        assert result["error_class"] == "provider_rate_limited"
+        assert len([c for c in fake.calls if c["method"] == "GET"]) == 3
+        assert sleeps and sleeps[0] == 2.0
+
+    def test_5xx_retry_then_success(self, fake):
+        fake.queue(FakeResponse(503, {"error": "down"}))
+        fake.queue(FakeResponse(200, _tournaments_body()))
+        with patch.object(px.time, "sleep"):
+            result = px.get_tournaments(_req())
+        assert result["status"] is True
+        assert len(fake.calls) == 2
+
+    def test_404_typed(self, fake):
+        fake.queue(FakeResponse(404, {"error": "data_not_found"}))
+        result = px.get_markets(_req(params={"event_id": 999}))
+        assert result["status"] is False
+        assert result["error_class"] == "data_not_found"
+
+    def test_network_exception_retries_then_typed(self, fake):
+        fake.queue(px.requests.RequestException("boom"))
+        fake.queue(px.requests.RequestException("boom"))
+        fake.queue(px.requests.RequestException("boom"))
+        with patch.object(px.time, "sleep"):
+            result = px.get_tournaments(_req())
+        assert result["status"] is False
+        assert result["error_class"] == "provider_unavailable"
+
+    def test_malformed_json_typed(self, fake):
+        fake.queue(FakeResponse(200, raw_text="<html>waf</html>"))
+        result = px.get_tournaments(_req())
+        assert result["status"] is False
+        assert result["error_class"] == "provider_bad_response"
+
+
+# ============================================================
+# Markets: versions, CFTC header, batches, dual-shape
+# ============================================================
+
+
+def _market_v3(event_id=101):
+    return {
+        "id": 219,
+        "name": "Moneyline",
+        "display_name": "Moneyline",
+        "group_name": "Game Lines",
+        "type": "moneyline",
+        "favourite": True,
+        "selections": [
+            [
+                {"line_id": "abc123", "outcome_id": 4, "odds": -150, "display_odds": "-150", "stake": 250.0},
+                {"line_id": "abc124", "outcome_id": 4, "odds": -155, "display_odds": "-155", "stake": 100.0},
+            ],
+            [{"line_id": "def456", "outcome_id": 5, "odds": 130, "display_odds": "+130", "stake": 80.0}],
+        ],
+    }
+
+
+def _market_v4(event_id=101):
+    return {
+        "id": 219,
+        "name": "Moneyline",
+        "type": "moneyline",
+        "strike": 0,
+        "selections": [
+            [{"strike_id": "abc123", "outcome_id": 4, "price": -150, "display_price": "-150", "quantity": 250.0}],
+            [{"strike_id": "def456", "outcome_id": 5, "price": 130, "display_price": "+130", "quantity": 80.0}],
+        ],
+    }
+
+
+class TestMarkets:
+    def test_version_paths(self, fake):
+        for version, expected in (
+            ("v1", "/affiliate/get_markets"),
+            ("v2", "/v2/affiliate/get_markets"),
+            ("v3", "/v3/affiliate/get_markets"),
+            ("v4", "/v4/affiliate/get_markets"),
+        ):
+            fake.calls, fake.script = [], []
+            fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+            result = px.get_markets(_req(params={"event_id": 1, "api_version": version}))
+            assert result["status"] is True, version
+            assert fake.calls[0]["url"] == f"{SANDBOX}{expected}"
+
+    def test_default_version_is_v3(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+        result = px.get_markets(_req(params={"event_id": 1}))
+        assert result["data"]["api_version"] == "v3"
+
+    def test_invalid_version_rejected(self, fake):
+        result = px.get_markets(_req(params={"event_id": 1, "api_version": "v9"}))
+        assert result["status"] is False
+        assert fake.calls == []
+
+    def test_cftc_header_only_on_v3_opt_in(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+        px.get_markets(_req(params={"event_id": 1, "api_version": "v3", "cftc_terminology": True}))
+        assert fake.calls[0]["headers"].get("X-CFTC-Terminology") == "true"
+
+        fake.calls, fake.script = [], []
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+        px.get_markets(_req(params={"event_id": 1, "api_version": "v3"}))
+        assert "X-CFTC-Terminology" not in fake.calls[0]["headers"]
+
+        fake.calls, fake.script = [], []
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+        px.get_markets(_req(params={"event_id": 1, "api_version": "v4", "cftc_terminology": True}))
+        assert "X-CFTC-Terminology" not in fake.calls[0]["headers"]
+
+    def test_v3_normalization_preserves_liquidity_levels(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 101, "markets": [_market_v3()]}}))
+        result = px.get_markets(_req(params={"event_id": 101, "api_version": "v3"}))
+        market = result["data"]["markets"][0]
+        assert market["market_key"] == "101:219"
+        assert market["favourite"] is True
+        assert len(market["selections"]) == 2  # two sides
+        assert len(market["selections"][0]) == 2  # two liquidity levels preserved
+        level = market["selections"][0][0]
+        assert level["line_id"] == "abc123"
+        assert level["odds"] == -150
+        assert level["stake"] == 250.0
+        assert level["_raw"]["line_id"] == "abc123"
+
+    def test_v4_cftc_names_map_to_neutral_fields(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 101, "markets": [_market_v4()]}}))
+        result = px.get_markets(_req(params={"event_id": 101, "api_version": "v4"}))
+        level = result["data"]["markets"][0]["selections"][0][0]
+        assert level["line_id"] == "abc123"  # strike_id mapped
+        assert level["odds"] == -150  # price mapped
+        assert level["stake"] == 250.0  # quantity mapped
+
+    def test_empty_markets_is_success(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": []}}))
+        result = px.get_markets(_req(params={"event_id": 1}))
+        assert result["status"] is True
+        assert result["data"]["count"] == 0
+
+    def test_markets_drift_fails_closed(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"event_id": 1, "markets": "nope"}}))
+        result = px.get_markets(_req(params={"event_id": 1}))
+        assert result["status"] is False
+        assert result["error_class"] == "provider_bad_response"
+
+
+class TestMultipleMarkets:
+    def test_batch_cap_enforced_without_network(self, fake):
+        result = px.get_multiple_markets(_req(params={"event_ids": list(range(51))}))
+        assert result["status"] is False
+        assert result["error_class"] == "invalid_request"
+        assert fake.calls == []
+
+    def test_dict_shape(self, fake):
+        fake.queue(FakeResponse(200, {"data": {"101": [_market_v3()], "102": []}}))
+        result = px.get_multiple_markets(_req(params={"event_ids": [101, 102]}))
+        assert result["status"] is True
+        assert result["data"]["market_count"] == 1
+        assert result["data"]["markets_by_event"]["101"][0]["market_key"] == "101:219"
+        assert result["data"]["markets_by_event"]["102"] == []
+
+    def test_flat_list_shape_attributed_by_event_field(self, fake):
+        flat = [dict(_market_v3(), sport_event_id=101), dict(_market_v3(), sport_event_id=999)]
+        fake.queue(FakeResponse(200, {"data": flat}))
+        result = px.get_multiple_markets(_req(params={"event_ids": [101, 102]}))
+        assert result["status"] is True
+        grouped = result["data"]["markets_by_event"]
+        assert len(grouped["101"]) == 1
+        assert grouped["102"] == []
+        assert len(grouped["_unattributed"]) == 1
+
+    def test_drift_fails_closed(self, fake):
+        fake.queue(FakeResponse(200, {"data": "garbage"}))
+        result = px.get_multiple_markets(_req(params={"event_ids": [1]}))
+        assert result["status"] is False
+        assert result["error_class"] == "provider_bad_response"
+
+
+# ============================================================
+# Sport events + normalization
+# ============================================================
+
+
+class TestSportEvents:
+    def test_requires_tournament_or_event_ids(self, fake):
+        result = px.get_sport_events(_req(params={}))
+        assert result["status"] is False
+        assert fake.calls == []
+
+    def test_normalizes_side_and_names(self, fake):
+        body = {
+            "data": {
+                "sport_events": [
+                    {
+                        "event_id": 101,
+                        "name": "CIN at PHI",
+                        "display_name": "Bengals at Eagles",
+                        "tournament_id": 31,
+                        "tournament_name": "NFL",
+                        "sport_name": "American Football",
+                        "scheduled": "2026-08-14T00:15:00Z",
+                        "status": "not_started",
+                        "competitors": [
+                            {"id": 1, "display_name": "Philadelphia Eagles", "abbreviation": "PHI", "side": "home"},
+                            {"id": 2, "display_name": "Cincinnati Bengals", "abbreviation": "CIN", "side": "away"},
+                        ],
+                    }
+                ]
+            }
+        }
+        fake.queue(FakeResponse(200, body))
+        result = px.get_sport_events(_req(params={"tournament_id": 31}))
+        event = result["data"]["sport_events"][0]
+        assert event["name"] == "Bengals at Eagles"
+        assert event["tournament"] == "NFL"
+        assert event["competitors"][0]["side"] == "home"
+        assert event["_raw"]["event_id"] == 101
+
+
+# ============================================================
+# Auto-Fill handoff (pure)
+# ============================================================
+
+
+class TestAutofill:
+    def test_single_line(self, fake):
+        result = px.build_autofill_link({"params": {"line_id": "abc", "partner_id": "machina"}})
+        assert result["status"] is True
+        data = result["data"]
+        assert data["app_link"] == "prophetx://addtobetslip?line_id=abc&line_ids=abc&partner_id=machina"
+        assert data["web_link"].startswith("https://www.prophetx.co/?action=addtobetslip&line_id=abc")
+        assert "deep_link_sub1=machina" in data["onelink"]
+        assert fake.calls == []  # pure — no network
+
+    def test_multiple_lines_and_odds(self, fake):
+        result = px.build_autofill_link(
+            {"params": {"line_ids": ["a", "b"], "partner_id": "machina", "odds": -150}}
+        )
+        data = result["data"]
+        assert "line_id=a&line_ids=a,b" in data["app_link"]
+        assert "odds=-150" in data["app_link"]
+        assert "deep_link_sub2=a,b" in data["onelink"]
+        assert "deep_link_sub3=-150" in data["onelink"]
+
+    def test_partner_id_required(self, fake):
+        result = px.build_autofill_link({"params": {"line_id": "abc"}})
+        assert result["status"] is False
+        assert result["error_class"] == "invalid_request"
+
+    def test_line_required(self, fake):
+        result = px.build_autofill_link({"params": {"partner_id": "machina"}})
+        assert result["status"] is False
+
+
+# ============================================================
+# Health + misc
+# ============================================================
+
+
+class TestHealthAndMisc:
+    def test_health_ok(self, fake):
+        fake.queue(FakeResponse(200, _tournaments_body(5)))
+        result = px.health(_req())
+        assert result["status"] is True
+        assert result["data"]["healthy"] is True
+        assert result["data"]["tournament_count"] == 5
+
+    def test_health_propagates_typed_failure(self, fake):
+        fake.queue(FakeResponse(401, {"error": "unauthorized"}))
+        result = px.health(_req())
+        assert result["status"] is False
+        assert result["error_class"] == "credential_invalid"
+
+    def test_epoch_normalization_units(self):
+        assert px._as_epoch_seconds(1736126912) == 1736126912
+        assert px._as_epoch_seconds(1736126912002) == pytest.approx(1736126912.002)
+        assert px._as_epoch_seconds(1736126912002271000) == pytest.approx(1736126912.002271)
+        assert px._as_epoch_seconds("n/a") is None
+
+    def test_no_write_commands_exposed(self):
+        forbidden = ("place", "create", "cancel", "wager", "order", "balance", "withdraw", "deposit")
+        public = [n for n in dir(px) if not n.startswith("_") and callable(getattr(px, n))]
+        for name in public:
+            assert not any(word in name.lower() for word in forbidden), name

--- a/connectors/prophetx/workflows/demo-autofill-handoff.yml
+++ b/connectors/prophetx/workflows/demo-autofill-handoff.yml
@@ -1,0 +1,104 @@
+workflow:
+  name: "prophetx-demo-autofill-handoff"
+  title: "ProphetX Demo - Odds Screen + Auto-Fill Handoff"
+  description: "End-to-end demo: fetch one event's v3 markets (odds + liquidity), pick the first priced selection, and build the official Auto-Fill handoff links. Machina never executes a wager - the handoff ends at the link. Sandbox by default."
+  context-variables:
+    debugger:
+      enabled: true
+    prophetx:
+      api_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_API_KEY
+      access_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_ACCESS_KEY
+      secret_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_SECRET_KEY
+  inputs:
+    environment: "$.get('environment', 'sandbox')"
+    event_id: "$.get('event_id')"
+    partner_id: "$.get('partner_id', 'machina-sports')"
+    market_types: "$.get('market_types', 'moneyline')"
+  outputs:
+    odds_screen: "$.get('odds_screen', [])"
+    selected_line: "$.get('selected_line', {})"
+    autofill_links: "$.get('autofill_links', {})"
+    workflow-status: "$.get('links_ok') is True and 'executed' or 'failed'"
+  tasks:
+
+    # task-get-markets: the odds screen data (v3 = odds + per-level liquidity)
+    - type: connector
+      name: task-get-markets
+      description: Fetch v3 markets for the event (odds screen payload)
+      condition: "$.get('event_id') is not None"
+      connector:
+        name: prophetx
+        command: get_markets
+      inputs:
+        environment: "$.get('environment')"
+        event_id: "$.get('event_id')"
+        api_version: "'v3'"
+        market_types: "$.get('market_types')"
+      outputs:
+        markets_ok: "$.get('status', False)"
+        odds_screen: |
+          [
+            {
+              'market': m.get('name', ''),
+              'type': m.get('type', ''),
+              'selections': [
+                {
+                  'name': level.get('name', ''),
+                  'display_odds': level.get('display_odds', ''),
+                  'implied_probability': level.get('implied_probability'),
+                  'stake_available': level.get('stake'),
+                  'line_id': level.get('line_id', '')
+                }
+                for side in (m.get('selections') or [])
+                for level in (side if isinstance(side, list) else [side])
+                if isinstance(level, dict)
+              ]
+            }
+            for m in $.get('data', {}).get('markets', [])
+          ]
+        selected_line: |
+          next(
+            (
+              {
+                'line_id': level.get('line_id', ''),
+                'name': level.get('name', ''),
+                'display_odds': level.get('display_odds', ''),
+                'odds': level.get('odds')
+              }
+              for m in $.get('data', {}).get('markets', [])
+              for side in (m.get('selections') or [])
+              for level in (side if isinstance(side, list) else [side])
+              if isinstance(level, dict) and level.get('line_id') and level.get('odds') is not None
+            ),
+            next(
+              (
+                {
+                  'line_id': level.get('line_id', ''),
+                  'name': level.get('name', ''),
+                  'display_odds': level.get('display_odds', ''),
+                  'odds': None
+                }
+                for m in $.get('data', {}).get('markets', [])
+                for side in (m.get('selections') or [])
+                for level in (side if isinstance(side, list) else [side])
+                if isinstance(level, dict) and level.get('line_id')
+              ),
+              {}
+            )
+          )
+
+    # task-build-autofill: the handoff — Machina's involvement ends at these links
+    - type: connector
+      name: task-build-autofill
+      description: Build official Auto-Fill deep links for the selected line
+      condition: "$.get('selected_line', {}).get('line_id') not in (None, '')"
+      connector:
+        name: prophetx
+        command: build_autofill_link
+      inputs:
+        line_id: "$.get('selected_line', {}).get('line_id')"
+        partner_id: "$.get('partner_id')"
+        odds: "$.get('selected_line', {}).get('odds')"
+      outputs:
+        links_ok: "$.get('status', False)"
+        autofill_links: "$.get('data', {})"

--- a/connectors/prophetx/workflows/market-discovery.yml
+++ b/connectors/prophetx/workflows/market-discovery.yml
@@ -1,0 +1,56 @@
+workflow:
+  name: "prophetx-market-discovery"
+  title: "ProphetX Market Discovery"
+  description: "Read-only odds-screen data for one tournament: sport events plus v3 markets (odds + liquidity levels) for a chosen event. Sandbox by default."
+  context-variables:
+    debugger:
+      enabled: true
+    prophetx:
+      api_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_API_KEY
+      access_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_ACCESS_KEY
+      secret_key: $MACHINA_CONTEXT_VARIABLE_PROPHETX_SECRET_KEY
+  inputs:
+    environment: "$.get('environment', 'sandbox')"
+    tournament_id: "$.get('tournament_id')"
+    event_id: "$.get('event_id')"
+    api_version: "$.get('api_version', 'v3')"
+    market_types: "$.get('market_types')"
+  outputs:
+    sport_events: "$.get('sport_events', [])"
+    markets: "$.get('markets', [])"
+    workflow-status: "$.get('events_ok') is True and 'executed' or 'failed'"
+  tasks:
+
+    # task-get-sport-events
+    - type: connector
+      name: task-get-sport-events
+      description: List sport events for the tournament
+      condition: "$.get('tournament_id') is not None"
+      connector:
+        name: prophetx
+        command: get_sport_events
+      inputs:
+        environment: "$.get('environment')"
+        tournament_id: "$.get('tournament_id')"
+      outputs:
+        events_ok: "$.get('status', False)"
+        sport_events: "$.get('data', {}).get('sport_events', [])"
+        sport_events_count: "$.get('data', {}).get('count', 0)"
+
+    # task-get-markets
+    - type: connector
+      name: task-get-markets
+      description: Markets with odds/liquidity for the chosen event (v3 default)
+      condition: "$.get('event_id') is not None"
+      connector:
+        name: prophetx
+        command: get_markets
+      inputs:
+        environment: "$.get('environment')"
+        event_id: "$.get('event_id')"
+        api_version: "$.get('api_version')"
+        market_types: "$.get('market_types')"
+      outputs:
+        markets_ok: "$.get('status', False)"
+        markets: "$.get('data', {}).get('markets', [])"
+        markets_count: "$.get('data', {}).get('count', 0)"


### PR DESCRIPTION
## Summary

PR 2 of the ProphetX track (ClickUp [86ak0a1jm](https://app.clickup.com/t/86ak0a1jm)) — implements the **approved design log** ([#310](https://github.com/machina-sports/machina-templates/pull/310), `docs/plans/2026-08-13-001-feat-prophetx-affiliate-connector-design-log.md`). Companion keyless catalog skill: [sports-skills#118](https://github.com/machina-sports/sports-skills/pull/118).

Read-only by design: **no wager/order/balance surface anywhere** — the Direct Play demo hands off via the official Auto-Fill deep links (`build_autofill_link`), never executing a wager.

## What's included

- `connectors/prophetx/prophetx.py` — pyscript connector:
  - Fixed environment allowlist (`sandbox` → `api.sandbox.prophetx.dev/partner`, `production` → `cash.api.prophetx.co/partner`); arbitrary endpoints rejected (the brief's old `*-ss-sandbox.betprophet.co` host is dead).
  - Dual auth: raw API key (default per the official Market Data guide) or access/secret login session (10-min token, cached, refresh-then-relogin, single 401 re-login). `auth_scheme: bearer` opt-in keeps the documented spec-vs-guide contradiction open until the sandbox smoke resolves it.
  - Commands: `get_tournaments`, `get_sport_events`, `get_markets` (v1–v4; default **v3** with per-level liquidity; **v4 CFTC names mapped onto the same neutral fields**; `X-CFTC-Terminology` opt-in gated to v3), `get_multiple_markets` (≤50 ids; tolerates the documented dual-shape response — dict-by-event-id or flat list, with an `_unattributed` bucket), `build_autofill_link` (pure), `health`.
  - Resilience: bounded retries with backoff honoring `Retry-After` on 429/5xx; typed error classes; sanitized errors (no credential/header echo — tested).
  - Normalization preserves `_raw` and keeps `line_id` **verbatim** (Auto-Fill handoff currency). No implied-probability derivation yet — official examples disagree on odds format (American vs decimal); the smoke settles it first.
- Workflows: `prophetx-test-credentials` (bounded health) and `prophetx-market-discovery` (events + v3 markets), credentials via `MACHINA_CONTEXT_VARIABLE_PROPHETX_*` vault context variables.
- `connectors/prophetx/tests/` — **39 offline unit tests** (auth modes/schemes, token cache+refresh, 401 re-login, 429/5xx/404/network failures, malformed JSON, environment allowlist, per-version paths, CFTC header gating, v3 selections nesting, v4 mapping, 50-id batch cap, dual-shape parsing, Auto-Fill links, credential-echo guard, no-write-surface guard) + `smoke_sandbox.py`, the bounded (~8 GETs) env-gated sandbox smoke that reports auth scheme, odds-format evidence, `updated_at` unit, v3 nesting, and multiple-markets shape — printing names/counts only, never token values.
- `connectors/prophetx/README.md` — setup, vault conventions, verify steps.

## Evidence

- Unit tests: **39 passed** (offline; smoke runner correctly SKIPs without a credential).
- Repo guardrails with the connector in-tree: `check-no-openai.sh all` exit 0; `check-machina-ai-policy.py` exit 0.
- Sandbox smoke execution is the next step (operator credential handoff pending); results will be attached to the ClickUp task. Production smoke remains read-only, bounded, and separately approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)